### PR TITLE
test: add ask evaluation fixtures and regressions

### DIFF
--- a/src/copyclip/intelligence/ask_project.py
+++ b/src/copyclip/intelligence/ask_project.py
@@ -205,6 +205,7 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
                     "snippet": (r[3] or "")[:240],
                     "query_linked": True,
                     "area": r[1],
+                    "risk_kind": r[2],
                 }
             )
 
@@ -334,6 +335,7 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
             ]
             item["ref"] = {"type": "risk", "target": e["id"]}
             item["related_file"] = e.get("area")
+            item["risk_kind"] = e.get("risk_kind")
             evidence_groups["risks"].append(item)
         elif e["type"] == "commit":
             citations.append({"type": "commit", "id": e["id"], "label": f"commit {str(e['id'])[:7]}"})
@@ -375,6 +377,53 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
 
         answer_evidence_ids.append(item["evidence_id"])
 
+    if not evidence_groups["files"]:
+        supporting_files = []
+        seen_supporting_files = set()
+        for item in evidence_groups["risks"] + evidence_groups["symbols"]:
+            related_file = item.get("related_file")
+            if isinstance(related_file, str) and related_file and related_file not in seen_supporting_files:
+                supporting_files.append(related_file)
+                seen_supporting_files.add(related_file)
+        for file_path, linked_decision_ids in decision_refs_by_file.items():
+            if any(decision["id"] in linked_decision_ids for decision in evidence_groups["decisions"]):
+                if file_path not in seen_supporting_files:
+                    supporting_files.append(file_path)
+                    seen_supporting_files.add(file_path)
+        for file_path in supporting_files[:2]:
+            signal = {
+                "lexical_hits": sum(1 for t in terms if t in str(file_path).lower()),
+                "churn": churn_by_file.get(str(file_path), 0),
+                "decision_refs": len(decision_refs_by_file.get(str(file_path), [])),
+                "risk_score": int((risk_by_file.get(str(file_path), {}) or {}).get("score", 0)),
+            }
+            why = []
+            if signal["lexical_hits"]:
+                why.append("Lexical file/path match with the question terms.")
+            if signal["decision_refs"]:
+                why.append("Linked from accepted decision refs, increasing architectural relevance.")
+            if signal["churn"]:
+                why.append("Recent churn increased the ranking for this file.")
+            if signal["risk_score"]:
+                why.append("Risk score contributed to the file ranking.")
+            if any(risk.get("related_file") == file_path for risk in evidence_groups["risks"]):
+                why.append("Backfilled because risk evidence pointed to this file.")
+            if any(symbol.get("related_file") == file_path for symbol in evidence_groups["symbols"]):
+                why.append("Backfilled because symbol evidence points to this file.")
+            file_item = _build_evidence_item(
+                "file",
+                file_path,
+                file_path,
+                ", ".join(why) or "Supporting file for the strongest ask evidence.",
+                TYPE_BOOST.get("file", 0) + signal["lexical_hits"] * 30 + min(signal["churn"] * 10, 60) + min(signal["decision_refs"] * 40, 80) + min(signal["risk_score"], 100),
+                why or ["Supporting file for the strongest ask evidence."],
+                file_path,
+            )
+            evidence_groups["files"].append(file_item)
+            answer_evidence_ids.append(file_item["evidence_id"])
+            if not any(citation["type"] == "file" and citation["id"] == file_path for citation in citations):
+                citations.append({"type": "file", "id": file_path, "label": file_path})
+
     rationale = []
     if evidence_groups["decisions"]:
         rationale.append("Selected decisions because they directly matched the question terms.")
@@ -412,7 +461,7 @@ def build_ask_response(conn, project_id: int, question: str) -> dict[str, Any]:
         for item in evidence_groups["risks"]
         if isinstance(item.get("related_file"), str)
         and item.get("related_file")
-        and "drift" in (risk_by_file.get(str(item.get("related_file")), {}) or {}).get("kind", "")
+        and "drift" in str(item.get("risk_kind") or "")
     }
     contradiction_detected = bool(decision_ids) and bool(
         decision_linked_files & file_ids & drift_risk_files

--- a/tests/ask_project_eval_fixture.py
+++ b/tests/ask_project_eval_fixture.py
@@ -1,0 +1,139 @@
+import json
+
+from copyclip.intelligence.db import get_or_create_project
+
+
+REPRESENTATIVE_ASK_EVAL_CASES = [
+    {
+        "scenario": "base",
+        "question": "what did we decide about auth session rollout?",
+        "answer_kind": "grounded_answer",
+        "grounded": True,
+        "confidence": "high",
+        "required_citation_types": ["decision", "file", "risk"],
+        "required_evidence_groups": ["decisions", "files", "risks"],
+        "drill_down_type": "decision",
+    },
+    {
+        "scenario": "base",
+        "question": "where is SessionManager defined?",
+        "answer_kind": "grounded_answer",
+        "grounded": True,
+        "confidence": "medium",
+        "required_citation_types": ["file"],
+        "required_evidence_groups": ["symbols"],
+        "drill_down_type": "file",
+    },
+    {
+        "scenario": "contradiction",
+        "question": "does auth session drift conflict with the rollout decision?",
+        "answer_kind": "contradiction_detected",
+        "grounded": False,
+        "confidence": "low",
+        "required_citation_types": ["decision", "risk", "file"],
+        "required_evidence_groups": ["decisions", "files", "risks"],
+        "drill_down_type": "decision",
+    },
+    {
+        "scenario": "base",
+        "question": "what happened to quantum orchard lattice?",
+        "answer_kind": "insufficient_evidence",
+        "grounded": False,
+        "confidence": "low",
+        "required_citation_types": [],
+        "required_evidence_groups": [],
+        "drill_down_type": "none",
+    },
+]
+
+
+def seed_representative_ask_project(conn, root: str, include_contradiction: bool = False) -> int:
+    pid = get_or_create_project(conn, root, name="ask-eval")
+
+    decision_id = conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type) VALUES(?,?,?,?,?)",
+        (pid, "Auth session rollout decision", "Use auth session flow for login continuity and keep rollout stable.", "accepted", "manual"),
+    ).lastrowid
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id, ref_type, ref_value) VALUES(?,?,?)",
+        (decision_id, "file", "src/auth/session.ts"),
+    )
+    billing_decision_id = conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type) VALUES(?,?,?,?,?)",
+        (pid, "Billing retry guidance", "Retries should stay isolated from auth session behavior.", "accepted", "manual"),
+    ).lastrowid
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id, ref_type, ref_value) VALUES(?,?,?)",
+        (billing_decision_id, "file", "src/billing/retries.ts"),
+    )
+
+    for path_value, hash_value in [
+        ("src/auth/session.ts", "h-auth"),
+        ("src/billing/retries.ts", "h-billing"),
+        ("src/ui/login.tsx", "h-ui"),
+    ]:
+        conn.execute(
+            "INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+            (pid, path_value, "typescript", 1000, 1.0, hash_value),
+        )
+
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/session.ts", "medium", "test_gap", "Session flow still lacks enough regression coverage.", 78),
+    )
+    if include_contradiction:
+        conn.execute(
+            "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+            (pid, "src/auth/session.ts", "high", "intent_drift", "Recent auth changes appear to conflict with the accepted rollout direction.", 96),
+        )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/billing/retries.ts", "medium", "complexity", "Billing retry branching is moderately complex.", 61),
+    )
+
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-auth-rollout", "samuel", "2026-04-15T10:00:00Z", "auth session rollout for login continuity"),
+    )
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-auth-rewrite", "samuel", "2026-04-16T08:30:00Z", "rewrite auth session behavior"),
+    )
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message) VALUES(?,?,?,?,?)",
+        (pid, "sha-billing", "samuel", "2026-04-14T09:00:00Z", "tighten billing retry conditions"),
+    )
+
+    for _ in range(4):
+        conn.execute(
+            "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+            (pid, "sha-auth-rollout", "src/auth/session.ts", 18, 4),
+        )
+    conn.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+        (pid, "sha-auth-rewrite", "src/auth/session.ts", 34, 12),
+    )
+    conn.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(?,?,?,?,?)",
+        (pid, "sha-billing", "src/billing/retries.ts", 12, 5),
+    )
+
+    conn.execute(
+        "INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+        (pid, "src/auth/session.ts", "auth", json.dumps(["src/ui/login.tsx"]), 13, 8.0),
+    )
+    conn.execute(
+        "INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+        (pid, "src/billing/retries.ts", "billing", json.dumps([]), 8, 5.0),
+    )
+
+    conn.execute(
+        "INSERT INTO symbols(project_id, name, kind, file_path, line_start, line_end, module) VALUES(?,?,?,?,?,?,?)",
+        (pid, "SessionManager", "class", "src/auth/session.ts", 10, 58, "auth"),
+    )
+    conn.execute(
+        "INSERT INTO symbols(project_id, name, kind, file_path, line_start, line_end, module) VALUES(?,?,?,?,?,?,?)",
+        (pid, "loginWithSession", "function", "src/auth/session.ts", 60, 105, "auth"),
+    )
+    conn.commit()
+    return pid

--- a/tests/test_ask_project_evaluation.py
+++ b/tests/test_ask_project_evaluation.py
@@ -1,0 +1,52 @@
+import re
+
+from copyclip.intelligence.ask_project import build_ask_response
+from copyclip.intelligence.db import connect, init_schema
+from tests.ask_project_eval_fixture import REPRESENTATIVE_ASK_EVAL_CASES, seed_representative_ask_project
+
+
+def _case_slug(case: dict) -> str:
+    return re.sub(r"[^a-z0-9_-]+", "_", f"{case['scenario']}_{case['question'].lower()}").strip("_")
+
+
+def test_build_ask_response_matches_representative_eval_cases(tmp_path):
+    for case in REPRESENTATIVE_ASK_EVAL_CASES:
+        root = str(tmp_path / _case_slug(case))
+        conn = connect(root)
+        init_schema(conn)
+        project_id = seed_representative_ask_project(
+            conn,
+            root,
+            include_contradiction=case["scenario"] == "contradiction",
+        )
+
+        response = build_ask_response(conn, project_id, case["question"])
+        assert response["answer_kind"] == case["answer_kind"]
+        assert response["grounded"] is case["grounded"]
+        assert response["confidence"] == case["confidence"]
+        assert set(case["required_citation_types"]).issubset({citation["type"] for citation in response["citations"]})
+        assert set(case["required_evidence_groups"]).issubset(
+            {name for name, items in response["evidence"].items() if items}
+        )
+        assert response["next_drill_down"]["type"] == case["drill_down_type"]
+        if case["answer_kind"] == "contradiction_detected":
+            assert any("intent_drift" in item["label"] for item in response["evidence"]["risks"])
+
+        conn.close()
+
+
+def test_build_ask_response_backfills_supporting_file_evidence_when_top_results_are_non_file(tmp_path):
+    root = str(tmp_path / "backfill")
+    conn = connect(root)
+    init_schema(conn)
+    project_id = seed_representative_ask_project(conn, root)
+
+    response = build_ask_response(conn, project_id, "what did we decide about auth session rollout?")
+    assert response["answer_kind"] == "grounded_answer"
+    assert response["evidence"]["files"]
+    assert any(
+        "backfilled" in " ".join(file_item["why_selected"]).lower()
+        for file_item in response["evidence"]["files"]
+    )
+
+    conn.close()


### PR DESCRIPTION
## Summary
- add representative Ask Project evaluation fixtures for grounded, contradiction, symbol, and insufficient-evidence questions
- add regression coverage for file-evidence backfill when top ask results contain only non-file evidence
- tighten contradiction detection so it only fires from returned drift-risk evidence, not hidden file-level risk state

## Test Plan
- python3 -m pytest tests/test_ask_project_evaluation.py -q
- python3 -m pytest tests/test_ask_project_evaluation.py tests/test_ask_project_ranking.py tests/test_ask_project_provenance.py tests/test_intelligence_server_api.py -q
- python3 -m pytest -q
- cd frontend && npm run build

Closes #39
Part of #17
