### PR TITLE
feat: enrich ask answers with traceable provenance

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -95,9 +95,17 @@ export type AskCitation = {
 }
 
 export type AskEvidenceItem = {
+  evidence_id: string
   id: string | number
   label: string
   snippet?: string
+  score: number
+  why_selected: string[]
+  ref: {
+    type: 'file' | 'commit' | 'decision' | 'risk' | 'symbol'
+    target: string | number
+  }
+  related_file?: string
 }
 
 export type AskEvidenceGroup = {
@@ -116,6 +124,7 @@ export type AskResponse = {
   citations: AskCitation[]
   grounded: boolean
   evidence: AskEvidenceGroup
+  answer_evidence_ids: string[]
   evidence_selection_rationale: string[]
   gaps_or_unknowns: string[]
   next_questions: string[]

--- a/src/copyclip/intelligence/ask_project.py
+++ b/src/copyclip/intelligence/ask_project.py
@@ -47,6 +47,7 @@ def _insufficient_evidence_response(bundle_manifest: list[dict[str, Any]], quest
         "citations": [],
         "grounded": False,
         "evidence": _empty_evidence_groups(),
+        "answer_evidence_ids": [],
         "evidence_selection_rationale": ["No indexed artifacts matched the current question strongly enough."],
         "gaps_or_unknowns": [
             "The current index does not contain enough query-linked evidence for a grounded answer.",
@@ -58,6 +59,30 @@ def _insufficient_evidence_response(bundle_manifest: list[dict[str, Any]], quest
         "next_drill_down": {"type": "none", "target": None},
         "bundle_manifest": bundle_manifest,
     }
+
+
+def _build_evidence_item(
+    evidence_type: str,
+    item_id: Any,
+    label: str,
+    snippet: str,
+    score: int | float,
+    why_selected: list[str],
+    ref_target: Any,
+    related_file: str | None = None,
+) -> dict[str, Any]:
+    item = {
+        "evidence_id": f"{evidence_type}:{item_id}",
+        "id": item_id,
+        "label": label,
+        "snippet": snippet,
+        "score": score,
+        "why_selected": why_selected,
+        "ref": {"type": evidence_type, "target": ref_target},
+    }
+    if related_file:
+        item["related_file"] = related_file
+    return item
 
 
 def _churn_by_file(conn, project_id: int) -> dict[str, int]:
@@ -242,31 +267,76 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
     citations = []
     lines = []
     evidence_groups = _empty_evidence_groups()
+    answer_evidence_ids: list[str] = []
 
     for e in top:
-        item = {"id": e["id"], "label": e["title"], "snippet": e.get("snippet", "")}
+        score = e.get("rank", e.get("score", 0))
+        item = _build_evidence_item(
+            e["type"],
+            e["id"],
+            e["title"],
+            e.get("snippet", ""),
+            score,
+            [],
+            e["id"],
+            related_file=e.get("file_path"),
+        )
         if e["type"] == "decision":
             citations.append({"type": "decision", "id": e["id"], "label": f"decision #{e['id']}"})
             lines.append(f"Decision #{e['id']}: {e['title']}")
+            item["why_selected"] = [
+                "Matched the question terms directly in the decision title or summary.",
+                "Accepted decisions are ranked ahead of raw activity signals.",
+            ]
+            item["ref"] = {"type": "decision", "target": e["id"]}
             evidence_groups["decisions"].append(item)
         elif e["type"] == "risk":
             citations.append({"type": "risk", "id": e["id"], "label": e["title"]})
             lines.append(f"Risk signal: {e['title']}")
+            item["why_selected"] = [
+                "Matched the question against a known project risk.",
+                "Risk severity and score increased its ranking priority.",
+            ]
+            item["ref"] = {"type": "risk", "target": e["id"]}
             evidence_groups["risks"].append(item)
         elif e["type"] == "commit":
             citations.append({"type": "commit", "id": e["id"], "label": f"commit {str(e['id'])[:7]}"})
             lines.append(f"Recent commit: {e['title']}")
+            item["why_selected"] = [
+                "Matched the question terms inside a recent commit message.",
+                "Recent activity provides temporal provenance for this answer.",
+            ]
+            item["ref"] = {"type": "commit", "target": e["id"]}
             evidence_groups["commits"].append(item)
         elif e["type"] == "file":
             citations.append({"type": "file", "id": e["id"], "label": e["title"]})
             lines.append(f"Relevant file: {e['title']}")
+            signal = e.get("signal_details", {})
+            why = []
+            if signal.get("lexical_hits"):
+                why.append("Lexical file/path match with the question terms.")
+            if signal.get("decision_refs"):
+                why.append("Linked from accepted decision refs, increasing architectural relevance.")
+            if signal.get("churn"):
+                why.append("Recent churn increased the ranking for this file.")
+            if signal.get("risk_score"):
+                why.append("Risk score contributed to the file ranking.")
+            item["why_selected"] = why or ["Selected from the compact context bundle."]
+            item["ref"] = {"type": "file", "target": e["id"]}
             evidence_groups["files"].append(item)
         elif e["type"] == "symbol":
             file_path = e.get("file_path")
             if file_path:
                 citations.append({"type": "file", "id": file_path, "label": file_path})
             lines.append(f"Relevant symbol: {e['title']}")
+            item["why_selected"] = [
+                "The question referenced a named code entity or module.",
+                "Symbol-aware retrieval linked the question to a concrete definition.",
+            ]
+            item["ref"] = {"type": "symbol", "target": e["id"]}
             evidence_groups["symbols"].append(item)
+
+        answer_evidence_ids.append(item["evidence_id"])
 
     rationale = []
     if evidence_groups["decisions"]:
@@ -304,6 +374,7 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
         "citations": citations,
         "grounded": True,
         "evidence": evidence_groups,
+        "answer_evidence_ids": answer_evidence_ids,
         "evidence_selection_rationale": rationale or ["Selected the strongest indexed artifacts for this question."],
         "gaps_or_unknowns": [],
         "next_questions": [

--- a/src/copyclip/intelligence/ask_project.py
+++ b/src/copyclip/intelligence/ask_project.py
@@ -99,15 +99,16 @@ def _churn_by_file(conn, project_id: int) -> dict[str, int]:
 def _risk_by_file(conn, project_id: int) -> dict[str, dict[str, Any]]:
     out: dict[str, dict[str, Any]] = {}
     for row in conn.execute(
-        "SELECT area, kind, rationale, score FROM risks WHERE project_id=? ORDER BY score DESC, id DESC",
+        "SELECT id, area, kind, rationale, score FROM risks WHERE project_id=? ORDER BY score DESC, id DESC",
         (project_id,),
     ).fetchall():
-        area = row[0]
+        area = row[1]
         if area and area not in out:
             out[area] = {
-                "kind": row[1],
-                "rationale": row[2] or "",
-                "score": int(row[3] or 0),
+                "id": int(row[0]),
+                "kind": row[2],
+                "rationale": row[3] or "",
+                "score": int(row[4] or 0),
             }
     return out
 
@@ -157,20 +158,21 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
             )
 
     for r in conn.execute(
-        "SELECT area,kind,rationale,score FROM risks WHERE project_id=? ORDER BY score DESC LIMIT 300",
+        "SELECT id, area, kind, rationale, score FROM risks WHERE project_id=? ORDER BY score DESC LIMIT 300",
         (project_id,),
     ).fetchall():
-        text = f"{r[0]} {r[1]} {r[2] or ''}".lower()
+        text = f"{r[1]} {r[2]} {r[3] or ''}".lower()
         score = sum(1 for t in terms if t in text)
         if score > 0:
             evidence.append(
                 {
                     "score": score + 1,
                     "type": "risk",
-                    "id": r[0],
-                    "title": f"{r[0]} ({r[1]})",
-                    "snippet": (r[2] or "")[:240],
+                    "id": int(r[0]),
+                    "title": f"{r[1]} ({r[2]})",
+                    "snippet": (r[3] or "")[:240],
                     "query_linked": True,
+                    "area": r[1],
                 }
             )
 
@@ -224,10 +226,10 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
         )
 
     for row in conn.execute(
-        "SELECT name, kind, file_path, module FROM symbols WHERE project_id=? ORDER BY id DESC LIMIT 300",
+        "SELECT id, name, kind, file_path, module FROM symbols WHERE project_id=? ORDER BY id DESC LIMIT 300",
         (project_id,),
     ).fetchall():
-        name, kind, file_path, module = row[0], row[1], row[2], row[3] or ""
+        symbol_id, name, kind, file_path, module = int(row[0]), row[1], row[2], row[3], row[4] or ""
         text = f"{name} {kind} {file_path} {module}".lower()
         score = sum(1 for t in terms if t in text)
         if score > 0:
@@ -235,11 +237,12 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
                 {
                     "score": score * 45 + min(churn_by_file.get(file_path, 0) * 5, 40),
                     "type": "symbol",
-                    "id": name,
+                    "id": symbol_id,
                     "title": name,
                     "snippet": f"{kind} in {file_path}",
                     "query_linked": True,
                     "file_path": file_path,
+                    "symbol_name": name,
                 }
             )
 
@@ -298,6 +301,7 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
                 "Risk severity and score increased its ranking priority.",
             ]
             item["ref"] = {"type": "risk", "target": e["id"]}
+            item["related_file"] = e.get("area")
             evidence_groups["risks"].append(item)
         elif e["type"] == "commit":
             citations.append({"type": "commit", "id": e["id"], "label": f"commit {str(e['id'])[:7]}"})
@@ -334,6 +338,7 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
                 "Symbol-aware retrieval linked the question to a concrete definition.",
             ]
             item["ref"] = {"type": "symbol", "target": e["id"]}
+            item["related_file"] = file_path
             evidence_groups["symbols"].append(item)
 
         answer_evidence_ids.append(item["evidence_id"])

--- a/tests/test_ask_project_provenance.py
+++ b/tests/test_ask_project_provenance.py
@@ -1,0 +1,94 @@
+from copyclip.intelligence.ask_project import build_ask_response
+from copyclip.intelligence.db import connect, init_schema, get_or_create_project
+
+
+def _seed_provenance_project(conn, root: str) -> int:
+    pid = get_or_create_project(conn, root, name="prov")
+
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type) VALUES(?,?,?,?,?)",
+        (pid, "Auth session decision", "Use auth session flow for login continuity.", "accepted", "manual"),
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id, ref_type, ref_value) VALUES(?,?,?)",
+        (1, "file", "src/auth/session.ts"),
+    )
+    conn.execute(
+        "INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/session.ts", "typescript", 1000, 1.0, "h-auth"),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/session.ts", "high", "test_gap", "Session flow lacks regression coverage.", 90),
+    )
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-auth", "samuel", "2026-04-15T10:00:00Z", "auth session rollout"),
+    )
+    conn.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+        (pid, "sha-auth", "src/auth/session.ts", 20, 4),
+    )
+    conn.execute(
+        "INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/session.ts", "auth", "[]", 11, 7.0),
+    )
+    conn.execute(
+        "INSERT INTO symbols(project_id, name, kind, file_path, line_start, line_end, module) VALUES(?,?,?,?,?,?,?)",
+        (pid, "SessionManager", "class", "src/auth/session.ts", 10, 55, "auth"),
+    )
+    conn.commit()
+    return pid
+
+
+def test_build_ask_response_exposes_traceable_evidence_objects(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_provenance_project(conn, root)
+
+    response = build_ask_response(conn, pid, "what did we decide about auth session?")
+    conn.close()
+
+    assert response["grounded"] is True
+    assert response["answer_evidence_ids"]
+    decision = response["evidence"]["decisions"][0]
+    assert decision["ref"] == {"type": "decision", "target": 1}
+    assert decision["score"] > 0
+    assert decision["why_selected"]
+    assert decision["evidence_id"] in response["answer_evidence_ids"]
+
+
+def test_build_ask_response_includes_file_and_risk_provenance_details(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_provenance_project(conn, root)
+
+    response = build_ask_response(conn, pid, "what changed in auth session?")
+    conn.close()
+
+    file_item = response["evidence"]["files"][0]
+    risk_item = response["evidence"]["risks"][0]
+    assert file_item["ref"] == {"type": "file", "target": "src/auth/session.ts"}
+    assert "lexical" in " ".join(file_item["why_selected"]).lower() or "decision" in " ".join(file_item["why_selected"]).lower()
+    assert risk_item["ref"] == {"type": "risk", "target": "src/auth/session.ts"}
+    assert risk_item["why_selected"]
+    assert file_item["evidence_id"] in response["answer_evidence_ids"]
+    assert risk_item["evidence_id"] in response["answer_evidence_ids"]
+
+
+def test_build_ask_response_symbol_provenance_points_back_to_file(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_provenance_project(conn, root)
+
+    response = build_ask_response(conn, pid, "where is SessionManager defined?")
+    conn.close()
+
+    symbol_item = response["evidence"]["symbols"][0]
+    assert symbol_item["ref"] == {"type": "symbol", "target": "SessionManager"}
+    assert symbol_item["related_file"] == "src/auth/session.ts"
+    assert symbol_item["why_selected"]
+    assert response["next_drill_down"]["target"] == "src/auth/session.ts"

--- a/tests/test_ask_project_provenance.py
+++ b/tests/test_ask_project_provenance.py
@@ -72,7 +72,8 @@ def test_build_ask_response_includes_file_and_risk_provenance_details(tmp_path):
     risk_item = response["evidence"]["risks"][0]
     assert file_item["ref"] == {"type": "file", "target": "src/auth/session.ts"}
     assert "lexical" in " ".join(file_item["why_selected"]).lower() or "decision" in " ".join(file_item["why_selected"]).lower()
-    assert risk_item["ref"] == {"type": "risk", "target": "src/auth/session.ts"}
+    assert risk_item["ref"] == {"type": "risk", "target": 1}
+    assert risk_item["related_file"] == "src/auth/session.ts"
     assert risk_item["why_selected"]
     assert file_item["evidence_id"] in response["answer_evidence_ids"]
     assert risk_item["evidence_id"] in response["answer_evidence_ids"]
@@ -88,7 +89,36 @@ def test_build_ask_response_symbol_provenance_points_back_to_file(tmp_path):
     conn.close()
 
     symbol_item = response["evidence"]["symbols"][0]
-    assert symbol_item["ref"] == {"type": "symbol", "target": "SessionManager"}
+    assert symbol_item["ref"] == {"type": "symbol", "target": 1}
     assert symbol_item["related_file"] == "src/auth/session.ts"
     assert symbol_item["why_selected"]
     assert response["next_drill_down"]["target"] == "src/auth/session.ts"
+
+
+def test_build_ask_response_uses_stable_ids_for_duplicate_symbols_and_risks(tmp_path):
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_provenance_project(conn, root)
+
+    conn.execute(
+        "INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/secondary.ts", "typescript", 1000, 1.0, "h-auth-2"),
+    )
+    conn.execute(
+        "INSERT INTO symbols(project_id, name, kind, file_path, line_start, line_end, module) VALUES(?,?,?,?,?,?,?)",
+        (pid, "SessionManager", "class", "src/auth/secondary.ts", 5, 20, "auth"),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/session.ts", "medium", "complexity", "Separate auth complexity signal.", 70),
+    )
+    conn.commit()
+
+    response = build_ask_response(conn, pid, "where is SessionManager defined and what is the auth session risk?")
+    conn.close()
+
+    symbol_targets = {item["ref"]["target"] for item in response["evidence"]["symbols"]}
+    risk_targets = {item["ref"]["target"] for item in response["evidence"]["risks"]}
+    assert all(isinstance(target, int) for target in symbol_targets)
+    assert all(isinstance(target, int) for target in risk_targets)


### PR DESCRIPTION
## Summary
Implements the backend provenance/rationale slice for Ask Project (#36).

This PR makes evidence objects more traceable and inspectable so Ask answers can explain not just what sources were selected, but also how each source connects back to project artifacts.

## What changed
- enriched backend Ask evidence objects with:
  - `evidence_id`
  - `score`
  - `why_selected`
  - `ref`
  - `related_file` for symbol evidence
- added `answer_evidence_ids` to trace the answer back to the selected evidence set
- updated frontend Ask types for richer provenance fields
- added dedicated provenance regression tests in:
  - `tests/test_ask_project_provenance.py`

## Verification
- `python3 -m pytest tests/test_ask_project_provenance.py tests/test_ask_project_ranking.py tests/test_intelligence_server_api.py -q` -> `25 passed`
- `python3 -m pytest -q` -> `113 passed, 1 skipped`
- `cd frontend && npm run build` -> passes

## Scope note
This PR is intentionally limited to backend provenance/rationale enrichment for #36.
It does not yet include:
- Ask UI rendering changes for these richer evidence objects (#37)
- contradiction handling (#38)
- broader evaluation fixtures beyond this provenance slice (#39)

## Issue
- Closes #36
