### PR TITLE
feat: add contradiction handling for ask responses

### DIFF
--- a/src/copyclip/intelligence/ask_project.py
+++ b/src/copyclip/intelligence/ask_project.py
@@ -61,6 +61,38 @@ def _insufficient_evidence_response(bundle_manifest: list[dict[str, Any]], quest
     }
 
 
+def _contradiction_response(
+    bundle_manifest: list[dict[str, Any]],
+    citations: list[dict[str, Any]],
+    evidence_groups: dict[str, list[dict[str, Any]]],
+    answer_evidence_ids: list[str],
+    next_drill_down: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "answer": "Indexed project evidence is pulling in conflicting directions, so I can’t give a confident grounded answer yet.",
+        "answer_summary": "The strongest project signals contradict each other.",
+        "answer_kind": "contradiction_detected",
+        "confidence": "low",
+        "citations": citations,
+        "grounded": False,
+        "evidence": evidence_groups,
+        "answer_evidence_ids": answer_evidence_ids,
+        "evidence_selection_rationale": [
+            "A decision suggests one direction while current risk signals suggest the area is drifting or under tension.",
+        ],
+        "gaps_or_unknowns": [
+            "The decision record and current risk/change signals appear to conflict.",
+            "Inspect the linked file and decision history before trusting a single interpretation.",
+        ],
+        "next_questions": [
+            "Which recent commit introduced the conflicting behavior?",
+            "Does the accepted decision still match the current implementation?",
+        ],
+        "next_drill_down": next_drill_down,
+        "bundle_manifest": bundle_manifest,
+    }
+
+
 def _build_evidence_item(
     evidence_type: str,
     item_id: Any,
@@ -368,6 +400,31 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
         next_drill_down = {"type": "commit", "target": evidence_groups["commits"][0]["id"]}
 
     confidence = "high" if len({c["type"] for c in citations}) >= 2 else "medium"
+    contradiction_detected = bool(evidence_groups["decisions"]) and any(
+        (item.get("related_file") or "") in {file_item["id"] for file_item in evidence_groups["files"]}
+        and "drift" in " ".join(item.get("why_selected", [])).lower()
+        for item in evidence_groups["risks"]
+    )
+    if not contradiction_detected:
+        contradiction_detected = bool(evidence_groups["decisions"]) and any(
+            isinstance(item.get("related_file"), str) and item.get("related_file")
+            and any(file_item["id"] == item["related_file"] for file_item in evidence_groups["files"])
+            and any("risk" in why.lower() for why in item.get("why_selected", []))
+            for item in evidence_groups["risks"]
+        ) and any(
+            "drift" in (risk_by_file.get(str(file_item["id"]), {}) or {}).get("kind", "")
+            for file_item in evidence_groups["files"]
+        )
+
+    if contradiction_detected:
+        return _contradiction_response(
+            bundle.get("manifest", []),
+            citations,
+            evidence_groups,
+            answer_evidence_ids,
+            next_drill_down,
+        )
+
     answer = "Based on indexed project evidence, here are the strongest signals:\n- " + "\n- ".join(lines)
     answer_summary = lines[0] if lines else "Grounded answer generated from indexed project evidence."
 

--- a/src/copyclip/intelligence/ask_project.py
+++ b/src/copyclip/intelligence/ask_project.py
@@ -400,21 +400,23 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
         next_drill_down = {"type": "commit", "target": evidence_groups["commits"][0]["id"]}
 
     confidence = "high" if len({c["type"] for c in citations}) >= 2 else "medium"
-    contradiction_detected = bool(evidence_groups["decisions"]) and any(
-        (item.get("related_file") or "") in {file_item["id"] for file_item in evidence_groups["files"]}
-        and "drift" in " ".join(item.get("why_selected", [])).lower()
+    decision_ids = {int(item["id"]) for item in evidence_groups["decisions"]}
+    decision_linked_files = {
+        file_path
+        for file_path, linked_decision_ids in decision_refs_by_file.items()
+        if any(decision_id in decision_ids for decision_id in linked_decision_ids)
+    }
+    file_ids = {str(file_item["id"]) for file_item in evidence_groups["files"]}
+    drift_risk_files = {
+        str(item.get("related_file"))
         for item in evidence_groups["risks"]
+        if isinstance(item.get("related_file"), str)
+        and item.get("related_file")
+        and "drift" in (risk_by_file.get(str(item.get("related_file")), {}) or {}).get("kind", "")
+    }
+    contradiction_detected = bool(decision_ids) and bool(
+        decision_linked_files & file_ids & drift_risk_files
     )
-    if not contradiction_detected:
-        contradiction_detected = bool(evidence_groups["decisions"]) and any(
-            isinstance(item.get("related_file"), str) and item.get("related_file")
-            and any(file_item["id"] == item["related_file"] for file_item in evidence_groups["files"])
-            and any("risk" in why.lower() for why in item.get("why_selected", []))
-            for item in evidence_groups["risks"]
-        ) and any(
-            "drift" in (risk_by_file.get(str(file_item["id"]), {}) or {}).get("kind", "")
-            for file_item in evidence_groups["files"]
-        )
 
     if contradiction_detected:
         return _contradiction_response(

--- a/tests/test_intelligence_server_api.py
+++ b/tests/test_intelligence_server_api.py
@@ -194,7 +194,58 @@ def test_ask_endpoint_returns_structured_insufficient_evidence_response():
         assert res["evidence_selection_rationale"]
         assert res["gaps_or_unknowns"]
         assert res["next_questions"]
+        assert any("specific" in q.lower() or "re-run analyze" in q.lower() for q in res["next_questions"])
         assert res["next_drill_down"] == {"type": "none", "target": None}
+
+
+def test_ask_endpoint_surfaces_contradictory_signals_instead_of_false_certainty():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root_path, "tmp"))
+        pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (root_path,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)",
+            (pid, "Keep auth session flow stable", "Avoid structural churn in auth session handling.", "accepted", "manual"),
+        )
+        conn.execute(
+            "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+            (1, "file", "src/auth/session.ts"),
+        )
+        conn.execute(
+            "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+            (pid, "src/auth/session.ts", "typescript", 1000, 1.0, "h-auth"),
+        )
+        conn.execute(
+            "INSERT INTO risks(project_id,area,severity,kind,rationale,score) VALUES(?,?,?,?,?,?)",
+            (pid, "src/auth/session.ts", "high", "intent_drift", "Recent changes appear to conflict with the accepted auth direction.", 95),
+        )
+        conn.execute(
+            "INSERT INTO commits(project_id,sha,author,date,message) VALUES(?,?,?,?,?)",
+            (pid, "sha-auth", "samuel", "2026-04-15T10:00:00Z", "rewrite auth session behavior"),
+        )
+        conn.execute(
+            "INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-auth", "src/auth/session.ts", 40, 12),
+        )
+        conn.commit()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        res = _post_json(f"http://127.0.0.1:{port}/api/ask", {"question": "is auth session flow stable?"})
+        assert res["answer_kind"] == "contradiction_detected"
+        assert res["grounded"] is False
+        assert res["confidence"] == "low"
+        assert res["citations"]
+        assert res["gaps_or_unknowns"]
+        assert any("contradict" in item.lower() or "conflict" in item.lower() for item in res["gaps_or_unknowns"])
+        assert res["next_questions"]
+        assert res["next_drill_down"]["target"] is not None
 
 
 def test_ask_endpoint_does_not_ground_vague_question_from_generic_project_noise():

--- a/tests/test_intelligence_server_api.py
+++ b/tests/test_intelligence_server_api.py
@@ -248,6 +248,49 @@ def test_ask_endpoint_surfaces_contradictory_signals_instead_of_false_certainty(
         assert res["next_drill_down"]["target"] is not None
 
 
+def test_ask_endpoint_requires_decision_and_drift_risk_to_overlap_on_same_file():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root_path, "tmp"))
+        pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (root_path,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)",
+            (pid, "Keep billing flow stable", "Avoid churn in billing session handling.", "accepted", "manual"),
+        )
+        conn.execute(
+            "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+            (1, "file", "src/billing/session.ts"),
+        )
+        conn.execute(
+            "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+            (pid, "src/auth/session.ts", "typescript", 1000, 1.0, "h-auth"),
+        )
+        conn.execute(
+            "INSERT INTO risks(project_id,area,severity,kind,rationale,score) VALUES(?,?,?,?,?,?)",
+            (pid, "src/auth/session.ts", "high", "intent_drift", "Recent changes appear to conflict with the current auth direction.", 95),
+        )
+        conn.execute(
+            "INSERT INTO commits(project_id,sha,author,date,message) VALUES(?,?,?,?,?)",
+            (pid, "sha-auth", "samuel", "2026-04-15T10:00:00Z", "rewrite auth session behavior"),
+        )
+        conn.execute(
+            "INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-auth", "src/auth/session.ts", 40, 12),
+        )
+        conn.commit()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        res = _post_json(f"http://127.0.0.1:{port}/api/ask", {"question": "is auth session flow stable?"})
+        assert res["answer_kind"] != "contradiction_detected"
+
+
 def test_ask_endpoint_does_not_ground_vague_question_from_generic_project_noise():
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)


### PR DESCRIPTION
## Summary
Implements the backend contradiction/insufficient-evidence handling slice for Ask Project (#38).

This PR teaches `/api/ask` to explicitly surface contradictory project signals instead of flattening them into false certainty.

## What changed
- added explicit contradiction response state:
  - `answer_kind = contradiction_detected`
  - `grounded = false`
- contradiction responses now preserve evidence so the user can inspect the conflict
- added contradiction-specific:
  - `gaps_or_unknowns`
  - `next_questions`
  - `next_drill_down`
- expanded insufficient-evidence guidance assertions in tests
- added API regression coverage for a conflicting-signal scenario involving:
  - accepted decision
  - `intent_drift` risk
  - recent commit/churn on the same file

## Verification
- `python3 -m pytest tests/test_intelligence_server_api.py -q` -> `20 passed`
- `python3 -m pytest -q` -> `115 passed, 1 skipped`
- `cd frontend && npm run build` -> passes

## Scope note
This PR is intentionally limited to backend contradiction/weak-evidence behavior for #38.
It does not yet include dedicated frontend contradiction rendering changes beyond the current evidence-first UI, or the broader fixture/evaluation work in #39.

## Issue
- Closes #38
