### PR TITLE
feat: build evidence-first ask investigation ui

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,7 +100,7 @@ export function App() {
 
         <div style={{ padding: '24px', flex: 1 }}>
           {page === 'reacquaintance' && <ReacquaintancePage onOpenDecision={openDecision} onOpenRisk={openRisk} onOpenChanges={openChanges} />}
-          {page === 'ask' && <AskPage onNotify={notify} />}
+          {page === 'ask' && <AskPage onNotify={notify} onOpenDecision={openDecision} onOpenRisk={openRisk} onOpenChanges={openChanges} />}
           {page === 'atlas-3d' && <Atlas3DPage />}
           {page === 'timeline' && <TimelinePage />}
           {page === 'planning' && <PlanningPage />}

--- a/frontend/src/pages/AskPage.tsx
+++ b/frontend/src/pages/AskPage.tsx
@@ -1,29 +1,34 @@
-import { useState, useRef, useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { api } from '../api/client'
-import type { AdvisorConflict } from '../types/api'
+import type { AskEvidenceItem, AskResponse } from '../types/api'
 
-import { ArchitecturePage } from './ArchitecturePage'
-import { RisksPage } from './RisksPage'
-import { AtlasPage } from './AtlasPage'
-
-type ChatMessage = {
+type AskMessage = {
   id: string
   role: 'user' | 'assistant'
   text: string
+  response?: AskResponse
   loading?: boolean
   error?: string
-  toolUsed?: 'architecture' | 'risks' | 'atlas' | 'decisions'
-  toolData?: any
-  citations?: any[]
-  conflicts?: AdvisorConflict[]
 }
 
-export function AskPage({ onNotify }: { onNotify?: (msg: string) => void }) {
-  const [messages, setMessages] = useState<ChatMessage[]>([{
-    id: 'welcome',
-    role: 'assistant',
-    text: "I am the project's consciousness. Ask about architecture, intent, drift, risks, or the hidden shape of the system.",
-  }])
+export function AskPage({
+  onNotify,
+  onOpenDecision,
+  onOpenRisk,
+  onOpenChanges,
+}: {
+  onNotify?: (msg: string) => void
+  onOpenDecision?: (id: number) => void
+  onOpenRisk?: (area: string) => void
+  onOpenChanges?: (opts?: { commitId?: string | null; filePath?: string | null }) => void
+}) {
+  const [messages, setMessages] = useState<AskMessage[]>([
+    {
+      id: 'welcome',
+      role: 'assistant',
+      text: 'Ask Project now answers with evidence, confidence, and drill-down paths instead of generic chat.',
+    },
+  ])
   const [input, setInput] = useState('')
   const [isTyping, setIsTyping] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
@@ -32,59 +37,47 @@ export function AskPage({ onNotify }: { onNotify?: (msg: string) => void }) {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
-  const handleSend = async () => {
-    if (!input.trim() || isTyping) return
-    const userText = input.trim()
+  const handleSend = async (prefill?: string) => {
+    const userText = (prefill ?? input).trim()
+    if (!userText || isTyping) return
     setInput('')
-    
-    console.group(`%c[Consciousness] User: "${userText}"`, 'color: #3b82f6; font-weight: bold;')
-    
+
     const userMsgId = Date.now().toString()
-    setMessages(prev => [...prev, { id: userMsgId, role: 'user', text: userText }])
-    
-    const loadingMsgId = (Date.now() + 1).toString()
-    setMessages(prev => [...prev, { id: loadingMsgId, role: 'assistant', text: 'Consulting the consciousness…', loading: true }])
+    setMessages((prev) => [...prev, { id: userMsgId, role: 'user', text: userText }])
+
+    const loadingMsgId = `${Date.now()}-loading`
+    setMessages((prev) => [...prev, { id: loadingMsgId, role: 'assistant', text: 'Investigating project evidence…', loading: true }])
     setIsTyping(true)
 
     try {
-      const chatRes = await api.agentChat('scout', userText)
-      console.log('%cAgent Raw Response:', 'color: #9ca3af;', chatRes.response)
-      
-      let answer = chatRes.response
-      let toolUsed: any = undefined
-      let toolData: any = undefined
-
-      try {
-        const parsed = JSON.parse(chatRes.response)
-        if (parsed.tool_used) {
-          answer = parsed.answer
-          toolUsed = parsed.tool_used
-          toolData = parsed.tool_data
-          console.log(`%c[GenUI] Injected Artifact: ${toolUsed}`, 'color: #f59e0b; font-weight: bold;', toolData)
-        }
-      } catch {
-        console.log('%c[GenUI] No artifact detected, rendering plain text.', 'color: #6b7280;')
-      }
-
-      setMessages(prev => prev.map(m => m.id === loadingMsgId ? {
-        ...m,
-        text: answer,
-        loading: false,
-        toolUsed: toolUsed,
-        toolData: toolData
-      } : m))
-
+      const response = await api.ask(userText)
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === loadingMsgId
+            ? {
+                ...m,
+                text: response.answer_summary || response.answer,
+                response,
+                loading: false,
+              }
+            : m,
+        ),
+      )
     } catch (e) {
-      console.error('%c[Consciousness Error]', 'color: #ef4444; font-weight: bold;', e)
-      setMessages(prev => prev.map(m => m.id === loadingMsgId ? {
-        ...m,
-        text: '',
-        loading: false,
-        error: e instanceof Error ? e.message : 'Failed to get answer'
-      } : m))
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === loadingMsgId
+            ? {
+                ...m,
+                text: '',
+                loading: false,
+                error: e instanceof Error ? e.message : 'Failed to get answer',
+              }
+            : m,
+        ),
+      )
     } finally {
       setIsTyping(false)
-      console.groupEnd()
     }
   }
 
@@ -95,71 +88,106 @@ export function AskPage({ onNotify }: { onNotify?: (msg: string) => void }) {
     }
   }
 
+  const openEvidence = (item: AskEvidenceItem) => {
+    const ref = item.ref
+    if (ref.type === 'decision' && typeof ref.target === 'number') {
+      onOpenDecision?.(ref.target)
+      return
+    }
+    if (ref.type === 'risk') {
+      const target = item.related_file || String(ref.target)
+      onOpenRisk?.(target)
+      return
+    }
+    if (ref.type === 'commit') {
+      onOpenChanges?.({ commitId: String(ref.target) })
+      return
+    }
+    if (ref.type === 'file') {
+      onOpenChanges?.({ filePath: String(ref.target) })
+      return
+    }
+    if (ref.type === 'symbol' && item.related_file) {
+      onOpenChanges?.({ filePath: item.related_file })
+      return
+    }
+    onNotify?.('No drill-down available for this evidence yet.')
+  }
+
   return (
     <div className="chat-container" style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 120px)', background: 'var(--bg)', borderRadius: 8, overflow: 'hidden' }}>
       <div style={{ padding: '0 24px 12px 24px' }}>
-        <div className="muted" style={{ fontSize: 10, letterSpacing: 2 }}>// consciousness_interface</div>
-        <h1 style={{ margin: '8px 0 6px 0' }}>Ask the Consciousness</h1>
-        <div className="muted" style={{ fontSize: 13, maxWidth: 720 }}>
-          Interrogate the living state of the project. Ask about architecture, intent, drift, risk, and the hidden relationships shaping the system.
+        <div className="muted" style={{ fontSize: 10, letterSpacing: 2 }}>// ask_project_investigation</div>
+        <h1 style={{ margin: '8px 0 6px 0' }}>Ask Project</h1>
+        <div className="muted" style={{ fontSize: 13, maxWidth: 760 }}>
+          Ask about decisions, risks, commits, files, and symbols. The answer comes first, but the evidence, confidence, unknowns, and next drill-down paths stay visible.
         </div>
       </div>
-      
-      <div className="chat-history" style={{ flex: 1, overflowY: 'auto', padding: '24px', display: 'flex', flexDirection: 'column', gap: '32px' }}>
-        {messages.map(msg => (
-          <div key={msg.id} className={`chat-message role-${msg.role}`} style={{ display: 'flex', gap: '16px', maxWidth: '100%', alignSelf: msg.role === 'user' ? 'flex-end' : 'flex-start' }}>
-            
-            {msg.role === 'assistant' && (
-              <div style={{ width: 32, height: 32, borderRadius: '50%', background: 'var(--accent-cyan)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#000', fontWeight: 'bold', flexShrink: 0 }}>C</div>
-            )}
-            
-            <div style={{ display: 'grid', gap: '16px', width: msg.role === 'user' ? 'auto' : '100%' }}>
-              {msg.text && (
-                <div style={{ 
-                  background: msg.role === 'user' ? 'var(--accent-cyan)' : 'transparent', 
-                  color: msg.role === 'user' ? '#000' : 'var(--text-primary)',
-                  padding: msg.role === 'user' ? '12px 16px' : '0',
-                  borderRadius: msg.role === 'user' ? '16px 16px 0 16px' : '0',
-                  lineHeight: '1.6',
-                  fontSize: '15px',
-                  whiteSpace: 'pre-wrap'
-                }}>
+
+      <div className="chat-history" style={{ flex: 1, overflowY: 'auto', padding: '24px', display: 'flex', flexDirection: 'column', gap: '24px' }}>
+        {messages.map((msg) => (
+          <div key={msg.id} style={{ display: 'grid', gap: '12px', alignSelf: msg.role === 'user' ? 'flex-end' : 'stretch' }}>
+            {msg.role === 'user' ? (
+              <div style={{ background: 'var(--accent-cyan)', color: '#000', padding: '12px 16px', borderRadius: '16px 16px 0 16px', maxWidth: 720 }}>
+                {msg.text}
+              </div>
+            ) : (
+              <div className="section-panel" style={{ display: 'grid', gap: 12 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                  <span className="muted" style={{ fontSize: 11 }}>// investigation_result</span>
+                  {msg.response && <span className={`badge badge-${msg.response.confidence === 'high' ? 'high' : msg.response.confidence === 'medium' ? 'med' : 'low'}`}>{msg.response.confidence}</span>}
+                  {msg.response && <span className="badge">{msg.response.answer_kind.replace('_', ' ')}</span>}
+                </div>
+
+                <div style={{ fontSize: 16, lineHeight: 1.6, whiteSpace: 'pre-wrap' }}>
                   {msg.loading ? <span className="pulsing-cursor">●</span> : msg.text}
                 </div>
-              )}
 
-              {msg.error && <div className="error" style={{ fontSize: 13, padding: 8 }}>{msg.error}</div>}
+                {msg.error && <div className="error" style={{ fontSize: 13, padding: 8 }}>{msg.error}</div>}
 
-              {msg.toolUsed === 'architecture' && msg.toolData && (
-                <div className="artifact-container" style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 16, background: '#111115' }}>
-                  <div className="muted" style={{ marginBottom: 12, fontSize: 11 }}>// artifact: architecture_constellation</div>
-                  <ArchitecturePage nodes={msg.toolData.nodes} edges={msg.toolData.edges} />
-                </div>
-              )}
+                {msg.response && (
+                  <>
+                    <div style={{ display: 'grid', gap: 12 }}>
+                      <Section title="// evidence_selection_rationale">
+                        <ul style={{ margin: 0, paddingLeft: 18 }}>
+                          {msg.response.evidence_selection_rationale.map((item, idx) => (
+                            <li key={idx} className="muted">{item}</li>
+                          ))}
+                        </ul>
+                      </Section>
 
-              {msg.toolUsed === 'risks' && msg.toolData && (
-                <div className="artifact-container" style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 16, background: '#111115' }}>
-                   <div className="muted" style={{ marginBottom: 12, fontSize: 11 }}>// artifact: distortion_field</div>
-                   <RisksPage items={msg.toolData} focusRiskArea={null} />
-                </div>
-              )}
+                      <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))' }}>
+                        <EvidenceGroup title="decisions" items={msg.response.evidence.decisions} onOpen={openEvidence} />
+                        <EvidenceGroup title="risks" items={msg.response.evidence.risks} onOpen={openEvidence} />
+                        <EvidenceGroup title="files" items={msg.response.evidence.files} onOpen={openEvidence} />
+                        <EvidenceGroup title="commits" items={msg.response.evidence.commits} onOpen={openEvidence} />
+                        <EvidenceGroup title="symbols" items={msg.response.evidence.symbols} onOpen={openEvidence} />
+                      </div>
 
-              {msg.toolUsed === 'atlas' && msg.toolData && (
-                <div className="artifact-container" style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 16, background: '#111115' }}>
-                   <div className="muted" style={{ marginBottom: 12, fontSize: 11 }}>// artifact: atlas_projection</div>
-                   <AtlasPage overview={msg.toolData.overview} changes={msg.toolData.changes} risks={msg.toolData.risks} decisions={msg.toolData.decisions} />
-                </div>
-              )}
+                      <Section title="// gaps_or_unknowns">
+                        {msg.response.gaps_or_unknowns.length ? (
+                          <ul style={{ margin: 0, paddingLeft: 18 }}>
+                            {msg.response.gaps_or_unknowns.map((item, idx) => (
+                              <li key={idx} className="muted">{item}</li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <div className="muted">No major evidence gaps surfaced for this answer.</div>
+                        )}
+                      </Section>
 
-              {msg.conflicts && msg.conflicts.length > 0 && (
-                <div style={{ background: 'rgba(239,68,68,0.1)', border: '1px solid var(--accent-red)', borderRadius: 6, padding: 12, fontSize: 13 }}>
-                  <strong style={{ color: 'var(--accent-red)' }}>Oracle warning: anchored intent may be under tension</strong>
-                  <ul style={{ margin: '8px 0 0 0', paddingLeft: 20 }}>
-                    {msg.conflicts.map(c => <li key={c.decision_id} className="muted">{c.why_conflict}</li>)}
-                  </ul>
-                </div>
-              )}
-            </div>
+                      <Section title="// follow_up_questions">
+                        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                          {msg.response.next_questions.map((q, idx) => (
+                            <button key={idx} className="btn" onClick={() => handleSend(q)}>{q}</button>
+                          ))}
+                        </div>
+                      </Section>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
           </div>
         ))}
         <div ref={bottomRef} />
@@ -171,25 +199,25 @@ export function AskPage({ onNotify }: { onNotify?: (msg: string) => void }) {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Ask about architecture, drift, intent, or the hidden shape of the system…"
+            placeholder="Ask about a decision, file, risk, commit, or symbol…"
             rows={1}
             disabled={isTyping}
-            style={{ 
-              width: '100%', 
-              background: 'transparent', 
-              color: 'var(--text-primary)', 
-              border: '1px solid var(--border)', 
-              borderRadius: 24, 
-              padding: '16px 24px', 
+            style={{
+              width: '100%',
+              background: 'transparent',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+              borderRadius: 24,
+              padding: '16px 24px',
               paddingRight: '60px',
               fontSize: '15px',
               resize: 'none',
               overflow: 'hidden',
-              lineHeight: '1.5'
+              lineHeight: '1.5',
             }}
           />
-          <button 
-            onClick={handleSend} 
+          <button
+            onClick={() => handleSend()}
             disabled={!input.trim() || isTyping}
             style={{ position: 'absolute', right: 8, background: 'var(--accent-cyan)', color: '#000', border: 'none', borderRadius: '50%', width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', opacity: input.trim() ? 1 : 0.5 }}
           >
@@ -198,5 +226,43 @@ export function AskPage({ onNotify }: { onNotify?: (msg: string) => void }) {
         </div>
       </div>
     </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="insight-card" style={{ margin: 0 }}>
+      <div className="insight-title">{title}</div>
+      <div style={{ marginTop: 8 }}>{children}</div>
+    </div>
+  )
+}
+
+function EvidenceGroup({ title, items, onOpen }: { title: string; items: AskEvidenceItem[]; onOpen: (item: AskEvidenceItem) => void }) {
+  return (
+    <Section title={`// ${title}`}>
+      {items.length ? (
+        <div style={{ display: 'grid', gap: 8 }}>
+          {items.map((item) => (
+            <div key={item.evidence_id} className="panel" style={{ padding: 10, display: 'grid', gap: 6 }}>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <strong>{item.label}</strong>
+                <span className="badge">score {Math.round(item.score)}</span>
+                <button className="btn" style={{ marginLeft: 'auto' }} onClick={() => onOpen(item)}>open</button>
+              </div>
+              {item.snippet && <div className="muted" style={{ fontSize: 12 }}>{item.snippet}</div>}
+              {item.related_file && <div className="muted" style={{ fontSize: 11 }}>related file: {item.related_file}</div>}
+              <ul style={{ margin: 0, paddingLeft: 18 }}>
+                {item.why_selected.map((why, idx) => (
+                  <li key={idx} className="muted">{why}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="muted">No {title} evidence selected.</div>
+      )}
+    </Section>
   )
 }


### PR DESCRIPTION
## Summary
Implements the frontend investigation UI slice for Ask Project (#37).

This PR replaces the old generic chat-style Ask surface with an evidence-first investigation UI wired to the structured `/api/ask` response.

## What changed
- Ask UI now uses `api.ask(...)` instead of `agentChat('scout', ...)`
- redesigned `AskPage` around the structured evidence-first response
- visible answer metadata:
  - confidence badge
  - answer kind
  - evidence selection rationale
  - grouped evidence panels
  - gaps / unknowns
  - suggested follow-up questions
- drill-down actions from evidence into existing dashboard surfaces:
  - Decisions
  - Risks
  - Changes archaeology / focused commit
- wired `AskPage` into App-level navigation handlers

## Verification
- `cd frontend && npm run build` -> passes

## Scope note
This PR is intentionally limited to #37 frontend investigation UI changes.
It does not yet include contradiction handling (#38) or the broader evaluation fixture work (#39).

## Issue
- Closes #37
