### PR TITLE
feat: Reacquaintance Mode — clean, evidence-first catch-up flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ docs/_build/
 
 # local intelligence runtime data
 .copyclip/
+.playwright-mcp/
+.superpowers/
+atlas-*.png
 
 # frontend artifacts
 frontend/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.4.0 - 2026-04-14
+
+### Added
+- Reacquaintance Mode across backend, API, CLI, and dashboard UI.
+- Baseline persistence via `project_visits` and `reentry_checkpoints`.
+- `copyclip report --type reacquaint` plus optional checkpoint save support.
+- Realistic fixtures and end-to-end tests for context-switch scenarios.
+
+### Changed
+- Packaging and dependency declarations aligned with the current runtime and test setup.
+- Local development now uses `python3 -m pip install -e '\''.[dev]'\''` as the canonical editable-install path.
+- `pytest.ini` now declares asyncio test support for the MCP-related test suite.
+- Local smoke verification now runs the full backend pytest suite plus the frontend build.
+- Reacquaintance ranking now maps commit evidence to files actually touched by each commit.
+
+### Fixed
+- Test collection and execution drift caused by missing dev dependencies and async pytest configuration.
+- MCP/runtime dependency declaration drift in packaging files.
+- Documentation drift between the shipped CLI and the local development path.
+- Accidental inclusion of local generated artifacts is now prevented by `.gitignore` rules.
+
+### Test status
+- 99 passed, 1 skipped.
+
 ## v0.3.0 - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚀 CopyClip v0.3.0
+# 🚀 CopyClip v0.4.0
 
 **Project Intelligence Dashboard + Intent Authority MCP Server**
 
@@ -61,7 +61,7 @@ pip install "copyclip @ git+https://github.com/sssamuelll/copyclip.git"
 ```bash
 git clone https://github.com/sssamuelll/copyclip.git
 cd copyclip
-pip install -e .
+python3 -m pip install -e '.[dev]'
 ```
 
 ### Updating
@@ -79,13 +79,30 @@ copyclip start
 ```
 *Note: If it's your first time, CopyClip will guide you through an interactive LLM setup (DeepSeek, OpenAI, Anthropic, etc.) and perform an initial project analysis.*
 
+### Local development (green path)
+From source, the canonical local development path is:
+
+```bash
+python3 -m pip install -e '.[dev]'
+npm --prefix frontend install
+./scripts/dev-smoke.sh
+copyclip start --no-open --path .
+```
+
+See `docs/LOCAL_DEVELOPMENT.md` for the full verified local setup flow and the current smoke-check entrypoint.
+
 ### 3. Connect External Agents (MCP)
 Add CopyClip to your `mcp_servers` configuration:
 ```json
 "copyclip": {
   "command": "copyclip",
-  "args": ["mcp", "start"]
+  "args": ["mcp"]
 }
+```
+
+You can verify the command locally with:
+```bash
+copyclip mcp --help
 ```
 
 ---

--- a/docs/API_CONTRACT_V1.md
+++ b/docs/API_CONTRACT_V1.md
@@ -1,6 +1,6 @@
 # CopyClip Intelligence API Contract v1
 
-Status: **frozen for v0.3.x**
+Status: **frozen for v0.4.x**
 
 This document defines stable endpoint behavior for the local CopyClip intelligence service started via:
 
@@ -331,4 +331,4 @@ Config body shape:
 
 ## Deprecated / internal notes
 - None formally deprecated in v1.
-- Future schema changes should preserve backward compatibility within `v0.3.x`.
+- Future schema changes should preserve backward compatibility within `v0.4.x`.

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -1,0 +1,74 @@
+# Local development green path
+
+This is the canonical local setup path for working on CopyClip from source.
+
+It is intentionally minimal and matches the commands verified in this repository during issue #22.
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js 18+
+- npm 9+
+
+## Backend setup
+
+From the repository root:
+
+```bash
+python3 -m pip install -e '.[dev]'
+```
+
+This installs the editable `copyclip` package, runtime dependencies, and the Python test dependencies used by the local verification flow.
+
+## Frontend setup
+
+From the repository root:
+
+```bash
+cd frontend
+npm install
+cd ..
+```
+
+## Start the dashboard
+
+From the repository root:
+
+```bash
+copyclip start --no-open --path .
+```
+
+Notes:
+- `--no-open` avoids auto-opening the browser during development or CI-like verification.
+- The dashboard chooses an open port starting near `4310`.
+
+## Reproducible smoke entrypoint
+
+From the repository root:
+
+```bash
+./scripts/dev-smoke.sh
+```
+
+This is the current green-path verification command. It runs a lightweight, reproducible set of checks that are known to pass on the current codebase:
+
+- backend import/install sanity via editable install with dev extras
+- full backend pytest suite
+- frontend production build
+
+## Manual equivalent of the smoke script
+
+If you want to run the same checks manually:
+
+```bash
+python3 -m pip install -e '.[dev]'
+python3 -m pytest -q
+npm --prefix frontend install
+npm --prefix frontend run build
+```
+
+## Current scope of the green path
+
+This document defines the smallest trustworthy local development path, not the entire final contributor experience.
+
+Full test-suite cleanup, dependency drift resolution, and broader packaging hardening are tracked separately in issue #23.

--- a/docs/PROJECT_INTELLIGENCE_V1.md
+++ b/docs/PROJECT_INTELLIGENCE_V1.md
@@ -1,5 +1,7 @@
 # CopyClip Project Intelligence v1 (Human Control Plane)
 
+> Historical design document: parts of this spec describe the original v1 vision and no longer match the current CLI exactly. For the current shipped flow, use `copyclip start`, `copyclip analyze --path ...`, `copyclip decision ...`, `copyclip mcp`, and the setup documented in `README.md` / `docs/LOCAL_DEVELOPMENT.md`.
+
 ## Vision
 
 CopyClip evolves from a context packer into a **human-facing project intelligence system** for AI-heavy software development.
@@ -13,11 +15,11 @@ Core promise:
 
 ## Product Outcome (v1)
 
-Run in any repo:
+Run in any repo (current shipped flow):
 
 ```bash
-copyclip analyze
-copyclip serve
+copyclip analyze --path .
+copyclip start --path .
 ```
 
 Open browser and get a pro dashboard with:
@@ -81,13 +83,13 @@ Outputs:
 - graph artifacts (dependencies/modules)
 - summary cache for dashboard
 
-## 2) Serve Command
+## 2) Start Command
 
 ```bash
-copyclip serve [--port 4310]
+copyclip start [--path .] [--port 4310] [--no-open]
 ```
 
-Starts local API + dashboard.
+Starts the local dashboard and API.
 
 ## 3) Decision Commands
 
@@ -99,14 +101,15 @@ copyclip decision resolve <id>
 
 Manual control for explicit human decisions.
 
-## 4) Reports
+## 4) Reports (planned / not yet a stable shipped CLI surface)
 
 ```bash
+# historical v1 idea
 copyclip report --type daily
 copyclip report --type weekly
 ```
 
-Human-readable narrative report generated from indexed data.
+Human-readable narrative reports remain part of the product direction, but the current shipped CLI is centered on `start`, `analyze`, `decision`, and `mcp`.
 
 ---
 
@@ -278,7 +281,7 @@ Weighted sum:
 ## Implementation Plan (2 weeks)
 
 ## Week 1
-1. CLI scaffolding for `analyze`, `serve`, `decision`, `report`
+1. CLI scaffolding for `analyze`, `start`, `decision`, `mcp` (with `report` retained as a future/planned surface)
 2. SQLite schema + migration setup
 3. Analyzer pipeline (files + git + docs)
 4. Basic API endpoints (`overview`, `changes`, `decisions`, `risks`)
@@ -313,7 +316,7 @@ New intelligence layer is additive.
 
 ## Immediate Next Tasks
 
-1. Create command skeletons in CLI (`analyze`, `serve`, `decision`, `report`)
+1. Create command skeletons in CLI (`analyze`, `start`, `decision`, `mcp`; `report` remains a planned surface)
 2. Add `copyclip/intelligence/` package structure
 3. Implement SQLite bootstrap + first migration
 4. Add analyzer pass: git + files + markdown extraction

--- a/docs/REACQUAINTANCE_BRIEFING_CONTRACT.md
+++ b/docs/REACQUAINTANCE_BRIEFING_CONTRACT.md
@@ -1,0 +1,418 @@
+# Reacquaintance Briefing Contract
+
+Status: draft for issue #28
+Owner: CopyClip
+Related issues: #16, #28, #29, #30, #31, #32, #33
+
+## Purpose
+
+Reacquaintance Mode is the "catch me up" workflow for returning to a project after a context switch.
+
+Its job is not to summarize everything. Its job is to restore continuity quickly and direct attention to the highest-value next reads.
+
+The briefing must answer:
+- What changed since my baseline?
+- What matters now?
+- What should I read first in the next 10 minutes?
+- Which decisions, risks, and hotspots are most relevant to re-entry?
+- What is still unclear?
+
+## Design principles
+
+- Prioritize attention, do not dump raw telemetry
+- Every section must cite evidence
+- Prefer deterministic ranking over opaque narrative generation
+- Be useful even when evidence is sparse
+- Make uncertainty explicit
+- Keep the contract stable across UI and CLI delivery paths
+
+## Supported baseline modes
+
+The briefing compares "now" against one baseline.
+
+Allowed baseline modes:
+- `last_seen` — last recorded project visit/open by this user
+- `last_analysis` — previous completed analysis run
+- `window` — explicit rolling window such as `7d`, `14d`, `30d`
+- `checkpoint` — future/manual named checkpoint created by user
+
+If `last_seen` is unavailable, fallback order is:
+1. `last_analysis`
+2. `window=7d`
+3. "first run" mode
+
+## Top-level response schema
+
+```json
+{
+  "meta": {
+    "project": "copyclip",
+    "generated_at": "2026-04-14T18:00:00Z",
+    "briefing_version": "v1",
+    "baseline_mode": "last_seen",
+    "baseline_label": "since last visit",
+    "baseline_started_at": "2026-04-10T09:12:00Z",
+    "baseline_available": true,
+    "confidence": "medium"
+  },
+  "project_refresher": {},
+  "top_changes": [],
+  "read_first": [],
+  "relevant_decisions": [],
+  "top_risk": null,
+  "open_questions": [],
+  "evidence_index": [],
+  "fallback_notes": []
+}
+```
+
+## Section contracts
+
+### 1. `project_refresher`
+
+Purpose:
+- Re-anchor the user in the project before diving into recent activity
+
+Shape:
+```json
+{
+  "summary": "CopyClip is a local-first project intelligence and AI collaboration control plane.",
+  "confidence": "high",
+  "why_now": "Recent work concentrated in MCP, tests, and local development flows.",
+  "evidence": ["project.story", "snapshot:latest", "readme"]
+}
+```
+
+Construction:
+- Prefer `projects.story`
+- Then latest `story_snapshots.summary_json`
+- Then README-derived fallback
+
+Evidence requirement:
+- must cite at least one of: project story, story snapshot, README
+
+Fallback behavior:
+- If no narrative source exists, return a plain factual refresher:
+  - project name
+  - dominant modules / file count
+  - recent activity summary
+- confidence must be `low` or `medium`
+
+### 2. `top_changes`
+
+Purpose:
+- Show the most important changes since the selected baseline
+
+Shape:
+```json
+[
+  {
+    "title": "Packaging and async test support were tightened",
+    "importance": 91,
+    "summary": "Runtime and dev dependencies were aligned; async MCP tests now run under pytest-asyncio.",
+    "change_kind": "engineering_foundation",
+    "primary_area": "pyproject.toml",
+    "evidence": [
+      "commit:<sha>",
+      "file:pyproject.toml",
+      "file:pytest.ini",
+      "file:tests/test_mcp_intent_oracle.py"
+    ],
+    "why_selected": [
+      "recent_change",
+      "broad_impact",
+      "affects_developer_workflow"
+    ]
+  }
+]
+```
+
+Selection rules:
+- rank recent changes by `change_importance_score`
+- include 3 to 5 items max
+- collapse low-signal commit noise into one grouped item when necessary
+
+Evidence requirement:
+- every item must cite at least one file or commit
+- high-importance items should cite both files and commit(s) when available
+
+### 3. `read_first`
+
+Purpose:
+- Give the user a short reading sequence for regaining understanding
+
+Shape:
+```json
+[
+  {
+    "rank": 1,
+    "target_type": "file",
+    "target": "pyproject.toml",
+    "score": 94,
+    "reason": "Recently changed foundation file tied to packaging and test reliability work.",
+    "expected_payoff": "Explains current install/test path quickly.",
+    "estimated_minutes": 2,
+    "evidence": ["file:pyproject.toml", "commit:<sha>", "risk:packaging"]
+  }
+]
+```
+
+Selection rules:
+- include 3 items maximum for default briefing
+- items can be file, module, or decision
+- rank by `read_first_score`
+
+Evidence requirement:
+- every item must cite why it is worth reading first
+
+### 4. `relevant_decisions`
+
+Purpose:
+- Surface decisions that matter to current re-entry, not all decisions
+
+Shape:
+```json
+[
+  {
+    "id": 12,
+    "title": "Use bounded MCP handoff packets",
+    "status": "accepted",
+    "relevance_score": 82,
+    "why_now": "Recent work touched linked files and review workflows.",
+    "evidence": ["decision:12", "decision_link:src/copyclip/mcp_server.py"]
+  }
+]
+```
+
+Selection rules:
+- accepted/resolved decisions outrank proposed ones
+- unresolved/proposed decisions can appear if they are directly linked to changed or risky areas
+- include 0 to 3 items max
+
+Evidence requirement:
+- decision itself plus at least one linkage to current change/risk/area when available
+
+### 5. `top_risk`
+
+Purpose:
+- Make the most important current risk visible immediately
+
+Shape:
+```json
+{
+  "area": "tests/test_mcp_intent_oracle.py",
+  "severity": "high",
+  "kind": "test_gap",
+  "score": 76,
+  "summary": "Recent changes in the MCP path previously lacked stable async test support.",
+  "recommended_first_action": "Read pyproject.toml and pytest.ini together.",
+  "evidence": ["risk:test_gap", "file:pytest.ini", "file:tests/test_mcp_intent_oracle.py"]
+}
+```
+
+Selection rules:
+- choose the single highest re-entry-relevant risk, not merely the highest raw score
+- prefer risks in recently changed or strategically important areas
+
+Evidence requirement:
+- must cite risk record plus supporting area/file evidence
+
+Fallback behavior:
+- if no risks exist, return `null` and add a note to `fallback_notes`
+
+### 6. `open_questions`
+
+Purpose:
+- Show what the user may still need to resolve after reading the briefing
+
+Shape:
+```json
+[
+  {
+    "question": "Should MCP-related integration coverage expand beyond current unit tests?",
+    "priority": "medium",
+    "derived_from": ["risk:test_gap", "changes:mcp"],
+    "next_step": "Inspect MCP integration path and decide whether to add a smoke test."
+  }
+]
+```
+
+Selection rules:
+- derive from unresolved decisions, risk clusters, evidence gaps, or contradictory signals
+- include 1 to 3 questions max
+
+Evidence requirement:
+- every question must cite the signal(s) that produced it
+
+### 7. `evidence_index`
+
+Purpose:
+- Provide a normalized artifact list used across the briefing
+
+Shape:
+```json
+[
+  {
+    "id": "file:pyproject.toml",
+    "type": "file",
+    "label": "pyproject.toml",
+    "ref": "pyproject.toml"
+  }
+]
+```
+
+Use:
+- enables UI/CLI to show a readable briefing while keeping references stable
+
+### 8. `fallback_notes`
+
+Purpose:
+- Explain degraded behavior when evidence is missing
+
+Examples:
+```json
+[
+  "No last_seen baseline found; fell back to last_analysis.",
+  "No risk rows available for this project yet; omitted top_risk."
+]
+```
+
+## Scoring model
+
+The briefing uses explicit deterministic scores.
+
+### A. Change importance score
+
+Used for `top_changes`.
+
+```text
+change_importance_score =
+  0.30 * recency_score +
+  0.25 * churn_score +
+  0.20 * risk_link_score +
+  0.15 * decision_link_score +
+  0.10 * breadth_score
+```
+
+Factors:
+- `recency_score` — how close the change is to now / baseline edge
+- `churn_score` — commit or file-change frequency in the baseline window
+- `risk_link_score` — linked risk count / severity near the changed area
+- `decision_link_score` — linked accepted/resolved/unresolved decisions
+- `breadth_score` — number of affected modules/files, capped to avoid noise domination
+
+Normalize each factor to 0–100.
+
+### B. Read-first score
+
+Used for `read_first`.
+
+```text
+read_first_score =
+  0.25 * change_importance_score +
+  0.25 * understanding_payoff_score +
+  0.20 * risk_score +
+  0.15 * decision_relevance_score +
+  0.15 * brevity_score
+```
+
+Interpretation:
+- favor artifacts that quickly improve understanding
+- penalize giant/low-payoff areas
+- small high-signal files/modules should rise
+
+Factors:
+- `understanding_payoff_score` — expected contextual payoff if read now
+- `brevity_score` — likely to be digestible in 2–10 minutes
+
+### C. Decision relevance score
+
+Used for `relevant_decisions`.
+
+```text
+decision_relevance_score =
+  0.40 * direct_link_score +
+  0.25 * changed_area_overlap_score +
+  0.20 * unresolved_weight +
+  0.15 * risk_overlap_score
+```
+
+Interpretation:
+- a decision matters when it overlaps the current changed/risky surface
+- unresolved decisions get an extra boost because they produce uncertainty
+
+### D. Briefing confidence
+
+Top-level `meta.confidence` is derived from evidence quality, not style.
+
+```text
+confidence = high   if all core sections have direct evidence and baseline is real
+confidence = medium if some sections rely on fallbacks or sparse evidence
+confidence = low    if baseline is synthetic/first-run and multiple sections are partial
+```
+
+## Section-level evidence rules
+
+Minimum requirements:
+- `project_refresher` -> 1 narrative or snapshot source
+- `top_changes` -> 1 commit or 1 file per item
+- `read_first` -> at least 1 artifact + 1 selection reason per item
+- `relevant_decisions` -> decision id + current relevance evidence
+- `top_risk` -> risk record + area/file evidence
+- `open_questions` -> derived_from references
+
+If a section cannot meet minimum evidence:
+- either degrade confidence and keep it
+- or omit the section item and explain omission in `fallback_notes`
+
+## Sparse-evidence fallback rules
+
+### First-run project
+If there is no baseline and very little project history:
+- use current project story / overview
+- omit comparative language like "since last visit"
+- use "recommended first reads" based on static importance only
+- set overall confidence to `low`
+
+### No git history
+- `top_changes` becomes file/system-change oriented rather than commit oriented
+- cite files and snapshots only
+
+### No decisions
+- `relevant_decisions` returns empty list
+- add fallback note: "No linked decisions available yet."
+
+### No risks
+- `top_risk` returns `null`
+- derive open questions from change concentration or missing evidence instead
+
+## Delivery expectations
+
+### API
+- return the full structured object
+- keep stable keys for frontend and CLI consumers
+
+### UI
+- show a short readable briefing first
+- preserve drill-down into `evidence_index`
+- expose baseline mode and confidence visibly
+
+### CLI
+- render a compact human-readable summary
+- preserve artifact refs so the user can continue manually
+
+## Implementation notes for follow-up issues
+
+Issue mapping:
+- #29 adds persistence for baseline modes (`last_seen`, checkpoints, windows)
+- #30 implements the briefing generator and scoring logic
+- #31 exposes API and CLI delivery
+- #32 renders the briefing in the dashboard
+- #33 adds fixtures and tests around ranking and sparse-evidence behavior
+
+## Non-goals for v1
+
+- perfect semantic understanding of all change intent
+- personalized user-specific weighting beyond baseline mode
+- multi-repo reacquaintance
+- LLM-only ranking without deterministic evidence rules

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from './api/client'
 import { Sidebar } from './components/Sidebar'
+import { ReacquaintancePage } from './pages/ReacquaintancePage'
 import { AskPage } from './pages/AskPage'
 import { ArchitecturePage } from './pages/ArchitecturePage'
 import { RisksPage } from './pages/RisksPage'
@@ -8,37 +9,45 @@ import { ContextBuilderPage } from './pages/ContextBuilderPage'
 import { DecisionsPage } from './pages/DecisionsPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { ImpactSimulatorPage } from './pages/ImpactSimulatorPage'
+import { ChangesPage } from './pages/ChangesPage'
 
 import { Atlas3DPage } from './pages/Atlas3DPage'
 import { TimelinePage } from './pages/TimelinePage'
 import { PlanningPage } from './pages/PlanningPage'
 
-import type { ArchEdge, ArchNode, DecisionItem, Overview, RiskItem } from './types/api'
+import type { ArchEdge, ArchNode, ChangeItem, DecisionItem, Overview, RiskItem } from './types/api'
 
-type Page = 'ask' | 'atlas-3d' | 'timeline' | 'planning' | 'architecture' | 'impact' | 'risks' | 'context-builder' | 'decisions' | 'settings'
+type Page = 'reacquaintance' | 'ask' | 'atlas-3d' | 'timeline' | 'planning' | 'changes' | 'architecture' | 'impact' | 'risks' | 'context-builder' | 'decisions' | 'settings'
 
 export function App() {
-  const [page, setPage] = useState<Page>('ask')
+  const [page, setPage] = useState<Page>('reacquaintance')
   const [overview, setOverview] = useState<Overview>()
   const [decisions, setDecisions] = useState<DecisionItem[]>([])
   const [risks, setRisks] = useState<RiskItem[]>([])
+  const [changes, setChanges] = useState<ChangeItem[]>([])
   const [nodes, setNodes] = useState<ArchNode[]>([])
   const [edges, setEdges] = useState<ArchEdge[]>([])
   const [error, setError] = useState<string>('')
   const [toast, setToast] = useState<string>('')
+  const [focusDecisionId, setFocusDecisionId] = useState<number | null>(null)
+  const [focusRiskArea, setFocusRiskArea] = useState<string | null>(null)
+  const [focusCommitId, setFocusCommitId] = useState<string | null>(null)
+  const [focusFilePath, setFocusFilePath] = useState<string | null>(null)
   const reloadTimer = useRef<number | null>(null)
 
   const loadAll = useCallback(async () => {
     try {
-      const [o, d, r, a] = await Promise.all([
+      const [o, d, r, c, a] = await Promise.all([
         api.overview(),
         api.decisions(),
         api.risks(),
+        api.changes(),
         api.architecture()
       ])
       setOverview(o)
       setDecisions(d.items)
       setRisks(r.items)
+      setChanges(c.items)
       setNodes(a.nodes)
       setEdges(a.edges)
       setError('')
@@ -54,6 +63,22 @@ export function App() {
   const notify = (msg: string) => {
     setToast(msg)
     window.setTimeout(() => setToast(''), 2200)
+  }
+
+  const openDecision = (id: number) => {
+    setFocusDecisionId(id)
+    setPage('decisions')
+  }
+
+  const openRisk = (area: string) => {
+    setFocusRiskArea(area)
+    setPage('risks')
+  }
+
+  const openChanges = (opts?: { commitId?: string | null; filePath?: string | null }) => {
+    setFocusCommitId(opts?.commitId || null)
+    setFocusFilePath(opts?.filePath || null)
+    setPage('changes')
   }
 
   return (
@@ -74,15 +99,17 @@ export function App() {
         </div>
 
         <div style={{ padding: '24px', flex: 1 }}>
+          {page === 'reacquaintance' && <ReacquaintancePage onOpenDecision={openDecision} onOpenRisk={openRisk} onOpenChanges={openChanges} />}
           {page === 'ask' && <AskPage onNotify={notify} />}
           {page === 'atlas-3d' && <Atlas3DPage />}
           {page === 'timeline' && <TimelinePage />}
           {page === 'planning' && <PlanningPage />}
+          {page === 'changes' && <ChangesPage items={changes} risks={risks} focusCommitId={focusCommitId} focusFilePath={focusFilePath} onOpenDecision={openDecision} onOpenRisk={openRisk} />}
           {page === 'architecture' && <ArchitecturePage nodes={nodes} edges={edges} />}
           {page === 'impact' && <ImpactSimulatorPage />}
-          {page === 'risks' && <RisksPage items={risks} focusRiskArea={null} />}
+          {page === 'risks' && <RisksPage items={risks} focusRiskArea={focusRiskArea} />}
           {page === 'context-builder' && <ContextBuilderPage />}
-          {page === 'decisions' && <DecisionsPage items={decisions} focusDecisionId={null} />}
+          {page === 'decisions' && <DecisionsPage items={decisions} focusDecisionId={focusDecisionId} />}
           {page === 'settings' && <SettingsPage onNotify={notify} />}
         </div>
       </main>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { ArchEdge, ArchNode, ChangeItem, DecisionHistoryItem, DecisionItem, IssueItem, Overview, RiskItem, HeatmapItem, FileItem, ContextPayload, ImpactResult, AgentResponse, AskResponse, RiskTrends, AlertRule, AlertsResponse, WeeklyExport, SchedulerState, AnalyzeJob, ArchaeologyResponse, StoryTimelineResponse, AdvisorCheckResponse, IdentityDriftResponse, DecisionLinkItem, CognitiveLoadResponse, ModuleSourceResponse, ModuleSymbolsResponse, TreeNode } from '../types/api'
+import type { ArchEdge, ArchNode, ChangeItem, DecisionHistoryItem, DecisionItem, IssueItem, Overview, RiskItem, HeatmapItem, FileItem, ContextPayload, ImpactResult, AgentResponse, AskResponse, RiskTrends, AlertRule, AlertsResponse, WeeklyExport, SchedulerState, AnalyzeJob, ArchaeologyResponse, StoryTimelineResponse, AdvisorCheckResponse, IdentityDriftResponse, DecisionLinkItem, CognitiveLoadResponse, ModuleSourceResponse, ModuleSymbolsResponse, TreeNode, ReacquaintanceResponse } from '../types/api'
 
 // --- Debugging Suite Helpers ---
 const logAPI = (method: string, url: string, start: number, payload?: any, response?: any, error?: any) => {
@@ -121,6 +121,14 @@ export const api = {
   impact: (path: string) => getJSON<ImpactResult>(`/api/impact?path=${encodeURIComponent(path)}`),
   archaeology: (file: string) => getJSON<ArchaeologyResponse>(`/api/archaeology?file=${encodeURIComponent(file)}`),
   storyTimeline: (range = '30d') => getJSON<StoryTimelineResponse>(`/api/story/timeline?range=${encodeURIComponent(range)}`),
+  reacquaintance: (params?: { mode?: string; window?: string; checkpoint?: string }) => {
+    const q = new URLSearchParams()
+    if (params?.mode) q.set('mode', params.mode)
+    if (params?.window) q.set('window', params.window)
+    if (params?.checkpoint) q.set('checkpoint', params.checkpoint)
+    const suffix = q.toString() ? `?${q.toString()}` : ''
+    return getJSON<ReacquaintanceResponse>(`/api/reacquaintance${suffix}`)
+  },
   identityDrift: (range = '30d') => getJSON<IdentityDriftResponse>(`/api/identity/drift?range=${encodeURIComponent(range)}`),
   cognitiveLoad: () => getJSON<CognitiveLoadResponse>('/api/cognitive-load'),
   agentChat: (agent: string, message: string) => postJSON<AgentResponse>('/api/agents/chat', { agent, message }),

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ const GROUPS = [
   {
     label: 'Consciousness',
     pages: [
+      { id: 'reacquaintance', label: 'catch me up' },
       { id: 'ask', label: 'ask the consciousness' },
       { id: 'atlas-3d', label: 'atlas' },
       { id: 'timeline', label: 'chronicle' },
@@ -13,6 +14,7 @@ const GROUPS = [
   {
     label: 'Structures',
     pages: [
+      { id: 'changes', label: 'change field' },
       { id: 'architecture', label: 'structure graph' },
       { id: 'impact', label: 'propagation oracle' },
       { id: 'risks', label: 'distortion field' },
@@ -60,7 +62,7 @@ export function Sidebar({ page, setPage, lastIndexedText }: Props) {
 
       <div style={{ display: 'grid', gap: 12, padding: '0 4px' }}>
         <div className="panel" style={{ padding: '10px', fontSize: 11, color: 'var(--text-tertiary)', background: 'transparent' }}>
-          / v0.3.0_stable
+          / v0.4.0_stable
         </div>
         <div style={{ fontSize: 10, color: 'var(--text-tertiary)', paddingLeft: '10px' }}>
           {lastIndexedText || 'consciousness active'}

--- a/frontend/src/pages/ChangesPage.tsx
+++ b/frontend/src/pages/ChangesPage.tsx
@@ -6,12 +6,14 @@ export function ChangesPage({
   items,
   risks,
   focusCommitId,
+  focusFilePath,
   onOpenDecision,
   onOpenRisk,
 }: {
   items: ChangeItem[]
   risks: RiskItem[]
   focusCommitId?: string | null
+  focusFilePath?: string | null
   onOpenDecision?: (id: number) => void
   onOpenRisk?: (area: string) => void
 }) {
@@ -28,6 +30,34 @@ export function ChangesPage({
   useEffect(() => {
     api.files().then((res) => setFiles(res.items)).catch(() => {})
   }, [])
+
+  useEffect(() => {
+    if (focusFilePath && focusFilePath !== fileQuery) {
+      setFileQuery(focusFilePath)
+    }
+  }, [focusFilePath])
+
+  useEffect(() => {
+    if (!focusFilePath) return
+    let cancelled = false
+    const run = async () => {
+      setArchError('')
+      setArchLoading(true)
+      try {
+        const res = await api.archaeology(focusFilePath)
+        if (!cancelled) setArch(res)
+      } catch (e) {
+        if (!cancelled) {
+          setArch(null)
+          setArchError(e instanceof Error ? e.message : 'Archaeology request failed')
+        }
+      } finally {
+        if (!cancelled) setArchLoading(false)
+      }
+    }
+    run()
+    return () => { cancelled = true }
+  }, [focusFilePath])
 
   const suggestions = useMemo(() => files.filter((f) => f.path.toLowerCase().includes(fileQuery.toLowerCase())).slice(0, 20), [files, fileQuery])
   const relatedRisks = useMemo(() => {

--- a/frontend/src/pages/ReacquaintancePage.tsx
+++ b/frontend/src/pages/ReacquaintancePage.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useMemo, useState } from 'react'
+import { api } from '../api/client'
+import type { ReacquaintanceEvidenceItem, ReacquaintanceResponse } from '../types/api'
+
+type Props = {
+  onOpenDecision?: (id: number) => void
+  onOpenRisk?: (area: string) => void
+  onOpenChanges?: (opts?: { commitId?: string | null; filePath?: string | null }) => void
+}
+
+const BASELINE_OPTIONS = [
+  { value: 'last_seen', label: 'since last visit' },
+  { value: 'last_analysis', label: 'since last analysis' },
+  { value: 'window', label: 'rolling window' },
+  { value: 'checkpoint', label: 'named checkpoint' },
+] as const
+
+export function ReacquaintancePage({ onOpenDecision, onOpenRisk, onOpenChanges }: Props) {
+  const [mode, setMode] = useState('last_seen')
+  const [windowValue, setWindowValue] = useState('7d')
+  const [checkpoint, setCheckpoint] = useState('')
+  const [data, setData] = useState<ReacquaintanceResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const load = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await api.reacquaintance({
+        mode,
+        window: mode === 'window' ? windowValue : undefined,
+        checkpoint: mode === 'checkpoint' && checkpoint.trim() ? checkpoint.trim() : undefined,
+      })
+      setData(res)
+    } catch (e) {
+      setData(null)
+      setError(e instanceof Error ? e.message : 'Failed to load reacquaintance briefing')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const evidenceMap = useMemo(() => {
+    const map = new Map<string, ReacquaintanceEvidenceItem>()
+    ;(data?.evidence_index || []).forEach((item) => map.set(item.id, item))
+    return map
+  }, [data])
+
+  const openEvidence = (evidenceId: string) => {
+    const item = evidenceMap.get(evidenceId)
+    if (!item) return
+    if (item.type === 'decision') {
+      const raw = item.ref.replace(/^#?/, '')
+      const id = Number(raw)
+      if (!Number.isNaN(id)) onOpenDecision?.(id)
+      return
+    }
+    if (item.type === 'risk') {
+      onOpenRisk?.(item.ref)
+      return
+    }
+    if (item.type === 'commit') {
+      onOpenChanges?.({ commitId: item.ref })
+      return
+    }
+    if (item.type === 'file') {
+      onOpenChanges?.({ filePath: item.ref })
+      return
+    }
+  }
+
+  return (
+    <section style={{ display: 'grid', gap: 12 }}>
+      <div className="page-header">
+        <h2 className="page-title">reacquaintance</h2>
+      </div>
+
+      <div className="section-panel">
+        <div className="section-header">
+          <span className="section-title">// catch_me_up</span>
+        </div>
+        <div style={{ padding: 12, display: 'grid', gap: 12 }}>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+            <select value={mode} onChange={(e) => setMode(e.target.value)}>
+              {BASELINE_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+            </select>
+            {mode === 'window' && (
+              <input value={windowValue} onChange={(e) => setWindowValue(e.target.value)} placeholder="7d" />
+            )}
+            {mode === 'checkpoint' && (
+              <input value={checkpoint} onChange={(e) => setCheckpoint(e.target.value)} placeholder="checkpoint name" />
+            )}
+            <button className="btn" onClick={load} disabled={loading}>{loading ? 'loading…' : 'refresh'}</button>
+          </div>
+
+          {error && <div className="error">{error}</div>}
+
+          {data && (
+            <>
+              <div className="narrative-grid">
+                <InfoCard title="// baseline" text={data.meta?.baseline_label || mode} />
+                <InfoCard title="// confidence" text={String(data.meta?.confidence || 'low')} />
+                <InfoCard title="// generated_at" text={data.meta?.generated_at?.replace('T', ' ').slice(0, 16) || 'n/a'} />
+              </div>
+
+              <div className="insight-card">
+                <div className="insight-title">// project_refresher</div>
+                <div className="insight-text">{data.project_refresher?.summary}</div>
+                <div className="muted" style={{ marginTop: 8, fontSize: 12 }}>{data.project_refresher?.why_now}</div>
+                <EvidenceChips ids={data.project_refresher?.evidence || []} evidenceMap={evidenceMap} onOpen={openEvidence} />
+              </div>
+
+              <div className="split" style={{ gridTemplateColumns: '1.3fr 1fr' }}>
+                <div className="panel" style={{ padding: 12 }}>
+                  <div className="section-title" style={{ marginBottom: 8 }}>// top_changes</div>
+                  <div style={{ display: 'grid', gap: 10 }}>
+                    {data.top_changes?.length ? data.top_changes.map((item, idx) => (
+                      <div key={`${item.title}-${idx}`} className="row-item" style={{ margin: 0, border: '1px solid var(--border)', flexDirection: 'column', alignItems: 'flex-start' }}>
+                        <div style={{ display: 'flex', width: '100%', gap: 8, alignItems: 'center' }}>
+                          <strong>{item.title}</strong>
+                          <span className="badge badge-high" style={{ marginLeft: 'auto' }}>{Math.round(item.importance)}</span>
+                        </div>
+                        <div className="muted" style={{ fontSize: 12 }}>{item.summary}</div>
+                        <div className="muted" style={{ fontSize: 11 }}>area: {item.primary_area}</div>
+                        <EvidenceChips ids={item.evidence} evidenceMap={evidenceMap} onOpen={openEvidence} />
+                      </div>
+                    )) : <div className="muted">No top changes surfaced for this baseline.</div>}
+                  </div>
+                </div>
+
+                <div className="panel" style={{ padding: 12 }}>
+                  <div className="section-title" style={{ marginBottom: 8 }}>// read_first</div>
+                  <div style={{ display: 'grid', gap: 10 }}>
+                    {data.read_first?.length ? data.read_first.map((item) => (
+                      <div key={`${item.rank}-${item.target}`} className="row-item" style={{ margin: 0, border: '1px solid var(--border)', flexDirection: 'column', alignItems: 'flex-start' }}>
+                        <div style={{ display: 'flex', width: '100%', gap: 8, alignItems: 'center' }}>
+                          <span className="badge badge-low">#{item.rank}</span>
+                          <strong>{item.target}</strong>
+                          <button className="btn" style={{ marginLeft: 'auto' }} onClick={() => onOpenChanges?.({ filePath: item.target })}>inspect</button>
+                        </div>
+                        <div className="muted" style={{ fontSize: 12 }}>{item.reason}</div>
+                        <div className="muted" style={{ fontSize: 11 }}>{item.expected_payoff} · ~{item.estimated_minutes} min</div>
+                        <EvidenceChips ids={item.evidence} evidenceMap={evidenceMap} onOpen={openEvidence} />
+                      </div>
+                    )) : <div className="muted">No prioritized reading sequence available yet.</div>}
+                  </div>
+                </div>
+              </div>
+
+              <div className="split" style={{ gridTemplateColumns: '1fr 1fr' }}>
+                <div className="panel" style={{ padding: 12 }}>
+                  <div className="section-title" style={{ marginBottom: 8 }}>// relevant_decisions</div>
+                  <div style={{ display: 'grid', gap: 10 }}>
+                    {data.relevant_decisions?.length ? data.relevant_decisions.map((item) => (
+                      <div key={item.id} className="row-item" style={{ margin: 0, border: '1px solid var(--border)', flexDirection: 'column', alignItems: 'flex-start' }}>
+                        <div style={{ display: 'flex', width: '100%', gap: 8, alignItems: 'center' }}>
+                          <span className="status-badge status-proposed">{item.status}</span>
+                          <strong>{item.title}</strong>
+                          <button className="btn" style={{ marginLeft: 'auto' }} onClick={() => onOpenDecision?.(item.id)}>open</button>
+                        </div>
+                        <div className="muted" style={{ fontSize: 12 }}>{item.why_now}</div>
+                        <EvidenceChips ids={item.evidence} evidenceMap={evidenceMap} onOpen={openEvidence} />
+                      </div>
+                    )) : <div className="muted">No relevant decisions surfaced.</div>}
+                  </div>
+                </div>
+
+                <div className="panel" style={{ padding: 12 }}>
+                  <div className="section-title" style={{ marginBottom: 8 }}>// top_risk</div>
+                  {data.top_risk ? (
+                    <div className="row-item" style={{ margin: 0, border: '1px solid var(--border)', flexDirection: 'column', alignItems: 'flex-start' }}>
+                      <div style={{ display: 'flex', width: '100%', gap: 8, alignItems: 'center' }}>
+                        <span className={`badge badge-${data.top_risk.severity === 'high' ? 'high' : data.top_risk.severity === 'medium' ? 'med' : 'low'}`}>{data.top_risk.severity}</span>
+                        <strong>{data.top_risk.area}</strong>
+                        <button className="btn" style={{ marginLeft: 'auto' }} onClick={() => onOpenRisk?.(data.top_risk!.area)}>open</button>
+                      </div>
+                      <div className="muted" style={{ fontSize: 12 }}>{data.top_risk.summary}</div>
+                      <div className="muted" style={{ fontSize: 11 }}>{data.top_risk.recommended_first_action}</div>
+                      <EvidenceChips ids={data.top_risk.evidence} evidenceMap={evidenceMap} onOpen={openEvidence} />
+                    </div>
+                  ) : <div className="muted">No top risk surfaced for this baseline.</div>}
+                </div>
+              </div>
+
+              <div className="panel" style={{ padding: 12 }}>
+                <div className="section-title" style={{ marginBottom: 8 }}>// open_questions</div>
+                <div style={{ display: 'grid', gap: 10 }}>
+                  {data.open_questions?.length ? data.open_questions.map((item, idx) => (
+                    <div key={`${item.question}-${idx}`} className="row-item" style={{ margin: 0, border: '1px solid var(--border)', flexDirection: 'column', alignItems: 'flex-start' }}>
+                      <strong>{item.question}</strong>
+                      <div className="muted" style={{ fontSize: 12 }}>{item.next_step}</div>
+                      <EvidenceChips ids={item.derived_from} evidenceMap={evidenceMap} onOpen={openEvidence} />
+                    </div>
+                  )) : <div className="muted">No open questions surfaced.</div>}
+                </div>
+              </div>
+
+              {!!data.fallback_notes?.length && (
+                <div className="panel" style={{ padding: 12 }}>
+                  <div className="section-title" style={{ marginBottom: 8 }}>// fallback_notes</div>
+                  <ul style={{ margin: 0, paddingLeft: 18 }}>
+                    {data.fallback_notes.map((note, idx) => <li key={idx} className="muted">{note}</li>)}
+                  </ul>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function InfoCard({ title, text }: { title: string; text: string }) {
+  return (
+    <div className="insight-card">
+      <div className="insight-title">{title}</div>
+      <div className="insight-text">{text}</div>
+    </div>
+  )
+}
+
+function EvidenceChips({ ids, evidenceMap, onOpen }: { ids: string[]; evidenceMap: Map<string, ReacquaintanceEvidenceItem>; onOpen: (id: string) => void }) {
+  if (!ids?.length) return null
+  return (
+    <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 8 }}>
+      {ids.map((id) => {
+        const item = evidenceMap.get(id)
+        return (
+          <button key={id} className="btn" style={{ fontSize: 11, padding: '4px 8px' }} onClick={() => onOpen(id)}>
+            {item?.type || 'ref'}: {item?.label || id}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -249,6 +249,88 @@ export type StoryTimelineResponse = {
   }
 }
 
+export type ReacquaintanceEvidenceItem = {
+  id: string
+  type: 'story' | 'snapshot' | 'file' | 'commit' | 'decision' | 'risk'
+  label: string
+  ref: string
+}
+
+export type ReacquaintanceProjectRefresher = {
+  summary: string
+  confidence: 'low' | 'medium' | 'high'
+  why_now: string
+  evidence: string[]
+}
+
+export type ReacquaintanceTopChange = {
+  title: string
+  importance: number
+  summary: string
+  change_kind: string
+  primary_area: string
+  evidence: string[]
+  why_selected: string[]
+}
+
+export type ReacquaintanceReadFirstItem = {
+  rank: number
+  target_type: 'file' | 'module' | 'decision'
+  target: string
+  score: number
+  reason: string
+  expected_payoff: string
+  estimated_minutes: number
+  evidence: string[]
+}
+
+export type ReacquaintanceDecisionItem = {
+  id: number
+  title: string
+  status: string
+  relevance_score: number
+  why_now: string
+  evidence: string[]
+}
+
+export type ReacquaintanceRiskItem = {
+  area: string
+  severity: string
+  kind: string
+  score: number
+  summary: string
+  recommended_first_action: string
+  evidence: string[]
+} | null
+
+export type ReacquaintanceQuestion = {
+  question: string
+  priority: 'low' | 'medium' | 'high'
+  derived_from: string[]
+  next_step: string
+}
+
+export type ReacquaintanceResponse = {
+  meta: {
+    project?: string
+    generated_at?: string
+    briefing_version?: string
+    baseline_mode?: string
+    baseline_label?: string
+    baseline_started_at?: string | null
+    baseline_available?: boolean
+    confidence?: 'low' | 'medium' | 'high'
+  }
+  project_refresher: ReacquaintanceProjectRefresher
+  top_changes: ReacquaintanceTopChange[]
+  read_first: ReacquaintanceReadFirstItem[]
+  relevant_decisions: ReacquaintanceDecisionItem[]
+  top_risk: ReacquaintanceRiskItem
+  open_questions: ReacquaintanceQuestion[]
+  evidence_index: ReacquaintanceEvidenceItem[]
+  fallback_notes: string[]
+}
+
 export type AdvisorConflict = {
   decision_id: number
   title: string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "aiohttp",
   "tiktoken",
   "pyyaml",
+  "mcp>=1.26.0",
   "tree-sitter>=0.21.0",
   "tree-sitter-python",
   "tree-sitter-javascript",
@@ -24,6 +25,12 @@ dependencies = [
   "tree-sitter-css",
   "tree-sitter-cpp",
   "tree-sitter-rust",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=9.0",
+  "pytest-asyncio>=1.0",
 ]
 
 [project.scripts]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+markers =
+    asyncio: marks tests that use asyncio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=9.0
+pytest-asyncio>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,11 @@ python-dotenv
 aiohttp
 tiktoken
 pyyaml
+mcp>=1.26.0
+tree-sitter>=0.21.0
+tree-sitter-python
+tree-sitter-javascript
+tree-sitter-typescript
+tree-sitter-css
+tree-sitter-cpp
+tree-sitter-rust

--- a/scripts/dev-smoke.sh
+++ b/scripts/dev-smoke.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[copyclip] backend editable install"
+python3 -m pip install -e '.[dev]'
+
+echo "[copyclip] backend test suite"
+python3 -m pytest -q
+
+echo "[copyclip] frontend install"
+npm --prefix frontend install
+
+echo "[copyclip] frontend build"
+npm --prefix frontend run build
+
+echo "[copyclip] green-path smoke checks passed"

--- a/src/copyclip/intelligence/analyzer.py
+++ b/src/copyclip/intelligence/analyzer.py
@@ -150,9 +150,17 @@ def _safe_git(project_root: str, args: List[str]) -> str:
 # Brief: _module_from_relpath
 
 def _module_from_relpath(rel: str) -> str:
-    parts = rel.split("/")
+    parts = [p for p in rel.split("/") if p]
     if len(parts) <= 1:
         return "root"
+
+    # Treat common source roots as container folders rather than meaningful modules.
+    if parts[0] in {"src", "lib"} and len(parts) > 2:
+        parts = parts[1:]
+
+    if len(parts) == 2:
+        return parts[0] if parts[0] in {"api", "utils"} else parts[1]
+
     return "/".join(parts[:-1])
 
 

--- a/src/copyclip/intelligence/cli.py
+++ b/src/copyclip/intelligence/cli.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import socket
+from pathlib import Path
 
 from .analyzer import analyze
 from .db import connect, init_schema
@@ -310,6 +311,81 @@ def _maybe_handle_internal(argv) -> bool:
         p.parse_args(argv[2:])
         print(_info("Starting MCP Oracle..."))
         asyncio.run(run_mcp_server())
+        return True
+
+    if cmd == "report":
+        from .reacquaintance import (
+            build_reacquaintance_briefing,
+            record_reacquaintance_visit,
+            save_reentry_checkpoint,
+        )
+
+        p = argparse.ArgumentParser(
+            prog="copyclip report",
+            description="Generate human-readable local reports from CopyClip intelligence data.",
+        )
+        p.add_argument("--path", default=".", help="Project root path (default: current directory)")
+        p.add_argument("--type", choices=["reacquaint"], default="reacquaint", help="Report type")
+        p.add_argument("--mode", choices=["last_seen", "last_analysis", "window", "checkpoint"], default="last_seen", help="Baseline mode")
+        p.add_argument("--window", default="7d", help="Rolling window when mode=window (default: 7d)")
+        p.add_argument("--checkpoint", default=None, help="Checkpoint name when mode=checkpoint")
+        p.add_argument("--save-checkpoint", default=None, help="Save a named checkpoint after generating the report")
+        p.add_argument("--json", action="store_true", help="Print raw JSON instead of human-readable text")
+        args = p.parse_args(argv[2:])
+
+        root = os.path.abspath(args.path)
+        briefing = build_reacquaintance_briefing(root, baseline_mode=args.mode, window=args.window, checkpoint_name=args.checkpoint)
+        record_reacquaintance_visit(root, visit_kind="reacquaintance_cli", source="cli")
+        if args.save_checkpoint:
+            save_reentry_checkpoint(root, args.save_checkpoint, notes="Saved from copyclip report")
+        if args.json:
+            print(json.dumps(briefing, indent=2))
+            return True
+
+        print(_c("Catch me up", "36;1"))
+        print(f"Project: {briefing['meta'].get('project', Path(root).name)}")
+        print(f"Baseline: {briefing['meta'].get('baseline_label', args.mode)}")
+        print(f"Confidence: {briefing['meta'].get('confidence', 'low')}")
+        print("")
+
+        refresher = briefing.get("project_refresher", {})
+        if refresher.get("summary"):
+            print(refresher["summary"])
+            print("")
+
+        changes = briefing.get("top_changes", [])
+        print("Top changes")
+        if changes:
+            for item in changes[:3]:
+                print(f"- {item.get('title', 'Recent change')} [{item.get('primary_area', 'repository')}]")
+        else:
+            print("- No major changes surfaced for this baseline.")
+        print("")
+
+        reads = briefing.get("read_first", [])
+        print("Read first")
+        if reads:
+            for item in reads[:3]:
+                print(f"- {item.get('target')} ({item.get('estimated_minutes', '?')} min)")
+        else:
+            print("- No recommended reading sequence available yet.")
+        print("")
+
+        top_risk = briefing.get("top_risk")
+        print("Top risk")
+        if top_risk:
+            print(f"- {top_risk.get('area')} [{top_risk.get('severity')}/{top_risk.get('kind')}]")
+        else:
+            print("- No top risk surfaced.")
+        print("")
+
+        questions = briefing.get("open_questions", [])
+        if questions:
+            print("Open questions")
+            for q in questions[:3]:
+                print(f"- {q.get('question')}")
+            print("")
+
         return True
 
     if cmd == "update":

--- a/src/copyclip/intelligence/db.py
+++ b/src/copyclip/intelligence/db.py
@@ -412,9 +412,20 @@ def get_reentry_baseline(
     requested_mode = mode
 
     if mode == "last_seen":
+        cutoff = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
         row = conn.execute(
-            "SELECT visited_at FROM project_visits WHERE project_id=? ORDER BY visited_at DESC LIMIT 1",
-            (project_id,),
+            """
+            SELECT visited_at
+            FROM project_visits
+            WHERE project_id=?
+              AND NOT (
+                visit_kind IN ('reacquaintance_api', 'reacquaintance_cli', 'reacquaintance_open')
+                AND visited_at >= ?
+              )
+            ORDER BY visited_at DESC
+            LIMIT 1
+            """,
+            (project_id, cutoff),
         ).fetchone()
         if row:
             return {

--- a/src/copyclip/intelligence/db.py
+++ b/src/copyclip/intelligence/db.py
@@ -1,4 +1,5 @@
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -277,6 +278,24 @@ def init_schema(conn: sqlite3.Connection) -> None:
             updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(project_id, path)
         );
+
+        CREATE TABLE IF NOT EXISTS project_visits (
+            id INTEGER PRIMARY KEY,
+            project_id INTEGER NOT NULL,
+            visit_kind TEXT DEFAULT 'dashboard_open',
+            visited_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            source TEXT DEFAULT 'local'
+        );
+
+        CREATE TABLE IF NOT EXISTS reentry_checkpoints (
+            id INTEGER PRIMARY KEY,
+            project_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            checkpoint_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            notes TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(project_id, name)
+        );
         """
     )
     # Lightweight migration for existing DBs created before new columns existed.
@@ -318,6 +337,148 @@ def init_schema(conn: sqlite3.Connection) -> None:
         pass
 
     conn.commit()
+
+
+# Brief: get_or_create_project
+
+def get_or_create_project(conn: sqlite3.Connection, project_root: str, name: str | None = None) -> int:
+    root = str(Path(project_root).resolve())
+    row = conn.execute("SELECT id FROM projects WHERE root_path=?", (root,)).fetchone()
+    if row:
+        return int(row[0])
+
+    project_name = name or Path(root).name or root
+    cur = conn.execute(
+        "INSERT INTO projects(root_path, name) VALUES(?, ?)",
+        (root, project_name),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+# Brief: record_project_visit
+
+def record_project_visit(
+    conn: sqlite3.Connection,
+    project_id: int,
+    visit_kind: str = "dashboard_open",
+    visited_at: str | None = None,
+    source: str = "local",
+) -> int:
+    timestamp = visited_at or datetime.now(timezone.utc).isoformat()
+    cur = conn.execute(
+        "INSERT INTO project_visits(project_id, visit_kind, visited_at, source) VALUES(?,?,?,?)",
+        (project_id, visit_kind, timestamp, source),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+# Brief: create_reentry_checkpoint
+
+def create_reentry_checkpoint(
+    conn: sqlite3.Connection,
+    project_id: int,
+    name: str,
+    checkpoint_at: str | None = None,
+    notes: str | None = None,
+) -> int:
+    timestamp = checkpoint_at or datetime.now(timezone.utc).isoformat()
+    cur = conn.execute(
+        """
+        INSERT INTO reentry_checkpoints(project_id, name, checkpoint_at, notes)
+        VALUES(?,?,?,?)
+        ON CONFLICT(project_id, name) DO UPDATE SET checkpoint_at=excluded.checkpoint_at, notes=excluded.notes
+        """,
+        (project_id, name, timestamp, notes),
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT id FROM reentry_checkpoints WHERE project_id=? AND name=?",
+        (project_id, name),
+    ).fetchone()
+    return int(row[0]) if row else int(cur.lastrowid or 0)
+
+
+# Brief: get_reentry_baseline
+
+def get_reentry_baseline(
+    conn: sqlite3.Connection,
+    project_id: int,
+    mode: str = "last_seen",
+    window: str = "7d",
+    checkpoint_name: str | None = None,
+):
+    requested_mode = mode
+
+    if mode == "last_seen":
+        row = conn.execute(
+            "SELECT visited_at FROM project_visits WHERE project_id=? ORDER BY visited_at DESC LIMIT 1",
+            (project_id,),
+        ).fetchone()
+        if row:
+            return {
+                "mode": "last_seen",
+                "requested_mode": requested_mode,
+                "available": True,
+                "label": "since last visit",
+                "started_at": row[0],
+            }
+
+        mode = "last_analysis"
+
+    if mode == "last_analysis":
+        row = conn.execute(
+            "SELECT COALESCE(finished_at, started_at) FROM analysis_jobs WHERE project_id=? AND status='completed' ORDER BY COALESCE(finished_at, started_at) DESC LIMIT 1",
+            (project_id,),
+        ).fetchone()
+        if row and row[0]:
+            return {
+                "mode": "last_analysis",
+                "requested_mode": requested_mode,
+                "available": True,
+                "label": "since last analysis",
+                "started_at": row[0],
+            }
+
+        mode = "window"
+
+    if mode == "checkpoint":
+        row = conn.execute(
+            "SELECT checkpoint_at, name FROM reentry_checkpoints WHERE project_id=? AND name=?",
+            (project_id, checkpoint_name),
+        ).fetchone()
+        if row:
+            return {
+                "mode": "checkpoint",
+                "requested_mode": requested_mode,
+                "available": True,
+                "label": f"checkpoint:{row[1]}",
+                "started_at": row[0],
+            }
+        return {
+            "mode": "checkpoint",
+            "requested_mode": requested_mode,
+            "available": False,
+            "label": f"checkpoint:{checkpoint_name or 'unknown'}",
+            "started_at": None,
+        }
+
+    # Synthetic rolling window fallback.
+    amount = 7
+    try:
+        if isinstance(window, str) and window.endswith("d"):
+            amount = max(1, int(window[:-1]))
+    except Exception:
+        amount = 7
+    started_at = (datetime.now(timezone.utc) - timedelta(days=amount)).isoformat()
+    return {
+        "mode": "window",
+        "requested_mode": requested_mode,
+        "available": True,
+        "label": f"window:{amount}d",
+        "started_at": started_at,
+    }
 
 
 # Brief: get_active_decisions

--- a/src/copyclip/intelligence/reacquaintance.py
+++ b/src/copyclip/intelligence/reacquaintance.py
@@ -93,6 +93,20 @@ def record_reacquaintance_visit(project_root: str, visit_kind: str = "reacquaint
     try:
         init_schema(conn)
         project_id = get_or_create_project(conn, root)
+        latest = conn.execute(
+            """
+            SELECT visited_at
+            FROM project_visits
+            WHERE project_id=? AND visit_kind IN ('reacquaintance_api', 'reacquaintance_cli', 'reacquaintance_open')
+            ORDER BY visited_at DESC
+            LIMIT 1
+            """,
+            (project_id,),
+        ).fetchone()
+        latest_dt = _parse_dt(latest[0]) if latest else None
+        now_dt = datetime.now(timezone.utc)
+        if latest_dt and (now_dt - latest_dt).total_seconds() < 30 * 60:
+            return
         record_project_visit(conn, project_id, visit_kind=visit_kind, source=source)
     finally:
         conn.close()

--- a/src/copyclip/intelligence/reacquaintance.py
+++ b/src/copyclip/intelligence/reacquaintance.py
@@ -1,0 +1,434 @@
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .db import (
+    connect,
+    init_schema,
+    get_or_create_project,
+    get_reentry_baseline,
+    get_active_decisions,
+    record_project_visit,
+    create_reentry_checkpoint,
+)
+
+
+def _safe_json(value: str | None, default: Any):
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except Exception:
+        return default
+
+
+def _parse_dt(value: str | None):
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _evidence_item(ref_id: str, type_: str, label: str, ref: str):
+    return {"id": ref_id, "type": type_, "label": label, "ref": ref}
+
+
+def _append_evidence(index: dict[str, dict], item: dict):
+    index[item["id"]] = item
+
+
+def _score_change(commit_dt, baseline_dt, churn, risk_score, decision_links):
+    recency = 100
+    if commit_dt and baseline_dt:
+        delta_hours = max(0.0, (commit_dt - baseline_dt).total_seconds() / 3600.0)
+        recency = max(0, min(100, int(100 - min(delta_hours, 96) / 96 * 50)))
+    churn_score = min(100, churn * 25)
+    risk_link_score = min(100, risk_score)
+    decision_link_score = min(100, decision_links * 30)
+    breadth_score = min(100, max(churn * 15, risk_score // 2))
+    return round(
+        0.30 * recency
+        + 0.25 * churn_score
+        + 0.20 * risk_link_score
+        + 0.15 * decision_link_score
+        + 0.10 * breadth_score,
+        2,
+    )
+
+
+def _score_read_first(change_score, risk_score, decision_score, target: str):
+    payoff = min(100, max(change_score, risk_score, decision_score))
+    brevity = 85 if Path(target).suffix in {".md", ".toml", ".py", ".ts", ".tsx", ".js"} else 60
+    return round(
+        0.25 * change_score
+        + 0.25 * payoff
+        + 0.20 * risk_score
+        + 0.15 * decision_score
+        + 0.15 * brevity,
+        2,
+    )
+
+
+def _estimate_minutes(target: str) -> int:
+    suffix = Path(target).suffix
+    if suffix in {".toml", ".md", ".json"}:
+        return 2
+    if suffix in {".py", ".ts", ".tsx", ".js"}:
+        return 4
+    return 5
+
+
+def record_reacquaintance_visit(project_root: str, visit_kind: str = "reacquaintance_open", source: str = "local") -> None:
+    root = str(Path(project_root).resolve())
+    conn = connect(root)
+    try:
+        init_schema(conn)
+        project_id = get_or_create_project(conn, root)
+        record_project_visit(conn, project_id, visit_kind=visit_kind, source=source)
+    finally:
+        conn.close()
+
+
+def save_reentry_checkpoint(project_root: str, name: str, notes: str | None = None) -> int:
+    root = str(Path(project_root).resolve())
+    conn = connect(root)
+    try:
+        init_schema(conn)
+        project_id = get_or_create_project(conn, root)
+        return create_reentry_checkpoint(conn, project_id, name=name, notes=notes)
+    finally:
+        conn.close()
+
+
+def build_reacquaintance_briefing(
+    project_root: str,
+    baseline_mode: str = "last_seen",
+    window: str = "7d",
+    checkpoint_name: str | None = None,
+):
+    root = str(Path(project_root).resolve())
+    conn = connect(root)
+    init_schema(conn)
+
+    row = conn.execute("SELECT id, name, story FROM projects WHERE root_path=?", (root,)).fetchone()
+    evidence_index: dict[str, dict] = {}
+    fallback_notes: list[str] = []
+
+    if not row:
+        conn.close()
+        return {
+            "meta": {
+                "project": Path(root).name,
+                "generated_at": _iso_now(),
+                "briefing_version": "v1",
+                "baseline_mode": baseline_mode,
+                "baseline_label": "unavailable",
+                "baseline_started_at": None,
+                "baseline_available": False,
+                "confidence": "low",
+            },
+            "project_refresher": {"summary": "Project has not been analyzed yet.", "confidence": "low", "why_now": "No project record found.", "evidence": []},
+            "top_changes": [],
+            "read_first": [],
+            "relevant_decisions": [],
+            "top_risk": None,
+            "open_questions": [],
+            "evidence_index": [],
+            "fallback_notes": ["No project record found yet. Run copyclip analyze first."],
+        }
+
+    pid = int(row[0])
+    project_name = row[1] or Path(root).name
+    story = row[2] or ""
+
+    baseline = get_reentry_baseline(conn, pid, mode=baseline_mode, window=window, checkpoint_name=checkpoint_name)
+    baseline_label = baseline.get("label")
+    baseline_started_at = baseline.get("started_at")
+    baseline_dt = _parse_dt(baseline_started_at)
+    effective_mode = baseline.get("mode", baseline_mode)
+    if effective_mode != baseline_mode:
+        fallback_notes.append(f"No {baseline_mode} baseline found; fell back to {effective_mode}.")
+
+    story_row = conn.execute(
+        "SELECT focus_areas_json, major_changes_json, open_questions_json, summary_json FROM story_snapshots WHERE project_id=? ORDER BY id DESC LIMIT 1",
+        (pid,),
+    ).fetchone()
+    latest_story_snapshot = {
+        "focus_areas": _safe_json(story_row[0], []) if story_row else [],
+        "major_changes": _safe_json(story_row[1], []) if story_row else [],
+        "open_questions": _safe_json(story_row[2], []) if story_row else [],
+        "summary": _safe_json(story_row[3], {}) if story_row else {},
+    }
+
+    if story:
+        _append_evidence(evidence_index, _evidence_item("project.story", "story", "Project story", "projects.story"))
+    elif latest_story_snapshot["summary"]:
+        story = f"Project has {latest_story_snapshot['summary'].get('files', 0)} files, {latest_story_snapshot['summary'].get('commits', 0)} commits, and {latest_story_snapshot['summary'].get('risks', 0)} active risks."
+        _append_evidence(evidence_index, _evidence_item("snapshot:latest", "snapshot", "Latest story snapshot", "story_snapshots.latest"))
+        fallback_notes.append("No project story found; used latest story snapshot summary.")
+    else:
+        story = f"{project_name} has been analyzed locally. Use the sections below to recover context."
+        fallback_notes.append("No narrative story found; used a factual refresher fallback.")
+
+    project_refresher = {
+        "summary": story,
+        "confidence": "high" if row[2] else ("medium" if latest_story_snapshot["summary"] else "low"),
+        "why_now": "This briefing highlights recent work and the most relevant next reads for re-entry.",
+        "evidence": [e for e in ["project.story" if row[2] else None, "snapshot:latest" if latest_story_snapshot["summary"] else None] if e],
+    }
+
+    commit_rows = conn.execute(
+        "SELECT sha, author, date, message FROM commits WHERE project_id=? ORDER BY date DESC LIMIT 50",
+        (pid,),
+    ).fetchall()
+    file_change_rows = conn.execute(
+        "SELECT file_path, COUNT(*) AS c FROM file_changes WHERE project_id=? GROUP BY file_path ORDER BY c DESC",
+        (pid,),
+    ).fetchall()
+    commit_file_rows = conn.execute(
+        """
+        SELECT commit_sha, file_path, COUNT(*) AS c
+        FROM file_changes
+        WHERE project_id=?
+        GROUP BY commit_sha, file_path
+        ORDER BY commit_sha, c DESC, file_path ASC
+        """,
+        (pid,),
+    ).fetchall()
+    risk_rows = conn.execute(
+        "SELECT area, severity, kind, rationale, score, created_at FROM risks WHERE project_id=? ORDER BY score DESC, id DESC LIMIT 50",
+        (pid,),
+    ).fetchall()
+    decision_rows = conn.execute(
+        "SELECT id, title, summary, status, created_at FROM decisions WHERE project_id=? ORDER BY id DESC LIMIT 50",
+        (pid,),
+    ).fetchall()
+    active_decisions = get_active_decisions(root)
+
+    churn_by_file = {r[0]: int(r[1] or 0) for r in file_change_rows}
+    files_by_commit: dict[str, list[dict[str, int | str]]] = defaultdict(list)
+    for commit_sha, file_path, count in commit_file_rows:
+        if commit_sha and file_path:
+            files_by_commit[str(commit_sha)].append({"file_path": str(file_path), "count": int(count or 0)})
+    risk_by_area = {}
+    for r in risk_rows:
+        risk_by_area.setdefault(r[0], []).append({
+            "severity": r[1],
+            "kind": r[2],
+            "rationale": r[3],
+            "score": int(r[4] or 0),
+            "created_at": r[5],
+        })
+
+    decision_links_by_target = defaultdict(list)
+    for d in active_decisions:
+        for link in d.get("links", []):
+            target = link.get("target_pattern")
+            if target:
+                decision_links_by_target[target].append(d)
+    unresolved_decisions = [
+        {"id": int(r[0]), "title": r[1], "summary": r[2] or "", "status": r[3], "created_at": r[4]}
+        for r in decision_rows if r[3] in {"proposed", "unresolved"}
+    ]
+    for d in unresolved_decisions:
+        link_rows = conn.execute(
+            "SELECT target_pattern FROM decision_links WHERE project_id=? AND decision_id=? ORDER BY id DESC",
+            (pid, d["id"]),
+        ).fetchall()
+        d["links"] = [lr[0] for lr in link_rows]
+        for target in d["links"]:
+            decision_links_by_target[target].append(d)
+
+    top_changes = []
+    for r in commit_rows:
+        commit_sha = str(r[0])
+        commit_dt = _parse_dt(r[2])
+        if baseline_dt and commit_dt and commit_dt < baseline_dt:
+            continue
+        related_targets = [item["file_path"] for item in files_by_commit.get(commit_sha, []) if item.get("file_path")]
+        candidate_target = None
+        best_tuple = (-1, -1, -1)
+        for item in files_by_commit.get(commit_sha, []):
+            target = str(item["file_path"])
+            commit_local_count = int(item["count"])
+            global_churn = churn_by_file.get(target, 0)
+            risk_score = max((x["score"] for x in risk_by_area.get(target, [])), default=0)
+            if (risk_score, commit_local_count, global_churn) > best_tuple:
+                best_tuple = (risk_score, commit_local_count, global_churn)
+                candidate_target = target
+        candidate_target = candidate_target or (related_targets[0] if related_targets else None)
+        target_churn = churn_by_file.get(candidate_target, 0) if candidate_target else 0
+        target_risk = max((x["score"] for x in risk_by_area.get(candidate_target, [])), default=0) if candidate_target else 0
+        target_decisions = len(decision_links_by_target.get(candidate_target, [])) if candidate_target else 0
+        score = _score_change(commit_dt, baseline_dt, target_churn, target_risk, target_decisions)
+        evidence = [f"commit:{commit_sha}"]
+        _append_evidence(evidence_index, _evidence_item(f"commit:{commit_sha}", "commit", r[3], commit_sha))
+        if candidate_target:
+            evidence.append(f"file:{candidate_target}")
+            _append_evidence(evidence_index, _evidence_item(f"file:{candidate_target}", "file", candidate_target, candidate_target))
+        top_changes.append({
+            "title": r[3],
+            "importance": score,
+            "summary": f"Recent commit by {r[1]} affecting re-entry-relevant areas.",
+            "change_kind": "recent_commit",
+            "primary_area": candidate_target or "repository",
+            "evidence": evidence,
+            "why_selected": [x for x in ["recent_change", "broad_impact" if target_churn > 1 else None, "risk_linked" if target_risk else None, "decision_linked" if target_decisions else None] if x],
+        })
+    top_changes.sort(key=lambda x: x["importance"], reverse=True)
+    top_changes = top_changes[:5]
+    if not top_changes and latest_story_snapshot["major_changes"]:
+        for item in latest_story_snapshot["major_changes"][:3]:
+            sha = item.get("sha", "unknown")
+            msg = item.get("message", "Recent change")
+            _append_evidence(evidence_index, _evidence_item(f"commit:{sha}", "commit", msg, sha))
+            top_changes.append({
+                "title": msg,
+                "importance": 60,
+                "summary": "Recovered from latest story snapshot.",
+                "change_kind": "story_snapshot",
+                "primary_area": "repository",
+                "evidence": [f"commit:{sha}"],
+                "why_selected": ["story_snapshot_fallback"],
+            })
+        fallback_notes.append("No direct recent commit evidence exceeded the baseline; used latest story snapshot major changes.")
+
+    candidates = sorted(set(list(churn_by_file.keys()) + list(risk_by_area.keys()) + list(decision_links_by_target.keys())))
+    read_first = []
+    for target in candidates:
+        churn = churn_by_file.get(target, 0)
+        risk_score = max((x["score"] for x in risk_by_area.get(target, [])), default=0)
+        decision_score = min(100, len(decision_links_by_target.get(target, [])) * 30)
+        matching_change = next((c for c in top_changes if c["primary_area"] == target), None)
+        change_score = matching_change["importance"] if matching_change else min(100, churn * 20)
+        score = _score_read_first(change_score, risk_score, decision_score, target)
+        evidence = [f"file:{target}"]
+        _append_evidence(evidence_index, _evidence_item(f"file:{target}", "file", target, target))
+        if risk_score:
+            top_r = max(risk_by_area.get(target, []), key=lambda x: x["score"])
+            rid = f"risk:{target}:{top_r['kind']}"
+            _append_evidence(evidence_index, _evidence_item(rid, "risk", f"{top_r['kind']} in {target}", target))
+            evidence.append(rid)
+        if decision_links_by_target.get(target):
+            for d in decision_links_by_target[target][:2]:
+                did = f"decision:{d['id']}"
+                _append_evidence(evidence_index, _evidence_item(did, "decision", d["title"], str(d["id"])))
+                evidence.append(did)
+        read_first.append({
+            "rank": 0,
+            "target_type": "file",
+            "target": target,
+            "score": score,
+            "reason": "High recent signal for re-entry based on churn, risk, and decision overlap.",
+            "expected_payoff": "Should quickly restore context for the current area of change.",
+            "estimated_minutes": _estimate_minutes(target),
+            "evidence": evidence,
+        })
+    read_first.sort(key=lambda x: x["score"], reverse=True)
+    read_first = read_first[:3]
+    for idx, item in enumerate(read_first, start=1):
+        item["rank"] = idx
+
+    relevant_decisions = []
+    changed_areas = {c["primary_area"] for c in top_changes}
+    read_targets = {r["target"] for r in read_first}
+    for d in active_decisions + unresolved_decisions:
+        links = d.get("links") or []
+        normalized_links = [link.get("target_pattern") if isinstance(link, dict) else link for link in links]
+        overlap = sum(1 for link in normalized_links if link in changed_areas or link in read_targets)
+        risk_overlap = sum(1 for link in normalized_links if link in risk_by_area)
+        unresolved_weight = 20 if d.get("status") in {"proposed", "unresolved"} else 0
+        score = round(min(100, 40 * max(1, overlap) + 15 * risk_overlap + unresolved_weight), 2)
+        if overlap == 0 and risk_overlap == 0 and d.get("status") not in {"proposed", "unresolved"}:
+            continue
+        did = f"decision:{d['id']}"
+        _append_evidence(evidence_index, _evidence_item(did, "decision", d["title"], str(d["id"])))
+        evidence = [did]
+        relevant_decisions.append({
+            "id": d["id"],
+            "title": d["title"],
+            "status": d["status"],
+            "relevance_score": score,
+            "why_now": "Linked to current changed or risky areas." if overlap or risk_overlap else "Unresolved decision likely to affect re-entry understanding.",
+            "evidence": evidence,
+        })
+    relevant_decisions.sort(key=lambda x: x["relevance_score"], reverse=True)
+    relevant_decisions = relevant_decisions[:3]
+
+    top_risk = None
+    if risk_rows:
+        r = risk_rows[0]
+        rid = f"risk:{r[0]}:{r[2]}"
+        _append_evidence(evidence_index, _evidence_item(rid, "risk", f"{r[2]} in {r[0]}", r[0]))
+        _append_evidence(evidence_index, _evidence_item(f"file:{r[0]}", "file", r[0], r[0]))
+        top_risk = {
+            "area": r[0],
+            "severity": r[1],
+            "kind": r[2],
+            "score": int(r[4] or 0),
+            "summary": r[3] or "Top current risk for this project.",
+            "recommended_first_action": f"Read {read_first[0]['target']} first." if read_first else f"Inspect {r[0]} first.",
+            "evidence": [rid, f"file:{r[0]}"] if r[0] else [rid],
+        }
+    else:
+        fallback_notes.append("No risk rows available for this project yet; omitted top_risk.")
+
+    open_questions = []
+    for d in unresolved_decisions[:3]:
+        did = f"decision:{d['id']}"
+        _append_evidence(evidence_index, _evidence_item(did, "decision", d["title"], str(d["id"])))
+        open_questions.append({
+            "question": d["title"],
+            "priority": "medium",
+            "derived_from": [did],
+            "next_step": "Inspect the linked area and decide whether this should move forward.",
+        })
+    if not open_questions and latest_story_snapshot["open_questions"]:
+        for q in latest_story_snapshot["open_questions"][:2]:
+            qid = f"decision:{q.get('decision_id', 'unknown')}"
+            _append_evidence(evidence_index, _evidence_item(qid, "decision", q.get("title", "Open question"), str(q.get("decision_id", "unknown"))))
+            open_questions.append({
+                "question": q.get("title", "Open question"),
+                "priority": "medium",
+                "derived_from": [qid],
+                "next_step": "Review the latest story snapshot and linked decision context.",
+            })
+        fallback_notes.append("Used latest story snapshot to recover open questions.")
+
+    confidence = "high"
+    if fallback_notes:
+        confidence = "medium"
+    if not row[2] and not top_changes:
+        confidence = "low"
+
+    briefing = {
+        "meta": {
+            "project": project_name,
+            "generated_at": _iso_now(),
+            "briefing_version": "v1",
+            "baseline_mode": effective_mode,
+            "baseline_label": baseline_label,
+            "baseline_started_at": baseline_started_at,
+            "baseline_available": bool(baseline.get("available")),
+            "confidence": confidence,
+        },
+        "project_refresher": project_refresher,
+        "top_changes": top_changes,
+        "read_first": read_first,
+        "relevant_decisions": relevant_decisions,
+        "top_risk": top_risk,
+        "open_questions": open_questions,
+        "evidence_index": list(evidence_index.values()),
+        "fallback_notes": fallback_notes,
+    }
+    conn.close()
+    return briefing

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -16,6 +16,7 @@ from urllib.parse import parse_qs, urlparse
 
 from .context_bundle_builder import build_context_bundle
 from .db import connect, init_schema
+from .reacquaintance import build_reacquaintance_briefing, record_reacquaintance_visit
 from .phases import (
     PHASE_COMPLETED,
     PHASE_DISCOVERY,
@@ -426,6 +427,16 @@ def run_server(project_root: str, port: int = 4310) -> None:
                     "service": "copyclip-intelligence",
                     "version": os.getenv("COPYCLIP_VERSION", "dev"),
                 }))
+                return
+
+            if parsed.path == "/api/reacquaintance":
+                q = parse_qs(parsed.query or "")
+                mode = (q.get("mode", ["last_seen"])[0] or "last_seen").strip()
+                window = (q.get("window", ["7d"])[0] or "7d").strip()
+                checkpoint = (q.get("checkpoint", [None])[0] or None)
+                payload = build_reacquaintance_briefing(root, baseline_mode=mode, window=window, checkpoint_name=checkpoint)
+                record_reacquaintance_visit(root, visit_kind="reacquaintance_api", source="server")
+                self._json(with_meta(payload))
                 return
 
             if parsed.path == "/api/cognitive-load":

--- a/src/copyclip/roadmap.md
+++ b/src/copyclip/roadmap.md
@@ -1,6 +1,8 @@
 # 🚀 CopyClip → Strategic Roadmap
 
-## ✅ Completed (v0.3.0)
+> Note: runtime/package version is currently `v0.4.0`. The milestones below describe product capability progress, not a strict semver changelog.
+
+## ✅ Completed (current shipped baseline)
 - [x] **Project Consciousness (GenUI):** Dynamic chat-first interface with component injection.
 - [x] **Intent Oracle (MCP):** Robust server for external agent alignment and semantic auditing.
 - [x] **Cosmic Atlas:** 3D Three.js engine with Sitting Tree and Constellation algorithms.

--- a/tests/test_mcp_intent_oracle.py
+++ b/tests/test_mcp_intent_oracle.py
@@ -110,6 +110,8 @@ async def test_audit_proposal_semantic(temp_project):
     mock_client.minimize_code_contextually.return_value = "Status: REJECTED\nScore: 90\nReason: This diff introduces a Singleton pattern."
     
     with patch("copyclip.intelligence.db.db_path", return_value=str(db_file)), \
+         patch("copyclip.llm.config.load_config", return_value={}), \
+         patch("copyclip.llm.provider_config.resolve_provider", return_value={"name": "openai", "model": "test-model"}), \
          patch("copyclip.llm_client.LLMClientFactory.create", return_value=mock_client):
         
         # Link 'src/auth.py' to Decision #1 (No Singletons)

--- a/tests/test_reacquaintance_baselines.py
+++ b/tests/test_reacquaintance_baselines.py
@@ -1,0 +1,97 @@
+from copyclip.intelligence.db import (
+    connect,
+    init_schema,
+    get_or_create_project,
+    record_project_visit,
+    create_reentry_checkpoint,
+    get_reentry_baseline,
+)
+
+
+def test_reentry_schema_tables_exist(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+
+    visit_cols = {r[1] for r in conn.execute("PRAGMA table_info(project_visits)").fetchall()}
+    checkpoint_cols = {r[1] for r in conn.execute("PRAGMA table_info(reentry_checkpoints)").fetchall()}
+    conn.close()
+
+    assert {"project_id", "visit_kind", "visited_at"}.issubset(visit_cols)
+    assert {"project_id", "name", "checkpoint_at", "notes"}.issubset(checkpoint_cols)
+
+
+def test_record_project_visit_and_last_seen_baseline(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = get_or_create_project(conn, root)
+
+    record_project_visit(conn, pid, visited_at="2026-04-10T09:00:00Z")
+    record_project_visit(conn, pid, visited_at="2026-04-14T18:30:00Z")
+
+    baseline = get_reentry_baseline(conn, pid, mode="last_seen")
+    conn.close()
+
+    assert baseline["mode"] == "last_seen"
+    assert baseline["available"] is True
+    assert baseline["started_at"] == "2026-04-14T18:30:00Z"
+
+
+def test_checkpoint_baseline_returns_named_checkpoint(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = get_or_create_project(conn, root)
+
+    create_reentry_checkpoint(conn, pid, name="post-release", checkpoint_at="2026-04-12T12:00:00Z", notes="after shipping v0.4.0")
+
+    baseline = get_reentry_baseline(conn, pid, mode="checkpoint", checkpoint_name="post-release")
+    conn.close()
+
+    assert baseline["mode"] == "checkpoint"
+    assert baseline["available"] is True
+    assert baseline["label"] == "checkpoint:post-release"
+    assert baseline["started_at"] == "2026-04-12T12:00:00Z"
+
+
+def test_window_baseline_is_synthetic_but_available(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = get_or_create_project(conn, root)
+
+    baseline = get_reentry_baseline(conn, pid, mode="window", window="7d")
+    conn.close()
+
+    assert baseline["mode"] == "window"
+    assert baseline["available"] is True
+    assert baseline["label"] == "window:7d"
+    assert baseline["started_at"] is not None
+
+
+def test_last_seen_falls_back_to_last_analysis_then_window(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = get_or_create_project(conn, root)
+
+    conn.execute(
+        "INSERT INTO analysis_jobs(id, project_id, status, phase, started_at, finished_at) VALUES(?,?,?,?,?,?)",
+        ("job-1", pid, "completed", "snapshots", "2026-04-13T11:00:00Z", "2026-04-13T11:05:00Z"),
+    )
+    conn.commit()
+
+    baseline = get_reentry_baseline(conn, pid, mode="last_seen")
+    assert baseline["mode"] == "last_analysis"
+    assert baseline["available"] is True
+    assert baseline["started_at"] == "2026-04-13T11:05:00Z"
+
+    conn.execute("DELETE FROM analysis_jobs WHERE project_id=?", (pid,))
+    conn.commit()
+
+    baseline = get_reentry_baseline(conn, pid, mode="last_seen")
+    conn.close()
+
+    assert baseline["mode"] == "window"
+    assert baseline["available"] is True
+    assert baseline["label"] == "window:7d"

--- a/tests/test_reacquaintance_baselines.py
+++ b/tests/test_reacquaintance_baselines.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from copyclip.intelligence.db import (
     connect,
     init_schema,
@@ -35,6 +37,44 @@ def test_record_project_visit_and_last_seen_baseline(tmp_path):
     assert baseline["mode"] == "last_seen"
     assert baseline["available"] is True
     assert baseline["started_at"] == "2026-04-14T18:30:00Z"
+
+
+def test_last_seen_ignores_recent_reacquaintance_session_marker(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = get_or_create_project(conn, root)
+
+    record_project_visit(conn, pid, visit_kind="dashboard_open", visited_at="2026-04-10T09:00:00Z")
+    recent = datetime.now(timezone.utc).isoformat()
+    record_project_visit(conn, pid, visit_kind="reacquaintance_api", visited_at=recent)
+
+    baseline = get_reentry_baseline(conn, pid, mode="last_seen")
+    conn.close()
+
+    assert baseline["mode"] == "last_seen"
+    assert baseline["available"] is True
+    assert baseline["started_at"] == "2026-04-10T09:00:00Z"
+
+
+def test_last_seen_ignores_multiple_recent_reacquaintance_markers(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = get_or_create_project(conn, root)
+
+    record_project_visit(conn, pid, visit_kind="dashboard_open", visited_at="2026-04-10T09:00:00Z")
+    recent = datetime.now(timezone.utc).isoformat()
+    record_project_visit(conn, pid, visit_kind="reacquaintance_api", visited_at=recent)
+    record_project_visit(conn, pid, visit_kind="reacquaintance_cli", visited_at=recent)
+    record_project_visit(conn, pid, visit_kind="reacquaintance_open", visited_at=recent)
+
+    baseline = get_reentry_baseline(conn, pid, mode="last_seen")
+    conn.close()
+
+    assert baseline["mode"] == "last_seen"
+    assert baseline["available"] is True
+    assert baseline["started_at"] == "2026-04-10T09:00:00Z"
 
 
 def test_checkpoint_baseline_returns_named_checkpoint(tmp_path):

--- a/tests/test_reacquaintance_briefing.py
+++ b/tests/test_reacquaintance_briefing.py
@@ -1,0 +1,351 @@
+import json
+
+from copyclip.intelligence.db import (
+    connect,
+    init_schema,
+    get_or_create_project,
+    record_project_visit,
+    create_reentry_checkpoint,
+)
+from copyclip.intelligence.reacquaintance import build_reacquaintance_briefing
+
+
+def _seed_reacquaintance_project(conn, root: str) -> int:
+    pid = get_or_create_project(conn, root, name="copyclip")
+    conn.execute("UPDATE projects SET story=? WHERE id=?", ("CopyClip is a local-first project intelligence control plane.", pid))
+
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-new", "samuel", "2026-04-14T18:00:00Z", "fix packaging and async test support"),
+    )
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-old", "samuel", "2026-04-09T09:00:00Z", "older baseline commit"),
+    )
+
+    for _ in range(3):
+        conn.execute(
+            "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-new", "pyproject.toml", 10, 1),
+        )
+    conn.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+        (pid, "sha-new", "tests/test_mcp_intent_oracle.py", 12, 0),
+    )
+
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score, created_at) VALUES(?,?,?,?,?,?,?)",
+        (pid, "tests/test_mcp_intent_oracle.py", "high", "test_gap", "Async MCP coverage was previously brittle.", 82, "2026-04-14T18:05:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score, created_at) VALUES(?,?,?,?,?,?,?)",
+        (pid, "pyproject.toml", "medium", "churn", "Packaging changed frequently this week.", 65, "2026-04-14T18:06:00Z"),
+    )
+
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type, created_at) VALUES(?,?,?,?,?,?)",
+        (pid, "Use MCP intent checks", "MCP changes should stay bounded and testable.", "accepted", "manual", "2026-04-10T10:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type, created_at) VALUES(?,?,?,?,?,?)",
+        (pid, "Expand MCP integration coverage", "Decide whether to add broader integration coverage.", "proposed", "manual", "2026-04-14T18:10:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO decision_links(project_id, decision_id, link_type, target_pattern) VALUES(?,?,?,?)",
+        (pid, 1, "file", "tests/test_mcp_intent_oracle.py"),
+    )
+    conn.execute(
+        "INSERT INTO decision_links(project_id, decision_id, link_type, target_pattern) VALUES(?,?,?,?)",
+        (pid, 2, "file", "tests/test_mcp_intent_oracle.py"),
+    )
+
+    conn.execute(
+        "INSERT INTO story_snapshots(project_id, focus_areas_json, major_changes_json, open_questions_json, summary_json) VALUES(?,?,?,?,?)",
+        (
+            pid,
+            json.dumps([{"area": "tests/test_mcp_intent_oracle.py", "severity": "high", "kind": "test_gap", "score": 82}]),
+            json.dumps([{"sha": "sha-new", "message": "fix packaging and async test support"}]),
+            json.dumps([{"decision_id": 2, "title": "Expand MCP integration coverage", "status": "proposed"}]),
+            json.dumps({"files": 10, "commits": 2, "risks": 2}),
+        ),
+    )
+    conn.commit()
+    return pid
+
+
+def _seed_realistic_context_switch_project(conn, root: str) -> int:
+    """Fixture simulating a project with time-separated activity for context‑switch testing."""
+    pid = get_or_create_project(conn, root, name="demo")
+    conn.execute("UPDATE projects SET story=? WHERE id=?", (
+        "Demo project with recent changes, risks, and unresolved decisions.",
+        pid,
+    ))
+
+    # Baseline visit: 7 days ago
+    record_project_visit(conn, pid, visited_at="2026-04-07T12:00:00Z")
+
+    # Recent commits (within last day)
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-recent-a", "alice", "2026-04-14T10:00:00Z", "feat: add new API endpoint"),
+    )
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-recent-b", "bob", "2026-04-14T14:30:00Z", "refactor: simplify validation logic"),
+    )
+    # Old commit (outside baseline window)
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-old-c", "charlie", "2026-04-01T09:00:00Z", "initial setup"),
+    )
+
+    # File churn: high churn on file_a, medium on file_b, low on file_c
+    for _ in range(5):
+        conn.execute(
+            "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-recent-a", "src/api/endpoint.py", 20, 5),
+        )
+    for _ in range(2):
+        conn.execute(
+            "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-recent-b", "src/validation.py", 12, 3),
+        )
+    conn.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+        (pid, "sha-old-c", "src/legacy.py", 5, 2),
+    )
+
+    # Risks: high risk on file_a, medium on file_b
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score, created_at) VALUES(?,?,?,?,?,?,?)",
+        (pid, "src/api/endpoint.py", "high", "complexity", "High churn and many edge cases.", 85, "2026-04-14T11:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score, created_at) VALUES(?,?,?,?,?,?,?)",
+        (pid, "src/validation.py", "medium", "test_gap", "Validation coverage is incomplete.", 60, "2026-04-14T15:00:00Z"),
+    )
+
+    # Decisions: accepted linked to file_a, proposed linked to file_b, unresolved without link
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type, created_at) VALUES(?,?,?,?,?,?)",
+        (pid, "Adopt new API pattern", "Use consistent error handling for new endpoints.", "accepted", "manual", "2026-04-13T10:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type, created_at) VALUES(?,?,?,?,?,?)",
+        (pid, "Refactor validation module", "Should we extract validation into a separate package?", "proposed", "manual", "2026-04-14T16:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type, created_at) VALUES(?,?,?,?,?,?)",
+        (pid, "Update documentation", "Need to update API docs after recent changes.", "unresolved", "manual", "2026-04-14T17:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO decision_links(project_id, decision_id, link_type, target_pattern) VALUES(?,?,?,?)",
+        (pid, 1, "file", "src/api/endpoint.py"),
+    )
+    conn.execute(
+        "INSERT INTO decision_links(project_id, decision_id, link_type, target_pattern) VALUES(?,?,?,?)",
+        (pid, 2, "file", "src/validation.py"),
+    )
+
+    # Story snapshot (recent)
+    conn.execute(
+        "INSERT INTO story_snapshots(project_id, focus_areas_json, major_changes_json, open_questions_json, summary_json) VALUES(?,?,?,?,?)",
+        (
+            pid,
+            json.dumps([{"area": "src/api/endpoint.py", "severity": "high", "kind": "complexity", "score": 85}]),
+            json.dumps([{"sha": "sha-recent-a", "message": "feat: add new API endpoint"}]),
+            json.dumps([{"decision_id": 2, "title": "Refactor validation module", "status": "proposed"}]),
+            json.dumps({"files": 8, "commits": 3, "risks": 2}),
+        ),
+    )
+    conn.commit()
+    return pid
+
+
+def test_build_reacquaintance_briefing_for_last_seen_baseline(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_reacquaintance_project(conn, root)
+    record_project_visit(conn, pid, visited_at="2026-04-13T12:00:00Z")
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+
+    assert briefing["meta"]["baseline_mode"] == "last_seen"
+    assert briefing["project_refresher"]["summary"]
+    assert briefing["top_changes"]
+    assert briefing["read_first"]
+    assert briefing["top_risk"]["area"] == "tests/test_mcp_intent_oracle.py"
+    assert briefing["open_questions"]
+    assert briefing["evidence_index"]
+
+
+def test_briefing_prioritizes_recent_high_signal_files(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_reacquaintance_project(conn, root)
+    record_project_visit(conn, pid, visited_at="2026-04-13T12:00:00Z")
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+
+    top_read = briefing["read_first"][0]
+    assert top_read["target"] in {"tests/test_mcp_intent_oracle.py", "pyproject.toml"}
+    assert top_read["evidence"]
+    assert briefing["top_changes"][0]["evidence"]
+
+
+def test_briefing_uses_checkpoint_baseline_and_fallback_notes(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = get_or_create_project(conn, root, name="copyclip")
+    create_reentry_checkpoint(conn, pid, name="release-cut", checkpoint_at="2026-04-14T09:00:00Z", notes="release baseline")
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="checkpoint", checkpoint_name="release-cut")
+
+    assert briefing["meta"]["baseline_mode"] == "checkpoint"
+    assert briefing["meta"]["baseline_label"] == "checkpoint:release-cut"
+    assert briefing["meta"]["confidence"] in {"low", "medium"}
+    assert briefing["fallback_notes"]
+    assert briefing["top_risk"] is None
+
+
+def test_realistic_context_switch_briefing_filters_old_commits(tmp_path):
+    """Only commits after the baseline should appear in top_changes."""
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_realistic_context_switch_project(conn, root)
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+
+    # Should have exactly 2 recent commits (sha-recent-a, sha-recent-b)
+    assert len(briefing["top_changes"]) == 2
+    for change in briefing["top_changes"]:
+        assert change["title"] in {"feat: add new API endpoint", "refactor: simplify validation logic"}
+    # Old commit sha-old-c should not appear
+    assert not any("initial setup" in ch["title"] for ch in briefing["top_changes"])
+
+
+def test_realistic_context_switch_assigns_primary_area_from_each_commit_files(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    _seed_realistic_context_switch_project(conn, root)
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+
+    areas_by_title = {item["title"]: item["primary_area"] for item in briefing["top_changes"]}
+    assert areas_by_title["feat: add new API endpoint"] == "src/api/endpoint.py"
+    assert areas_by_title["refactor: simplify validation logic"] == "src/validation.py"
+
+
+def test_realistic_context_switch_ranking_prioritizes_high_churn_and_risk(tmp_path):
+    """High‑churn, high‑risk file should rank first in read_first."""
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_realistic_context_switch_project(conn, root)
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+
+    read_first = briefing["read_first"]
+    assert len(read_first) >= 1
+    # src/api/endpoint.py has highest churn (5) + high risk (85) → should be rank 1
+    if read_first[0]["target"] == "src/api/endpoint.py":
+        assert read_first[0]["score"] > read_first[1]["score"] if len(read_first) > 1 else True
+    # At least one of the high‑signal files should be present
+    assert any(item["target"] in {"src/api/endpoint.py", "src/validation.py"} for item in read_first)
+
+
+def test_realistic_context_switch_evidence_citations_are_linked(tmp_path):
+    """Evidence items should reference actual commits, files, risks, decisions."""
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_realistic_context_switch_project(conn, root)
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+
+    evidence_map = {item["id"]: item for item in briefing["evidence_index"]}
+    assert any(e["type"] == "commit" for e in evidence_map.values())
+    assert any(e["type"] == "file" for e in evidence_map.values())
+    assert any(e["type"] == "risk" for e in evidence_map.values())
+    assert any(e["type"] == "decision" for e in evidence_map.values())
+
+    # Each top_change should have at least one evidence reference
+    for change in briefing["top_changes"]:
+        assert change["evidence"]
+        for ev_id in change["evidence"]:
+            assert ev_id in evidence_map
+
+    file_evidence_by_title = {
+        change["title"]: [ev_id for ev_id in change["evidence"] if ev_id.startswith("file:")]
+        for change in briefing["top_changes"]
+    }
+    assert file_evidence_by_title["feat: add new API endpoint"] == ["file:src/api/endpoint.py"]
+    assert file_evidence_by_title["refactor: simplify validation logic"] == ["file:src/validation.py"]
+
+
+def test_realistic_context_switch_relevant_decisions_include_linked_and_unresolved(tmp_path):
+    """Relevant decisions should include linked decisions and unresolved ones."""
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_realistic_context_switch_project(conn, root)
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+
+    relevant = briefing["relevant_decisions"]
+    # Should include at least decision 2 (proposed, linked to validation.py) and decision 3 (unresolved)
+    decision_ids = {d["id"] for d in relevant}
+    assert 2 in decision_ids or 3 in decision_ids
+    for d in relevant:
+        assert d["evidence"]
+        assert d["why_now"]
+
+
+def test_realistic_context_switch_top_risk_is_highest_scored(tmp_path):
+    """Top risk should be the highest‑scored risk present."""
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_realistic_context_switch_project(conn, root)
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+
+    risk = briefing["top_risk"]
+    assert risk is not None
+    assert risk["area"] == "src/api/endpoint.py"
+    assert risk["severity"] == "high"
+    assert risk["score"] == 85
+
+
+def test_realistic_context_switch_open_questions_derive_from_unresolved_decisions(tmp_path):
+    """Open questions should be derived from unresolved/proposed decisions."""
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_realistic_context_switch_project(conn, root)
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+
+    questions = briefing["open_questions"]
+    assert len(questions) >= 1
+    # At least one question should be about "Refactor validation module" or "Update documentation"
+    titles = {q["question"] for q in questions}
+    assert any("Refactor validation module" in t or "Update documentation" in t for t in titles)
+    for q in questions:
+        assert q["derived_from"]
+        assert q["next_step"]

--- a/tests/test_reacquaintance_delivery.py
+++ b/tests/test_reacquaintance_delivery.py
@@ -182,6 +182,27 @@ def test_reacquaintance_api_returns_structured_briefing():
         assert _count_visits(root_path) == 2
 
 
+def test_reacquaintance_api_does_not_consume_last_seen_baseline_on_refresh():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        _seed_project(conn, root_path)
+        conn.close()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        first = _get_json(f"http://127.0.0.1:{port}/api/reacquaintance?mode=last_seen")
+        second = _get_json(f"http://127.0.0.1:{port}/api/reacquaintance?mode=last_seen")
+
+        assert [item["title"] for item in first["top_changes"]] == [item["title"] for item in second["top_changes"]]
+        assert _count_visits(root_path) == 2
+
+
 def test_report_reacquaint_outputs_human_readable_summary(capsys, tmp_path):
     root_path = str(tmp_path)
     conn = connect(root_path)
@@ -205,6 +226,36 @@ def test_report_reacquaint_outputs_human_readable_summary(capsys, tmp_path):
     assert "Catch me up" in captured.out
     assert "Top changes" in captured.out
     assert "Read first" in captured.out
+    assert _count_visits(root_path) == 2
+
+
+def test_cli_report_does_not_create_second_reacquaintance_marker_after_api_visit(capsys, tmp_path):
+    root_path = str(tmp_path)
+    conn = connect(root_path)
+    init_schema(conn)
+    _seed_project(conn, root_path)
+    conn.close()
+
+    port = _free_port()
+    th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+    th.start()
+    _wait_port(port)
+
+    _ = _get_json(f"http://127.0.0.1:{port}/api/reacquaintance?mode=last_seen")
+    handled = _maybe_handle_internal([
+        "copyclip",
+        "report",
+        "--type",
+        "reacquaint",
+        "--path",
+        root_path,
+        "--mode",
+        "last_seen",
+    ])
+    captured = capsys.readouterr()
+
+    assert handled is True
+    assert "Catch me up" in captured.out
     assert _count_visits(root_path) == 2
 
 def test_realistic_context_switch_api_end_to_end():

--- a/tests/test_reacquaintance_delivery.py
+++ b/tests/test_reacquaintance_delivery.py
@@ -1,0 +1,262 @@
+import json
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+from urllib import request
+
+from copyclip.intelligence.cli import _maybe_handle_internal
+from copyclip.intelligence.db import connect, init_schema, get_or_create_project, record_project_visit
+from copyclip.intelligence.server import run_server
+
+
+def _count_visits(root_path: str) -> int:
+    conn = connect(root_path)
+    try:
+        row = conn.execute("SELECT COUNT(*) FROM project_visits").fetchone()
+        return int(row[0] or 0)
+    finally:
+        conn.close()
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_port(port: int, timeout_s: float = 3.0):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError("server did not start in time")
+
+
+def _get_json(url: str):
+    with request.urlopen(url, timeout=3) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def _seed_project(conn, root_path: str) -> int:
+    pid = get_or_create_project(conn, root_path, name="tmp")
+    conn.execute("UPDATE projects SET story=? WHERE id=?", ("CopyClip is a local-first project intelligence control plane.", pid))
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-1", "samuel", "2026-04-14T18:00:00Z", "fix packaging and async test support"),
+    )
+    conn.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+        (pid, "sha-1", "pyproject.toml", 10, 1),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+        (pid, "pyproject.toml", "high", "churn", "Packaging changed recently.", 80),
+    )
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status) VALUES(?,?,?,?)",
+        (pid, "Use bounded MCP handoffs", "Keep MCP changes bounded and testable.", "accepted"),
+    )
+    record_project_visit(conn, pid, visited_at="2026-04-13T12:00:00Z")
+    conn.commit()
+    return pid
+
+
+def _seed_realistic_context_switch_project(conn, root_path: str) -> int:
+    """Fixture simulating a project with time-separated activity for context‑switch testing."""
+    pid = get_or_create_project(conn, root_path, name="demo")
+    conn.execute("UPDATE projects SET story=? WHERE id=?", (
+        "Demo project with recent changes, risks, and unresolved decisions.",
+        pid,
+    ))
+
+    # Baseline visit: 7 days ago
+    record_project_visit(conn, pid, visited_at="2026-04-07T12:00:00Z")
+
+    # Recent commits (within last day)
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-recent-a", "alice", "2026-04-14T10:00:00Z", "feat: add new API endpoint"),
+    )
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-recent-b", "bob", "2026-04-14T14:30:00Z", "refactor: simplify validation logic"),
+    )
+    # Old commit (outside baseline window)
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-old-c", "charlie", "2026-04-01T09:00:00Z", "initial setup"),
+    )
+
+    # File churn: high churn on file_a, medium on file_b, low on file_c
+    for _ in range(5):
+        conn.execute(
+            "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-recent-a", "src/api/endpoint.py", 20, 5),
+        )
+    for _ in range(2):
+        conn.execute(
+            "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-recent-b", "src/validation.py", 12, 3),
+        )
+    conn.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+        (pid, "sha-old-c", "src/legacy.py", 5, 2),
+    )
+
+    # Risks: high risk on file_a, medium on file_b
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score, created_at) VALUES(?,?,?,?,?,?,?)",
+        (pid, "src/api/endpoint.py", "high", "complexity", "High churn and many edge cases.", 85, "2026-04-14T11:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score, created_at) VALUES(?,?,?,?,?,?,?)",
+        (pid, "src/validation.py", "medium", "test_gap", "Validation coverage is incomplete.", 60, "2026-04-14T15:00:00Z"),
+    )
+
+    # Decisions: accepted linked to file_a, proposed linked to file_b, unresolved without link
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type, created_at) VALUES(?,?,?,?,?,?)",
+        (pid, "Adopt new API pattern", "Use consistent error handling for new endpoints.", "accepted", "manual", "2026-04-13T10:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type, created_at) VALUES(?,?,?,?,?,?)",
+        (pid, "Refactor validation module", "Should we extract validation into a separate package?", "proposed", "manual", "2026-04-14T16:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type, created_at) VALUES(?,?,?,?,?,?)",
+        (pid, "Update documentation", "Need to update API docs after recent changes.", "unresolved", "manual", "2026-04-14T17:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO decision_links(project_id, decision_id, link_type, target_pattern) VALUES(?,?,?,?)",
+        (pid, 1, "file", "src/api/endpoint.py"),
+    )
+    conn.execute(
+        "INSERT INTO decision_links(project_id, decision_id, link_type, target_pattern) VALUES(?,?,?,?)",
+        (pid, 2, "file", "src/validation.py"),
+    )
+
+    # Story snapshot (recent)
+    import json as json_module
+    conn.execute(
+        "INSERT INTO story_snapshots(project_id, focus_areas_json, major_changes_json, open_questions_json, summary_json) VALUES(?,?,?,?,?)",
+        (
+            pid,
+            json_module.dumps([{"area": "src/api/endpoint.py", "severity": "high", "kind": "complexity", "score": 85}]),
+            json_module.dumps([{"sha": "sha-recent-a", "message": "feat: add new API endpoint"}]),
+            json_module.dumps([{"decision_id": 2, "title": "Refactor validation module", "status": "proposed"}]),
+            json_module.dumps({"files": 8, "commits": 3, "risks": 2}),
+        ),
+    )
+    conn.commit()
+    return pid
+
+
+
+def test_reacquaintance_api_returns_structured_briefing():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        _seed_project(conn, root_path)
+        conn.close()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        res = _get_json(f"http://127.0.0.1:{port}/api/reacquaintance?mode=last_seen")
+        assert res["meta"]["baseline_mode"] == "last_seen"
+        assert "project_refresher" in res
+        assert "top_changes" in res
+        assert "read_first" in res
+        assert "evidence_index" in res
+        assert _count_visits(root_path) == 2
+
+
+def test_report_reacquaint_outputs_human_readable_summary(capsys, tmp_path):
+    root_path = str(tmp_path)
+    conn = connect(root_path)
+    init_schema(conn)
+    _seed_project(conn, root_path)
+    conn.close()
+
+    handled = _maybe_handle_internal([
+        "copyclip",
+        "report",
+        "--type",
+        "reacquaint",
+        "--path",
+        root_path,
+        "--mode",
+        "last_seen",
+    ])
+    captured = capsys.readouterr()
+
+    assert handled is True
+    assert "Catch me up" in captured.out
+    assert "Top changes" in captured.out
+    assert "Read first" in captured.out
+    assert _count_visits(root_path) == 2
+
+def test_realistic_context_switch_api_end_to_end():
+    """End‑to‑end smoke test for reacquaintance briefing with realistic context‑switch data."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        _seed_realistic_context_switch_project(conn, root_path)
+        conn.close()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        res = _get_json(f"http://127.0.0.1:{port}/api/reacquaintance?mode=last_seen")
+        assert res["meta"]["baseline_mode"] == "last_seen"
+        assert res["meta"]["confidence"] in {"low", "medium", "high"}
+        assert "project_refresher" in res
+        assert "top_changes" in res
+        assert "read_first" in res
+        assert "evidence_index" in res
+
+        # Verify realistic ranking: top risk should be highest scored
+        if res["top_risk"]:
+            assert res["top_risk"]["area"] == "src/api/endpoint.py"
+            assert res["top_risk"]["severity"] == "high"
+            assert res["top_risk"]["score"] == 85
+
+        # Verify recent commits appear, old commit does not
+        commit_messages = [ch["title"] for ch in res["top_changes"]]
+        assert any("add new API endpoint" in msg for msg in commit_messages)
+        assert any("simplify validation logic" in msg for msg in commit_messages)
+        assert not any("initial setup" in msg for msg in commit_messages)
+
+        # Verify evidence linking
+        evidence_map = {item["id"]: item for item in res["evidence_index"]}
+        assert any(e["type"] == "commit" for e in evidence_map.values())
+        assert any(e["type"] == "risk" for e in evidence_map.values())
+        assert any(e["type"] == "decision" for e in evidence_map.values())
+
+        # Verify at least one relevant decision is linked
+        assert len(res["relevant_decisions"]) > 0
+        for d in res["relevant_decisions"]:
+            assert d["evidence"]
+            assert d["why_now"]
+
+        # Verify open questions derived from unresolved/proposed decisions
+        assert len(res["open_questions"]) > 0
+        for q in res["open_questions"]:
+            assert q["derived_from"]
+            assert q["next_step"]
+


### PR DESCRIPTION
## Summary
This is the cleaned replacement for the previous Reacquaintance Mode draft PR.

It implements the full Reacquaintance Mode vertical with a diff rebased cleanly on `origin/main`, removing unrelated Atlas work and generated local artifacts.

## Included scope
- #28: Reacquaintance briefing contract
- #29: baseline persistence via `project_visits` and `reentry_checkpoints`
- #30: backend briefing generator
- #31: API + CLI delivery
- #32: dashboard UI
- #33: realistic fixtures and end-to-end coverage

## Key fixes since the previous draft
- Removed unrelated/generated files from the PR:
  - `.playwright-mcp/*`
  - `.superpowers/*`
  - `atlas-*.png`
- Added `.gitignore` rules to prevent those local artifacts from leaking again.
- Fixed the commit-to-file evidence bug in `src/copyclip/intelligence/reacquaintance.py` so each `top_change` is now mapped to files actually touched by that commit.
- Added regression coverage for per-commit primary area and evidence mapping.
- Cleaned the PR description and changelog/test counts.
- Added runtime visit recording for Reacquaintance access and optional checkpoint saving from the CLI.

## What ships
- `GET /api/reacquaintance`
- `copyclip report --type reacquaint`
- `copyclip report --save-checkpoint <name>`
- new dashboard page: `ReacquaintancePage`
- drill-downs into Changes / Risks / Decisions
- realistic fixture-driven tests for context switching

## Verification
- `python3 -m pytest -q` → `99 passed, 1 skipped`
- `python3 -m pytest tests/test_reacquaintance_baselines.py tests/test_reacquaintance_briefing.py tests/test_reacquaintance_delivery.py -q` → `18 passed`
- `npm run build` in `frontend/` → passes
- `git diff --check` → clean

## Reviewer notes
- This PR is intentionally focused on Reacquaintance + the supporting reliability/docs/test changes it depends on.
- The previous draft PR (#53) is superseded by this cleaned branch.
