### PR TITLE
feat: improve ask project ranking signals

### DIFF
--- a/src/copyclip/intelligence/ask_project.py
+++ b/src/copyclip/intelligence/ask_project.py
@@ -17,7 +17,7 @@ STOP_WORDS = {
     "tell",
     "happened",
 }
-TYPE_BOOST = {"decision": 1000, "risk": 500, "commit": 100, "file": 50}
+TYPE_BOOST = {"decision": 1000, "risk": 500, "commit": 100, "file": 50, "symbol": 750}
 
 
 def _terms(question: str) -> list[str]:
@@ -60,9 +60,56 @@ def _insufficient_evidence_response(bundle_manifest: list[dict[str, Any]], quest
     }
 
 
+def _churn_by_file(conn, project_id: int) -> dict[str, int]:
+    return {
+        row[0]: int(row[1] or 0)
+        for row in conn.execute(
+            "SELECT file_path, COUNT(*) AS c FROM file_changes WHERE project_id=? GROUP BY file_path",
+            (project_id,),
+        ).fetchall()
+        if row[0]
+    }
+
+
+def _risk_by_file(conn, project_id: int) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for row in conn.execute(
+        "SELECT area, kind, rationale, score FROM risks WHERE project_id=? ORDER BY score DESC, id DESC",
+        (project_id,),
+    ).fetchall():
+        area = row[0]
+        if area and area not in out:
+            out[area] = {
+                "kind": row[1],
+                "rationale": row[2] or "",
+                "score": int(row[3] or 0),
+            }
+    return out
+
+
+def _decision_ref_targets(conn, project_id: int) -> dict[str, list[int]]:
+    out: dict[str, list[int]] = {}
+    for row in conn.execute(
+        """
+        SELECT dr.ref_value, d.id
+        FROM decision_refs dr
+        JOIN decisions d ON d.id = dr.decision_id
+        WHERE d.project_id=? AND d.status IN ('accepted', 'resolved') AND dr.ref_type='file'
+        ORDER BY d.id DESC
+        """,
+        (project_id,),
+    ).fetchall():
+        if row[0]:
+            out.setdefault(str(row[0]), []).append(int(row[1]))
+    return out
+
+
 def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
     terms = _terms(question)
     bundle = build_context_bundle(conn, project_id, question, max_files=20)
+    churn_by_file = _churn_by_file(conn, project_id)
+    risk_by_file = _risk_by_file(conn, project_id)
+    decision_refs_by_file = _decision_ref_targets(conn, project_id)
 
     evidence: list[dict[str, Any]] = []
 
@@ -122,16 +169,54 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
 
     for item in bundle.get("manifest", [])[:10]:
         reasons = item.get("reasons") or []
+        file_path = item.get("path")
+        lexical_hits = sum(1 for t in terms if file_path and t in str(file_path).lower())
+        churn = churn_by_file.get(str(file_path), 0) if file_path else 0
+        linked_decisions = len(decision_refs_by_file.get(str(file_path), [])) if file_path else 0
+        risk_score = int((risk_by_file.get(str(file_path), {}) or {}).get("score", 0)) if file_path else 0
+        score = (
+            lexical_hits * 30
+            + min(churn * 10, 60)
+            + min(linked_decisions * 40, 80)
+            + min(risk_score, 100)
+            + max(1, int(item.get("score") or 0) // 20)
+        )
         evidence.append(
             {
-                "score": max(1, int(item.get("score") or 0) // 20),
+                "score": score,
                 "type": "file",
-                "id": item.get("path"),
-                "title": item.get("path"),
+                "id": file_path,
+                "title": file_path,
                 "snippet": ", ".join(reasons),
-                "query_linked": any(str(reason).startswith("term-match:") for reason in reasons),
+                "query_linked": lexical_hits > 0,
+                "signal_details": {
+                    "lexical_hits": lexical_hits,
+                    "churn": churn,
+                    "decision_refs": linked_decisions,
+                    "risk_score": risk_score,
+                },
             }
         )
+
+    for row in conn.execute(
+        "SELECT name, kind, file_path, module FROM symbols WHERE project_id=? ORDER BY id DESC LIMIT 300",
+        (project_id,),
+    ).fetchall():
+        name, kind, file_path, module = row[0], row[1], row[2], row[3] or ""
+        text = f"{name} {kind} {file_path} {module}".lower()
+        score = sum(1 for t in terms if t in text)
+        if score > 0:
+            evidence.append(
+                {
+                    "score": score * 45 + min(churn_by_file.get(file_path, 0) * 5, 40),
+                    "type": "symbol",
+                    "id": name,
+                    "title": name,
+                    "snippet": f"{kind} in {file_path}",
+                    "query_linked": True,
+                    "file_path": file_path,
+                }
+            )
 
     for e in evidence:
         e["rank"] = TYPE_BOOST.get(e["type"], 0) + e["score"]
@@ -176,6 +261,9 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
             citations.append({"type": "file", "id": e["id"], "label": e["title"]})
             lines.append(f"Relevant file: {e['title']}")
             evidence_groups["files"].append(item)
+        elif e["type"] == "symbol":
+            lines.append(f"Relevant symbol: {e['title']}")
+            evidence_groups["symbols"].append(item)
 
     rationale = []
     if evidence_groups["decisions"]:
@@ -185,7 +273,9 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
     if evidence_groups["commits"]:
         rationale.append("Included recent commits to show the latest activity around the topic.")
     if evidence_groups["files"]:
-        rationale.append("Included files from the compact context bundle for direct drill-down.")
+        rationale.append("Included files using lexical match plus decision, churn, and risk signals from the compact context bundle.")
+    if evidence_groups["symbols"]:
+        rationale.append("Included symbol-level evidence because the question referenced named code entities or modules.")
 
     next_drill_down = {"type": "none", "target": None}
     if evidence_groups["decisions"]:
@@ -194,6 +284,8 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
         next_drill_down = {"type": "risk", "target": evidence_groups["risks"][0]["id"]}
     elif evidence_groups["files"]:
         next_drill_down = {"type": "file", "target": evidence_groups["files"][0]["id"]}
+    elif evidence_groups["symbols"]:
+        next_drill_down = {"type": "file", "target": top[[e["type"] for e in top].index("symbol")].get("file_path")}
     elif evidence_groups["commits"]:
         next_drill_down = {"type": "commit", "target": evidence_groups["commits"][0]["id"]}
 

--- a/src/copyclip/intelligence/ask_project.py
+++ b/src/copyclip/intelligence/ask_project.py
@@ -262,6 +262,9 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
             lines.append(f"Relevant file: {e['title']}")
             evidence_groups["files"].append(item)
         elif e["type"] == "symbol":
+            file_path = e.get("file_path")
+            if file_path:
+                citations.append({"type": "file", "id": file_path, "label": file_path})
             lines.append(f"Relevant symbol: {e['title']}")
             evidence_groups["symbols"].append(item)
 

--- a/tests/test_ask_project_ranking.py
+++ b/tests/test_ask_project_ranking.py
@@ -1,0 +1,114 @@
+from copyclip.intelligence.ask_project import build_ask_response
+from copyclip.intelligence.db import connect, init_schema, get_or_create_project
+
+
+def _seed_ranked_project(conn, root: str) -> int:
+    pid = get_or_create_project(conn, root, name="ranked")
+
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type) VALUES(?,?,?,?,?)",
+        (pid, "Auth rollout decision", "Use the new auth session flow in auth module.", "accepted", "manual"),
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id, ref_type, ref_value) VALUES(?,?,?)",
+        (1, "file", "src/auth/session.ts"),
+    )
+
+    conn.execute(
+        "INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/session.ts", "typescript", 1000, 1.0, "h-auth"),
+    )
+    conn.execute(
+        "INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+        (pid, "src/billing/invoice.ts", "typescript", 1000, 1.0, "h-billing"),
+    )
+
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/session.ts", "high", "test_gap", "Auth session flow lacks enough regression coverage.", 92),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/billing/invoice.ts", "medium", "complexity", "Invoice generation has moderate branching.", 60),
+    )
+
+    for _ in range(5):
+        conn.execute(
+            "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-auth", "src/auth/session.ts", 12, 3),
+        )
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-auth", "samuel", "2026-04-14T12:00:00Z", "auth session rollout for login flow"),
+    )
+
+    conn.execute(
+        "INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/session.ts", "auth", "[]", 12, 8.0),
+    )
+    conn.execute(
+        "INSERT INTO symbols(project_id, name, kind, file_path, line_start, line_end, module) VALUES(?,?,?,?,?,?,?)",
+        (pid, "SessionManager", "class", "src/auth/session.ts", 10, 60, "auth"),
+    )
+    conn.execute(
+        "INSERT INTO symbols(project_id, name, kind, file_path, line_start, line_end, module) VALUES(?,?,?,?,?,?,?)",
+        (pid, "loginWithSession", "function", "src/auth/session.ts", 70, 100, "auth"),
+    )
+
+    conn.commit()
+    return pid
+
+
+def test_build_ask_response_prefers_decision_and_risk_aligned_auth_evidence(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_ranked_project(conn, root)
+
+    response = build_ask_response(conn, pid, "what did we decide about auth session rollout?")
+    conn.close()
+
+    assert response["grounded"] is True
+    assert response["answer_kind"] == "grounded_answer"
+    assert response["evidence"]["decisions"]
+    assert response["evidence"]["risks"]
+    assert response["evidence"]["files"]
+    assert response["evidence"]["files"][0]["id"] == "src/auth/session.ts"
+    assert any("question terms" in item.lower() for item in response["evidence_selection_rationale"])
+    assert response["next_drill_down"]["target"] in {1, "src/auth/session.ts"}
+
+
+def test_build_ask_response_returns_symbol_evidence_for_symbol_query(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_ranked_project(conn, root)
+
+    response = build_ask_response(conn, pid, "where is SessionManager defined?")
+    conn.close()
+
+    assert response["grounded"] is True
+    assert response["evidence"]["symbols"]
+    assert response["evidence"]["symbols"][0]["label"] == "SessionManager"
+    assert response["next_drill_down"]["target"] in {"src/auth/session.ts", "SessionManager"}
+
+
+def test_build_ask_response_does_not_prefer_unrelated_hot_file_when_decision_ref_exists(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_ranked_project(conn, root)
+
+    for _ in range(15):
+        conn.execute(
+            "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-billing", "src/billing/invoice.ts", 20, 10),
+        )
+    conn.commit()
+
+    response = build_ask_response(conn, pid, "what changed in auth session flow?")
+    conn.close()
+
+    assert response["grounded"] is True
+    assert response["evidence"]["files"]
+    assert response["evidence"]["files"][0]["id"] == "src/auth/session.ts"

--- a/tests/test_ask_project_ranking.py
+++ b/tests/test_ask_project_ranking.py
@@ -90,6 +90,7 @@ def test_build_ask_response_returns_symbol_evidence_for_symbol_query(tmp_path):
     assert response["grounded"] is True
     assert response["evidence"]["symbols"]
     assert response["evidence"]["symbols"][0]["label"] == "SessionManager"
+    assert any(c["type"] == "file" and c["id"] == "src/auth/session.ts" for c in response["citations"])
     assert response["next_drill_down"]["target"] in {"src/auth/session.ts", "SessionManager"}
 
 


### PR DESCRIPTION
## Summary
Implements the first backend slice of Ask Project ranking improvements for #35.

This PR upgrades retrieval/ranking in `ask_project.py` so evidence selection reflects project context more strongly and more deterministically.

## What changed
- improved file ranking using combined signals:
  - lexical file/path match
  - decision refs
  - churn
  - risk score
  - compact bundle score
- added symbol-aware retrieval from indexed `symbols`
- improved `evidence_selection_rationale` for ranking-driven answers
- improved `next_drill_down` targeting for symbol matches
- added ranking-focused regression coverage in:
  - `tests/test_ask_project_ranking.py`

## Verification
- `python3 -m pytest tests/test_ask_project_ranking.py tests/test_intelligence_server_api.py -q` -> `22 passed`
- `python3 -m pytest -q` -> `110 passed, 1 skipped`
- `cd frontend && npm run build` -> passes

## Scope note
This PR is intentionally limited to #35 backend retrieval/ranking improvements.
It does not yet include:
- richer provenance formatting beyond the current contract (#36)
- Ask UI rewrite (#37)
- contradiction handling (#38)
- broader evaluation fixtures beyond this ranking slice (#39)

## Issue
- Closes #35
