### PR TITLE
feat: define evidence-first ask response contract

### DIFF
--- a/docs/API_CONTRACT_V1.md
+++ b/docs/API_CONTRACT_V1.md
@@ -214,15 +214,30 @@ Response:
 ```json
 {
   "answer": "...",
+  "answer_summary": "...",
+  "answer_kind": "grounded_answer",
+  "confidence": "low|medium|high",
   "citations": [
-    {"type": "decision|risk|commit", "id": "...", "label": "..."}
+    {"type": "decision|risk|commit|file", "id": "...", "label": "..."}
   ],
   "grounded": true,
+  "evidence": {
+    "files": [],
+    "commits": [],
+    "decisions": [],
+    "risks": [],
+    "symbols": []
+  },
+  "evidence_selection_rationale": ["..."],
+  "gaps_or_unknowns": [],
+  "next_questions": ["..."],
+  "next_drill_down": {"type": "file|commit|decision|risk|module|none", "target": "..."},
+  "bundle_manifest": [],
   "meta": {}
 }
 ```
 
-If evidence is insufficient, returns grounded=false with empty citations.
+If evidence is insufficient, returns `answer_kind=insufficient_evidence`, `grounded=false`, empty citations, explicit gaps, and suggested next questions.
 
 ---
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -89,15 +89,41 @@ export type AgentResponse = {
 }
 
 export type AskCitation = {
-  type: 'decision' | 'risk' | 'commit'
+  type: 'decision' | 'risk' | 'commit' | 'file'
   id: string | number
   label: string
 }
 
+export type AskEvidenceItem = {
+  id: string | number
+  label: string
+  snippet?: string
+}
+
+export type AskEvidenceGroup = {
+  files: AskEvidenceItem[]
+  commits: AskEvidenceItem[]
+  decisions: AskEvidenceItem[]
+  risks: AskEvidenceItem[]
+  symbols: AskEvidenceItem[]
+}
+
 export type AskResponse = {
   answer: string
+  answer_summary: string
+  answer_kind: 'grounded_answer' | 'insufficient_evidence' | 'contradiction_detected'
+  confidence: 'low' | 'medium' | 'high'
   citations: AskCitation[]
   grounded: boolean
+  evidence: AskEvidenceGroup
+  evidence_selection_rationale: string[]
+  gaps_or_unknowns: string[]
+  next_questions: string[]
+  next_drill_down: {
+    type: 'file' | 'commit' | 'decision' | 'risk' | 'module' | 'none'
+    target: string | number | null
+  }
+  bundle_manifest?: Array<Record<string, unknown>>
 }
 
 export type AlertRule = {

--- a/src/copyclip/intelligence/ask_project.py
+++ b/src/copyclip/intelligence/ask_project.py
@@ -4,7 +4,19 @@ from typing import Any
 from .context_bundle_builder import build_context_bundle
 
 
-STOP_WORDS = {"the", "and", "for", "with", "that", "this", "what", "how"}
+STOP_WORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "that",
+    "this",
+    "what",
+    "how",
+    "about",
+    "tell",
+    "happened",
+}
 TYPE_BOOST = {"decision": 1000, "risk": 500, "commit": 100, "file": 50}
 
 
@@ -23,6 +35,28 @@ def _empty_evidence_groups() -> dict[str, list[dict[str, Any]]]:
         "decisions": [],
         "risks": [],
         "symbols": [],
+    }
+
+
+def _insufficient_evidence_response(bundle_manifest: list[dict[str, Any]], question: str | None = None) -> dict[str, Any]:
+    return {
+        "answer": "I don’t have enough indexed evidence to answer that yet. Re-run analyze or ask with more specific entities (module/file/decision).",
+        "answer_summary": "I don’t have enough indexed evidence to answer that yet.",
+        "answer_kind": "insufficient_evidence",
+        "confidence": "low",
+        "citations": [],
+        "grounded": False,
+        "evidence": _empty_evidence_groups(),
+        "evidence_selection_rationale": ["No indexed artifacts matched the current question strongly enough."],
+        "gaps_or_unknowns": [
+            "The current index does not contain enough query-linked evidence for a grounded answer.",
+        ],
+        "next_questions": [
+            "Ask about a specific file, decision, commit, or module.",
+            "Re-run analyze if the relevant area changed recently.",
+        ],
+        "next_drill_down": {"type": "none", "target": None},
+        "bundle_manifest": bundle_manifest,
     }
 
 
@@ -46,6 +80,7 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
                     "id": r[0],
                     "title": r[1],
                     "snippet": (r[2] or "")[:240],
+                    "query_linked": True,
                 }
             )
 
@@ -63,6 +98,7 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
                     "id": r[0],
                     "title": f"{r[0]} ({r[1]})",
                     "snippet": (r[2] or "")[:240],
+                    "query_linked": True,
                 }
             )
 
@@ -80,17 +116,20 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
                     "id": r[0],
                     "title": (r[1] or "")[:120],
                     "snippet": f"commit {r[0][:7]} on {(r[2] or '')[:10]}",
+                    "query_linked": True,
                 }
             )
 
     for item in bundle.get("manifest", [])[:10]:
+        reasons = item.get("reasons") or []
         evidence.append(
             {
                 "score": max(1, int(item.get("score") or 0) // 20),
                 "type": "file",
                 "id": item.get("path"),
                 "title": item.get("path"),
-                "snippet": ", ".join(item.get("reasons") or []),
+                "snippet": ", ".join(reasons),
+                "query_linked": any(str(reason).startswith("term-match:") for reason in reasons),
             }
         )
 
@@ -110,23 +149,10 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
             break
 
     if not top:
-        return {
-            "answer": "I don’t have enough indexed evidence to answer that yet. Re-run analyze or ask with more specific entities (module/file/decision).",
-            "answer_summary": "I don’t have enough indexed evidence to answer that yet.",
-            "answer_kind": "insufficient_evidence",
-            "confidence": "low",
-            "citations": [],
-            "grounded": False,
-            "evidence": _empty_evidence_groups(),
-            "evidence_selection_rationale": ["No indexed artifacts matched the current question strongly enough."],
-            "gaps_or_unknowns": ["The current index does not contain enough matching evidence for a grounded answer."],
-            "next_questions": [
-                "Ask about a specific file, decision, commit, or module.",
-                "Re-run analyze if the relevant area changed recently.",
-            ],
-            "next_drill_down": {"type": "none", "target": None},
-            "bundle_manifest": bundle.get("manifest", []),
-        }
+        return _insufficient_evidence_response(bundle.get("manifest", []))
+
+    if not any(bool(e.get("query_linked")) for e in top):
+        return _insufficient_evidence_response(bundle.get("manifest", []))
 
     citations = []
     lines = []

--- a/src/copyclip/intelligence/ask_project.py
+++ b/src/copyclip/intelligence/ask_project.py
@@ -1,0 +1,194 @@
+import re
+from typing import Any
+
+from .context_bundle_builder import build_context_bundle
+
+
+STOP_WORDS = {"the", "and", "for", "with", "that", "this", "what", "how"}
+TYPE_BOOST = {"decision": 1000, "risk": 500, "commit": 100, "file": 50}
+
+
+def _terms(question: str) -> list[str]:
+    return [
+        t
+        for t in re.findall(r"[a-zA-Z0-9_\-]{3,}", (question or "").lower())
+        if t not in STOP_WORDS
+    ]
+
+
+def _empty_evidence_groups() -> dict[str, list[dict[str, Any]]]:
+    return {
+        "files": [],
+        "commits": [],
+        "decisions": [],
+        "risks": [],
+        "symbols": [],
+    }
+
+
+def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
+    terms = _terms(question)
+    bundle = build_context_bundle(conn, project_id, question, max_files=20)
+
+    evidence: list[dict[str, Any]] = []
+
+    for r in conn.execute(
+        "SELECT id,title,summary,status FROM decisions WHERE project_id=? ORDER BY id DESC LIMIT 200",
+        (project_id,),
+    ).fetchall():
+        text = f"{r[1]} {r[2] or ''} {r[3]}".lower()
+        score = sum(1 for t in terms if t in text)
+        if score > 0:
+            evidence.append(
+                {
+                    "score": score + 2,
+                    "type": "decision",
+                    "id": r[0],
+                    "title": r[1],
+                    "snippet": (r[2] or "")[:240],
+                }
+            )
+
+    for r in conn.execute(
+        "SELECT area,kind,rationale,score FROM risks WHERE project_id=? ORDER BY score DESC LIMIT 300",
+        (project_id,),
+    ).fetchall():
+        text = f"{r[0]} {r[1]} {r[2] or ''}".lower()
+        score = sum(1 for t in terms if t in text)
+        if score > 0:
+            evidence.append(
+                {
+                    "score": score + 1,
+                    "type": "risk",
+                    "id": r[0],
+                    "title": f"{r[0]} ({r[1]})",
+                    "snippet": (r[2] or "")[:240],
+                }
+            )
+
+    for r in conn.execute(
+        "SELECT sha,message,date FROM commits WHERE project_id=? ORDER BY date DESC LIMIT 300",
+        (project_id,),
+    ).fetchall():
+        text = f"{r[0]} {r[1] or ''}".lower()
+        score = sum(1 for t in terms if t in text)
+        if score > 0:
+            evidence.append(
+                {
+                    "score": score,
+                    "type": "commit",
+                    "id": r[0],
+                    "title": (r[1] or "")[:120],
+                    "snippet": f"commit {r[0][:7]} on {(r[2] or '')[:10]}",
+                }
+            )
+
+    for item in bundle.get("manifest", [])[:10]:
+        evidence.append(
+            {
+                "score": max(1, int(item.get("score") or 0) // 20),
+                "type": "file",
+                "id": item.get("path"),
+                "title": item.get("path"),
+                "snippet": ", ".join(item.get("reasons") or []),
+            }
+        )
+
+    for e in evidence:
+        e["rank"] = TYPE_BOOST.get(e["type"], 0) + e["score"]
+    evidence.sort(key=lambda x: x["rank"], reverse=True)
+
+    seen = set()
+    top = []
+    for e in evidence:
+        key = (e["type"], e["id"])
+        if key in seen:
+            continue
+        seen.add(key)
+        top.append(e)
+        if len(top) >= 5:
+            break
+
+    if not top:
+        return {
+            "answer": "I don’t have enough indexed evidence to answer that yet. Re-run analyze or ask with more specific entities (module/file/decision).",
+            "answer_summary": "I don’t have enough indexed evidence to answer that yet.",
+            "answer_kind": "insufficient_evidence",
+            "confidence": "low",
+            "citations": [],
+            "grounded": False,
+            "evidence": _empty_evidence_groups(),
+            "evidence_selection_rationale": ["No indexed artifacts matched the current question strongly enough."],
+            "gaps_or_unknowns": ["The current index does not contain enough matching evidence for a grounded answer."],
+            "next_questions": [
+                "Ask about a specific file, decision, commit, or module.",
+                "Re-run analyze if the relevant area changed recently.",
+            ],
+            "next_drill_down": {"type": "none", "target": None},
+            "bundle_manifest": bundle.get("manifest", []),
+        }
+
+    citations = []
+    lines = []
+    evidence_groups = _empty_evidence_groups()
+
+    for e in top:
+        item = {"id": e["id"], "label": e["title"], "snippet": e.get("snippet", "")}
+        if e["type"] == "decision":
+            citations.append({"type": "decision", "id": e["id"], "label": f"decision #{e['id']}"})
+            lines.append(f"Decision #{e['id']}: {e['title']}")
+            evidence_groups["decisions"].append(item)
+        elif e["type"] == "risk":
+            citations.append({"type": "risk", "id": e["id"], "label": e["title"]})
+            lines.append(f"Risk signal: {e['title']}")
+            evidence_groups["risks"].append(item)
+        elif e["type"] == "commit":
+            citations.append({"type": "commit", "id": e["id"], "label": f"commit {str(e['id'])[:7]}"})
+            lines.append(f"Recent commit: {e['title']}")
+            evidence_groups["commits"].append(item)
+        elif e["type"] == "file":
+            citations.append({"type": "file", "id": e["id"], "label": e["title"]})
+            lines.append(f"Relevant file: {e['title']}")
+            evidence_groups["files"].append(item)
+
+    rationale = []
+    if evidence_groups["decisions"]:
+        rationale.append("Selected decisions because they directly matched the question terms.")
+    if evidence_groups["risks"]:
+        rationale.append("Included risk signals because they overlap with the same project area.")
+    if evidence_groups["commits"]:
+        rationale.append("Included recent commits to show the latest activity around the topic.")
+    if evidence_groups["files"]:
+        rationale.append("Included files from the compact context bundle for direct drill-down.")
+
+    next_drill_down = {"type": "none", "target": None}
+    if evidence_groups["decisions"]:
+        next_drill_down = {"type": "decision", "target": evidence_groups["decisions"][0]["id"]}
+    elif evidence_groups["risks"]:
+        next_drill_down = {"type": "risk", "target": evidence_groups["risks"][0]["id"]}
+    elif evidence_groups["files"]:
+        next_drill_down = {"type": "file", "target": evidence_groups["files"][0]["id"]}
+    elif evidence_groups["commits"]:
+        next_drill_down = {"type": "commit", "target": evidence_groups["commits"][0]["id"]}
+
+    confidence = "high" if len({c["type"] for c in citations}) >= 2 else "medium"
+    answer = "Based on indexed project evidence, here are the strongest signals:\n- " + "\n- ".join(lines)
+    answer_summary = lines[0] if lines else "Grounded answer generated from indexed project evidence."
+
+    return {
+        "answer": answer,
+        "answer_summary": answer_summary,
+        "answer_kind": "grounded_answer",
+        "confidence": confidence,
+        "citations": citations,
+        "grounded": True,
+        "evidence": evidence_groups,
+        "evidence_selection_rationale": rationale or ["Selected the strongest indexed artifacts for this question."],
+        "gaps_or_unknowns": [],
+        "next_questions": [
+            "Which file or decision should I inspect first?",
+            "What changed most recently in this area?",
+        ],
+        "next_drill_down": next_drill_down,
+        "bundle_manifest": bundle.get("manifest", []),
+    }

--- a/src/copyclip/intelligence/context_bundle_builder.py
+++ b/src/copyclip/intelligence/context_bundle_builder.py
@@ -7,7 +7,7 @@ def _terms(text: str) -> List[str]:
     return [
         t
         for t in re.findall(r"[a-zA-Z0-9_\-]{3,}", (text or "").lower())
-        if t not in {"the", "and", "for", "with", "that", "this", "what", "how", "about"}
+        if t not in {"the", "and", "for", "with", "that", "this", "what", "how", "about", "tell", "happened"}
     ]
 
 

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -2015,8 +2015,25 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 if not top:
                     self._json(with_meta({
                         "answer": "I don’t have enough indexed evidence to answer that yet. Re-run analyze or ask with more specific entities (module/file/decision).",
+                        "answer_summary": "I don’t have enough indexed evidence to answer that yet.",
+                        "answer_kind": "insufficient_evidence",
+                        "confidence": "low",
                         "citations": [],
                         "grounded": False,
+                        "evidence": {
+                            "files": [],
+                            "commits": [],
+                            "decisions": [],
+                            "risks": [],
+                            "symbols": [],
+                        },
+                        "evidence_selection_rationale": ["No indexed artifacts matched the current question strongly enough."],
+                        "gaps_or_unknowns": ["The current index does not contain enough matching evidence for a grounded answer."],
+                        "next_questions": [
+                            "Ask about a specific file, decision, commit, or module.",
+                            "Re-run analyze if the relevant area changed recently.",
+                        ],
+                        "next_drill_down": {"type": "none", "target": None},
                         "bundle_manifest": bundle.get("manifest", []),
                     }))
                     return
@@ -2038,6 +2055,50 @@ def run_server(project_root: str, port: int = 4310) -> None:
                         lines.append(f"Relevant file: {e['title']}")
 
                 answer = "Based on indexed project evidence, here are the strongest signals:\n- " + "\n- ".join(lines)
+                answer_summary = lines[0] if lines else "Grounded answer generated from indexed project evidence."
+                evidence_groups = {
+                    "files": [],
+                    "commits": [],
+                    "decisions": [],
+                    "risks": [],
+                    "symbols": [],
+                }
+                for e in top:
+                    item = {
+                        "id": e["id"],
+                        "label": e["title"],
+                        "snippet": e.get("snippet", ""),
+                    }
+                    if e["type"] == "file":
+                        evidence_groups["files"].append(item)
+                    elif e["type"] == "commit":
+                        evidence_groups["commits"].append(item)
+                    elif e["type"] == "decision":
+                        evidence_groups["decisions"].append(item)
+                    elif e["type"] == "risk":
+                        evidence_groups["risks"].append(item)
+
+                rationale = []
+                if evidence_groups["decisions"]:
+                    rationale.append("Selected decisions because they directly matched the question terms.")
+                if evidence_groups["risks"]:
+                    rationale.append("Included risk signals because they overlap with the same project area.")
+                if evidence_groups["commits"]:
+                    rationale.append("Included recent commits to show the latest activity around the topic.")
+                if evidence_groups["files"]:
+                    rationale.append("Included files from the compact context bundle for direct drill-down.")
+
+                next_drill_down = {"type": "none", "target": None}
+                if evidence_groups["decisions"]:
+                    next_drill_down = {"type": "decision", "target": evidence_groups["decisions"][0]["id"]}
+                elif evidence_groups["risks"]:
+                    next_drill_down = {"type": "risk", "target": evidence_groups["risks"][0]["id"]}
+                elif evidence_groups["files"]:
+                    next_drill_down = {"type": "file", "target": evidence_groups["files"][0]["id"]}
+                elif evidence_groups["commits"]:
+                    next_drill_down = {"type": "commit", "target": evidence_groups["commits"][0]["id"]}
+
+                confidence = "high" if len({c["type"] for c in citations}) >= 2 else "medium"
 
                 # Strict grounding contract: no claim without citations.
                 if not citations:
@@ -2046,8 +2107,19 @@ def run_server(project_root: str, port: int = 4310) -> None:
 
                 self._json(with_meta({
                     "answer": answer,
+                    "answer_summary": answer_summary,
+                    "answer_kind": "grounded_answer",
+                    "confidence": confidence,
                     "citations": citations,
                     "grounded": True,
+                    "evidence": evidence_groups,
+                    "evidence_selection_rationale": rationale or ["Selected the strongest indexed artifacts for this question."],
+                    "gaps_or_unknowns": [],
+                    "next_questions": [
+                        "Which file or decision should I inspect first?",
+                        "What changed most recently in this area?",
+                    ],
+                    "next_drill_down": next_drill_down,
                     "bundle_manifest": bundle.get("manifest", []),
                 }))
                 return

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 from .context_bundle_builder import build_context_bundle
+from .ask_project import build_ask_response
 from .db import connect, init_schema
 from .reacquaintance import build_reacquaintance_briefing, record_reacquaintance_visit
 from .phases import (
@@ -1929,199 +1930,14 @@ def run_server(project_root: str, port: int = 4310) -> None:
                     self._json({"error": "question_required"}, 400)
                     return
 
-                # Lightweight retrieval over indexed artifacts + deterministic compact bundle.
-                terms = [t for t in re.findall(r"[a-zA-Z0-9_\-]{3,}", question.lower()) if t not in {"the", "and", "for", "with", "that", "this", "what", "how"}]
-                bundle = build_context_bundle(conn, pid, question, max_files=20)
+                payload = build_ask_response(conn, pid, question)
 
-                evidence = []
-
-                # Decisions
-                for r in conn.execute(
-                    "SELECT id,title,summary,status FROM decisions WHERE project_id=? ORDER BY id DESC LIMIT 200",
-                    (pid,),
-                ).fetchall():
-                    text = f"{r[1]} {r[2] or ''} {r[3]}".lower()
-                    score = sum(1 for t in terms if t in text)
-                    if score > 0:
-                        evidence.append({
-                            "score": score + 2,
-                            "type": "decision",
-                            "id": r[0],
-                            "title": r[1],
-                            "snippet": (r[2] or "")[:240],
-                        })
-
-                # Risks
-                for r in conn.execute(
-                    "SELECT area,kind,rationale,score FROM risks WHERE project_id=? ORDER BY score DESC LIMIT 300",
-                    (pid,),
-                ).fetchall():
-                    text = f"{r[0]} {r[1]} {r[2] or ''}".lower()
-                    score = sum(1 for t in terms if t in text)
-                    if score > 0:
-                        evidence.append({
-                            "score": score + 1,
-                            "type": "risk",
-                            "id": r[0],
-                            "title": f"{r[0]} ({r[1]})",
-                            "snippet": (r[2] or "")[:240],
-                        })
-
-                # Commits
-                for r in conn.execute(
-                    "SELECT sha,message,date FROM commits WHERE project_id=? ORDER BY date DESC LIMIT 300",
-                    (pid,),
-                ).fetchall():
-                    text = f"{r[0]} {r[1] or ''}".lower()
-                    score = sum(1 for t in terms if t in text)
-                    if score > 0:
-                        evidence.append({
-                            "score": score,
-                            "type": "commit",
-                            "id": r[0],
-                            "title": (r[1] or "")[:120],
-                            "snippet": f"commit {r[0][:7]} on {(r[2] or '')[:10]}",
-                        })
-
-                # Compact-bundle file evidence (deterministic + explainable).
-                for item in bundle.get("manifest", [])[:10]:
-                    evidence.append({
-                        "score": max(1, int(item.get("score") or 0) // 20),
-                        "type": "file",
-                        "id": item.get("path"),
-                        "title": item.get("path"),
-                        "snippet": ", ".join(item.get("reasons") or []),
-                    })
-
-                # Prefer governance artifacts over raw activity noise.
-                type_boost = {"decision": 1000, "risk": 500, "commit": 100, "file": 50}
-                for e in evidence:
-                    e["rank"] = type_boost.get(e["type"], 0) + e["score"]
-
-                evidence.sort(key=lambda x: x["rank"], reverse=True)
-
-                # Deduplicate by (type,id)
-                seen = set()
-                top = []
-                for e in evidence:
-                    k = (e["type"], e["id"])
-                    if k in seen:
-                        continue
-                    seen.add(k)
-                    top.append(e)
-                    if len(top) >= 5:
-                        break
-
-                if not top:
-                    self._json(with_meta({
-                        "answer": "I don’t have enough indexed evidence to answer that yet. Re-run analyze or ask with more specific entities (module/file/decision).",
-                        "answer_summary": "I don’t have enough indexed evidence to answer that yet.",
-                        "answer_kind": "insufficient_evidence",
-                        "confidence": "low",
-                        "citations": [],
-                        "grounded": False,
-                        "evidence": {
-                            "files": [],
-                            "commits": [],
-                            "decisions": [],
-                            "risks": [],
-                            "symbols": [],
-                        },
-                        "evidence_selection_rationale": ["No indexed artifacts matched the current question strongly enough."],
-                        "gaps_or_unknowns": ["The current index does not contain enough matching evidence for a grounded answer."],
-                        "next_questions": [
-                            "Ask about a specific file, decision, commit, or module.",
-                            "Re-run analyze if the relevant area changed recently.",
-                        ],
-                        "next_drill_down": {"type": "none", "target": None},
-                        "bundle_manifest": bundle.get("manifest", []),
-                    }))
-                    return
-
-                citations = []
-                lines = []
-                for e in top:
-                    if e["type"] == "decision":
-                        citations.append({"type": "decision", "id": e["id"], "label": f"decision #{e['id']}"})
-                        lines.append(f"Decision #{e['id']}: {e['title']}")
-                    elif e["type"] == "risk":
-                        citations.append({"type": "risk", "id": e["id"], "label": e["title"]})
-                        lines.append(f"Risk signal: {e['title']}")
-                    elif e["type"] == "commit":
-                        citations.append({"type": "commit", "id": e["id"], "label": f"commit {e['id'][:7]}"})
-                        lines.append(f"Recent commit: {e['title']}")
-                    elif e["type"] == "file":
-                        citations.append({"type": "file", "id": e["id"], "label": e["title"]})
-                        lines.append(f"Relevant file: {e['title']}")
-
-                answer = "Based on indexed project evidence, here are the strongest signals:\n- " + "\n- ".join(lines)
-                answer_summary = lines[0] if lines else "Grounded answer generated from indexed project evidence."
-                evidence_groups = {
-                    "files": [],
-                    "commits": [],
-                    "decisions": [],
-                    "risks": [],
-                    "symbols": [],
-                }
-                for e in top:
-                    item = {
-                        "id": e["id"],
-                        "label": e["title"],
-                        "snippet": e.get("snippet", ""),
-                    }
-                    if e["type"] == "file":
-                        evidence_groups["files"].append(item)
-                    elif e["type"] == "commit":
-                        evidence_groups["commits"].append(item)
-                    elif e["type"] == "decision":
-                        evidence_groups["decisions"].append(item)
-                    elif e["type"] == "risk":
-                        evidence_groups["risks"].append(item)
-
-                rationale = []
-                if evidence_groups["decisions"]:
-                    rationale.append("Selected decisions because they directly matched the question terms.")
-                if evidence_groups["risks"]:
-                    rationale.append("Included risk signals because they overlap with the same project area.")
-                if evidence_groups["commits"]:
-                    rationale.append("Included recent commits to show the latest activity around the topic.")
-                if evidence_groups["files"]:
-                    rationale.append("Included files from the compact context bundle for direct drill-down.")
-
-                next_drill_down = {"type": "none", "target": None}
-                if evidence_groups["decisions"]:
-                    next_drill_down = {"type": "decision", "target": evidence_groups["decisions"][0]["id"]}
-                elif evidence_groups["risks"]:
-                    next_drill_down = {"type": "risk", "target": evidence_groups["risks"][0]["id"]}
-                elif evidence_groups["files"]:
-                    next_drill_down = {"type": "file", "target": evidence_groups["files"][0]["id"]}
-                elif evidence_groups["commits"]:
-                    next_drill_down = {"type": "commit", "target": evidence_groups["commits"][0]["id"]}
-
-                confidence = "high" if len({c["type"] for c in citations}) >= 2 else "medium"
-
-                # Strict grounding contract: no claim without citations.
-                if not citations:
+                # Strict grounding contract: no claim without citations for grounded answers.
+                if payload.get("grounded") and not payload.get("citations"):
                     self._json({"error": "ungrounded_answer_blocked"}, 500)
                     return
 
-                self._json(with_meta({
-                    "answer": answer,
-                    "answer_summary": answer_summary,
-                    "answer_kind": "grounded_answer",
-                    "confidence": confidence,
-                    "citations": citations,
-                    "grounded": True,
-                    "evidence": evidence_groups,
-                    "evidence_selection_rationale": rationale or ["Selected the strongest indexed artifacts for this question."],
-                    "gaps_or_unknowns": [],
-                    "next_questions": [
-                        "Which file or decision should I inspect first?",
-                        "What changed most recently in this area?",
-                    ],
-                    "next_drill_down": next_drill_down,
-                    "bundle_manifest": bundle.get("manifest", []),
-                }))
+                self._json(with_meta(payload))
                 return
 
             if parsed.path == "/api/assemble-context":

--- a/tests/test_intelligence_server_api.py
+++ b/tests/test_intelligence_server_api.py
@@ -164,6 +164,39 @@ def test_ask_endpoint_returns_evidence_first_contract():
         assert set(res["next_drill_down"].keys()) == {"type", "target"}
 
 
+def test_ask_endpoint_returns_structured_insufficient_evidence_response():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root_path, "tmp"))
+        conn.commit()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        res = _post_json(f"http://127.0.0.1:{port}/api/ask", {"question": "what happened to quantum orchard lattice?"})
+        assert res["grounded"] is False
+        assert res["answer_kind"] == "insufficient_evidence"
+        assert res["confidence"] == "low"
+        assert res["citations"] == []
+        assert res["answer_summary"]
+        assert res["evidence"] == {
+            "files": [],
+            "commits": [],
+            "decisions": [],
+            "risks": [],
+            "symbols": [],
+        }
+        assert res["evidence_selection_rationale"]
+        assert res["gaps_or_unknowns"]
+        assert res["next_questions"]
+        assert res["next_drill_down"] == {"type": "none", "target": None}
+
+
 def test_context_bundle_endpoint_returns_manifest():
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)

--- a/tests/test_intelligence_server_api.py
+++ b/tests/test_intelligence_server_api.py
@@ -197,6 +197,87 @@ def test_ask_endpoint_returns_structured_insufficient_evidence_response():
         assert res["next_drill_down"] == {"type": "none", "target": None}
 
 
+def test_ask_endpoint_does_not_ground_vague_question_from_generic_project_noise():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root_path, "tmp"))
+        pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (root_path,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+            (pid, "src/auth/session.ts", "typescript", 1000, 1.0, "h1"),
+        )
+        conn.execute(
+            "INSERT INTO risks(project_id,area,severity,kind,rationale,score) VALUES(?,?,?,?,?,?)",
+            (pid, "src/auth/session.ts", "high", "churn", "frequent edits", 90),
+        )
+        conn.commit()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        res = _post_json(f"http://127.0.0.1:{port}/api/ask", {"question": "what happened?"})
+        assert res["grounded"] is False
+        assert res["answer_kind"] == "insufficient_evidence"
+        assert res["confidence"] == "low"
+        assert res["citations"] == []
+        assert res["gaps_or_unknowns"]
+
+
+def test_ask_endpoint_does_not_ground_common_word_match_in_decision_text():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root_path, "tmp"))
+        pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (root_path,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)",
+            (pid, "About auth rollout", "About the staged release plan", "accepted", "manual"),
+        )
+        conn.commit()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        res = _post_json(f"http://127.0.0.1:{port}/api/ask", {"question": "what about it?"})
+        assert res["grounded"] is False
+        assert res["answer_kind"] == "insufficient_evidence"
+        assert res["citations"] == []
+
+
+def test_ask_endpoint_does_not_ground_common_word_file_path_match():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root_path, "tmp"))
+        pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (root_path,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+            (pid, "src/teller/session.ts", "typescript", 1000, 1.0, "h1"),
+        )
+        conn.commit()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        res = _post_json(f"http://127.0.0.1:{port}/api/ask", {"question": "tell me about it"})
+        assert res["grounded"] is False
+        assert res["answer_kind"] == "insufficient_evidence"
+        assert res["citations"] == []
+
+
 def test_context_bundle_endpoint_returns_manifest():
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)

--- a/tests/test_intelligence_server_api.py
+++ b/tests/test_intelligence_server_api.py
@@ -119,7 +119,7 @@ def test_decision_history_endpoint():
         assert any(item["action"] == "status_change" for item in hist["items"])
 
 
-def test_ask_endpoint_returns_grounded_answer_with_citations():
+def test_ask_endpoint_returns_evidence_first_contract():
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         root_path = str(root.absolute())
@@ -151,6 +151,17 @@ def test_ask_endpoint_returns_grounded_answer_with_citations():
         assert len(res["citations"]) >= 1
         assert any(c["type"] == "decision" for c in res["citations"])
         assert "bundle_manifest" in res
+        assert res["answer_kind"] == "grounded_answer"
+        assert res["confidence"] in {"medium", "high"}
+        assert isinstance(res["answer_summary"], str) and res["answer_summary"]
+        assert isinstance(res["evidence"], dict)
+        assert set(res["evidence"].keys()) == {"files", "commits", "decisions", "risks", "symbols"}
+        assert len(res["evidence"]["decisions"]) >= 1
+        assert isinstance(res["evidence_selection_rationale"], list) and res["evidence_selection_rationale"]
+        assert isinstance(res["gaps_or_unknowns"], list)
+        assert isinstance(res["next_questions"], list)
+        assert isinstance(res["next_drill_down"], dict)
+        assert set(res["next_drill_down"].keys()) == {"type", "target"}
 
 
 def test_context_bundle_endpoint_returns_manifest():


### PR DESCRIPTION
## Summary
Implements the first clean slice of Evidence-first Ask Project (#34).

This PR does three things:
- defines the new `/api/ask` response contract
- extracts ask response construction into a dedicated backend builder module
- adds explicit insufficient-evidence contract coverage

## What changed
- expanded `/api/ask` response shape with:
  - `answer_summary`
  - `answer_kind`
  - `confidence`
  - grouped `evidence`
  - `evidence_selection_rationale`
  - `gaps_or_unknowns`
  - `next_questions`
  - `next_drill_down`
- preserved compatibility fields:
  - `answer`
  - `citations`
  - `grounded`
  - `bundle_manifest`
- extracted backend answer logic to:
  - `src/copyclip/intelligence/ask_project.py`
- reduced `server.py` to a thin route wrapper for `/api/ask`
- updated frontend `AskResponse` types
- updated API contract docs
- added tests for:
  - grounded evidence-first answer contract
  - insufficient-evidence structured fallback

## Verification
- `python3 -m pytest tests/test_intelligence_server_api.py -q` -> `16 passed`
- `cd frontend && npm run build` -> passes

## Scope note
This PR is intentionally limited to #34 contract/fallback behavior and does not yet implement:
- improved retrieval/ranking (#35)
- deeper provenance/rationale logic (#36)
- frontend Ask investigation UI rewrite (#37)
- contradiction handling (#38)
- broader evaluation fixtures (#39)

## Issue
- Closes #34
