### PR TITLE
feat: persist handoff packets and review summaries

### DIFF
--- a/src/copyclip/intelligence/db.py
+++ b/src/copyclip/intelligence/db.py
@@ -296,6 +296,29 @@ def init_schema(conn: sqlite3.Connection) -> None:
             created_at TEXT DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(project_id, name)
         );
+
+        CREATE TABLE IF NOT EXISTS handoff_packets (
+            id INTEGER PRIMARY KEY,
+            project_id INTEGER NOT NULL,
+            packet_id TEXT NOT NULL,
+            state TEXT NOT NULL,
+            objective_summary TEXT,
+            packet_json TEXT NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(project_id, packet_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS handoff_review_summaries (
+            id INTEGER PRIMARY KEY,
+            project_id INTEGER NOT NULL,
+            packet_id TEXT NOT NULL,
+            review_state TEXT NOT NULL,
+            review_json TEXT NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(project_id, packet_id)
+        );
         """
     )
     # Lightweight migration for existing DBs created before new columns existed.

--- a/src/copyclip/intelligence/handoff.py
+++ b/src/copyclip/intelligence/handoff.py
@@ -8,6 +8,20 @@ from typing import Any
 from .context_bundle_builder import build_context_bundle
 
 
+PACKET_TRANSITIONS = {
+    "draft": {"ready_for_review", "superseded"},
+    "ready_for_review": {"draft", "approved_for_handoff", "superseded"},
+    "approved_for_handoff": {"delegated", "cancelled", "superseded"},
+    "delegated": {"change_received", "cancelled", "superseded"},
+    "change_received": {"reviewed", "superseded"},
+    "reviewed": {"superseded"},
+    "superseded": set(),
+    "cancelled": set(),
+}
+
+REVIEW_STATES = {"not_started", "generated", "human_reviewed", "accepted", "changes_requested"}
+
+
 STOP_WORDS = {
     "the",
     "and",
@@ -401,3 +415,137 @@ def build_handoff_packet(
     }
     packet["meta"]["packet_id"] = _stable_packet_id(packet)
     return packet
+
+
+def save_handoff_packet(conn, project_id: int, packet: dict[str, Any], commit: bool = True) -> dict[str, Any]:
+    packet_id = str(packet.get("meta", {}).get("packet_id") or "")
+    if not packet_id:
+        raise ValueError("packet_id_required")
+    state = str(packet.get("meta", {}).get("state") or "draft")
+    objective = str(((packet.get("objective") or {}).get("summary")) or "")
+    conn.execute(
+        """
+        INSERT INTO handoff_packets(project_id, packet_id, state, objective_summary, packet_json, created_at, updated_at)
+        VALUES(?,?,?,?,?,?,?)
+        ON CONFLICT(project_id, packet_id) DO UPDATE SET
+            state=excluded.state,
+            objective_summary=excluded.objective_summary,
+            packet_json=excluded.packet_json,
+            updated_at=excluded.updated_at
+        """,
+        (
+            project_id,
+            packet_id,
+            state,
+            objective,
+            json.dumps(packet, sort_keys=True),
+            packet["meta"].get("created_at"),
+            packet["meta"].get("updated_at"),
+        ),
+    )
+    if commit:
+        conn.commit()
+    return packet
+
+
+def list_handoff_packets(conn, project_id: int, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+    total = conn.execute("SELECT COUNT(*) FROM handoff_packets WHERE project_id=?", (project_id,)).fetchone()[0]
+    rows = conn.execute(
+        "SELECT packet_id, state, objective_summary, created_at, updated_at FROM handoff_packets WHERE project_id=? ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?",
+        (project_id, limit, offset),
+    ).fetchall()
+    return {
+        "items": [
+            {
+                "packet_id": row[0],
+                "state": row[1],
+                "objective_summary": row[2],
+                "created_at": row[3],
+                "updated_at": row[4],
+            }
+            for row in rows
+        ],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+def get_handoff_packet(conn, project_id: int, packet_id: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT packet_json FROM handoff_packets WHERE project_id=? AND packet_id=?",
+        (project_id, packet_id),
+    ).fetchone()
+    if not row:
+        return None
+    return json.loads(row[0])
+
+
+def update_handoff_packet(conn, project_id: int, packet_id: str, updates: dict[str, Any]) -> dict[str, Any] | None:
+    packet = get_handoff_packet(conn, project_id, packet_id)
+    if not packet:
+        return None
+    meta = packet.setdefault("meta", {})
+    current_state = str(meta.get("state") or "draft")
+    next_state = updates.get("state")
+    if next_state is not None:
+        next_state = str(next_state)
+        allowed = PACKET_TRANSITIONS.get(current_state, set())
+        if next_state != current_state and next_state not in allowed:
+            raise ValueError(f"invalid_state_transition:{current_state}->{next_state}")
+        meta["state"] = next_state
+    if "approved_by" in updates:
+        meta["approved_by"] = updates.get("approved_by")
+    if "delegation_target" in updates:
+        meta["delegation_target"] = updates.get("delegation_target")
+    if "notes" in updates and isinstance(updates.get("notes"), list):
+        packet["notes"] = updates.get("notes")
+    meta["updated_at"] = updates.get("updated_at") or _now_iso()
+    return save_handoff_packet(conn, project_id, packet, commit=False)
+
+
+def save_handoff_review_summary(
+    conn,
+    project_id: int,
+    packet_id: str,
+    review_summary: dict[str, Any],
+    commit: bool = True,
+) -> dict[str, Any]:
+    meta = review_summary.get("meta") or {}
+    review_state = str(meta.get("review_state") or "generated")
+    if review_state not in REVIEW_STATES:
+        raise ValueError("invalid_review_state")
+    meta_packet_id = meta.get("packet_id")
+    if meta_packet_id and str(meta_packet_id) != packet_id:
+        raise ValueError("review_packet_id_mismatch")
+    conn.execute(
+        """
+        INSERT INTO handoff_review_summaries(project_id, packet_id, review_state, review_json, created_at, updated_at)
+        VALUES(?,?,?,?,?,?)
+        ON CONFLICT(project_id, packet_id) DO UPDATE SET
+            review_state=excluded.review_state,
+            review_json=excluded.review_json,
+            updated_at=excluded.updated_at
+        """,
+        (
+            project_id,
+            packet_id,
+            review_state,
+            json.dumps(review_summary, sort_keys=True),
+            (review_summary.get("meta") or {}).get("generated_at"),
+            (review_summary.get("meta") or {}).get("generated_at"),
+        ),
+    )
+    if commit:
+        conn.commit()
+    return review_summary
+
+
+def get_handoff_review_summary(conn, project_id: int, packet_id: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT review_json FROM handoff_review_summaries WHERE project_id=? AND packet_id=?",
+        (project_id, packet_id),
+    ).fetchone()
+    if not row:
+        return None
+    return json.loads(row[0])

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -16,6 +16,15 @@ from urllib.parse import parse_qs, urlparse
 
 from .context_bundle_builder import build_context_bundle
 from .ask_project import build_ask_response
+from .handoff import (
+    build_handoff_packet,
+    get_handoff_packet,
+    get_handoff_review_summary,
+    list_handoff_packets,
+    save_handoff_packet,
+    save_handoff_review_summary,
+    update_handoff_packet,
+)
 from .db import connect, init_schema
 from .reacquaintance import build_reacquaintance_briefing, record_reacquaintance_visit
 from .phases import (
@@ -942,6 +951,38 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 }))
                 return
 
+            if parsed.path == "/api/handoff-packets":
+                if not pid:
+                    self._json(with_meta({"items": [], "total": 0, "limit": 0, "offset": 0}))
+                    return
+                limit, offset = _pagination(parsed)
+                self._json(with_meta(list_handoff_packets(conn, pid, limit=limit, offset=offset)))
+                return
+
+            if parsed.path.startswith("/api/handoff-packets/") and parsed.path.endswith("/review-summary"):
+                if not pid:
+                    self._json({"error": "run_analyze_first"}, 400)
+                    return
+                packet_id = parsed.path.split("/")[3]
+                review_summary = get_handoff_review_summary(conn, pid, packet_id)
+                if not review_summary:
+                    self._json({"error": "review_summary_not_found"}, 404)
+                    return
+                self._json(with_meta({"review_summary": review_summary}))
+                return
+
+            if parsed.path.startswith("/api/handoff-packets/"):
+                if not pid:
+                    self._json({"error": "run_analyze_first"}, 400)
+                    return
+                packet_id = parsed.path.rsplit("/", 1)[-1]
+                packet = get_handoff_packet(conn, pid, packet_id)
+                if not packet:
+                    self._json({"error": "handoff_packet_not_found"}, 404)
+                    return
+                self._json(with_meta({"packet": packet}))
+                return
+
             if parsed.path == "/api/decisions":
                 if not pid:
                     self._json(with_meta({"items": [], "total": 0, "limit": 0, "offset": 0}))
@@ -1610,6 +1651,25 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 self._json({"ok": True, "id": rule_id})
                 return
 
+            if parsed.path.startswith("/api/handoff-packets/"):
+                packet_id = parsed.path.rsplit("/", 1)[-1]
+                length = int(self.headers.get("Content-Length", "0"))
+                raw = self.rfile.read(length) if length else b"{}"
+                data = json.loads(raw.decode("utf-8"))
+                try:
+                    packet = update_handoff_packet(conn, pid, packet_id, data)
+                    conn.commit()
+                except ValueError as e:
+                    if str(e).startswith("invalid_state_transition:"):
+                        self._json({"error": "invalid_state_transition", "detail": str(e)}, 409)
+                        return
+                    raise
+                if not packet:
+                    self._json({"error": "handoff_packet_not_found"}, 404)
+                    return
+                self._json(with_meta({"packet": packet}))
+                return
+
             if parsed.path.startswith("/api/decisions/"): 
                 try:
                     decision_id = int(parsed.path.rsplit("/", 1)[-1])
@@ -1695,6 +1755,77 @@ def run_server(project_root: str, port: int = 4310) -> None:
             pid = _project_id(conn, root)
             if not pid:
                 self._json({"error": "run_analyze_first"}, 400)
+                return
+
+            if parsed.path == "/api/handoff-packets":
+                length = int(self.headers.get("Content-Length", "0"))
+                raw = self.rfile.read(length) if length else b"{}"
+                data = json.loads(raw.decode("utf-8"))
+                task_prompt = (data.get("task_prompt") or "").strip()
+                if not task_prompt:
+                    self._json({"error": "task_prompt_required"}, 400)
+                    return
+                packet = build_handoff_packet(
+                    conn,
+                    pid,
+                    task_prompt=task_prompt,
+                    declared_files=[str(x) for x in (data.get("declared_files") or [])],
+                    declared_modules=[str(x) for x in (data.get("declared_modules") or [])],
+                    do_not_touch=data.get("do_not_touch") or [],
+                    acceptance_criteria=[str(x) for x in (data.get("acceptance_criteria") or [])],
+                    delegation_target=data.get("delegation_target"),
+                    generated_at=data.get("generated_at"),
+                )
+                save_handoff_packet(conn, pid, packet)
+                self._json(with_meta({"packet": packet}))
+                return
+
+            if parsed.path.startswith("/api/handoff-packets/") and parsed.path.endswith("/review-summary"):
+                packet_id = parsed.path.split("/")[3]
+                packet = get_handoff_packet(conn, pid, packet_id)
+                if not packet:
+                    self._json({"error": "handoff_packet_not_found"}, 404)
+                    return
+                packet_state = str(((packet.get("meta") or {}).get("state")) or "draft")
+                if packet_state not in {"change_received", "reviewed"}:
+                    self._json({"error": "invalid_review_state_for_packet", "packet_state": packet_state}, 409)
+                    return
+                length = int(self.headers.get("Content-Length", "0"))
+                raw = self.rfile.read(length) if length else b"{}"
+                data = json.loads(raw.decode("utf-8"))
+                review_summary = {
+                    "meta": {
+                        "review_id": f"review_{packet_id}",
+                        "packet_id": packet_id,
+                        "review_state": str(data.get("review_state") or "generated"),
+                        "generated_at": str(data.get("generated_at") or datetime.now(timezone.utc).isoformat()),
+                    },
+                    "result": data.get("result") or {},
+                    "scope_check": data.get("scope_check") or {},
+                    "decision_conflicts": data.get("decision_conflicts") or [],
+                    "blast_radius": data.get("blast_radius") or {},
+                    "dark_zone_entry": data.get("dark_zone_entry") or [],
+                    "unresolved_questions": data.get("unresolved_questions") or [],
+                    "review_evidence": data.get("review_evidence") or [],
+                }
+                try:
+                    conn.execute("BEGIN")
+                    save_handoff_review_summary(conn, pid, packet_id, review_summary, commit=False)
+                    updated_packet = update_handoff_packet(conn, pid, packet_id, {"state": "reviewed"})
+                    conn.commit()
+                except ValueError as e:
+                    conn.rollback()
+                    if str(e) == "invalid_review_state":
+                        self._json({"error": "invalid_review_state"}, 400)
+                        return
+                    if str(e).startswith("invalid_state_transition:"):
+                        self._json({"error": "invalid_state_transition", "detail": str(e)}, 409)
+                        return
+                    if str(e) == "review_packet_id_mismatch":
+                        self._json({"error": "review_packet_id_mismatch"}, 400)
+                        return
+                    raise
+                self._json(with_meta({"review_summary": review_summary, "packet": updated_packet}))
                 return
 
             if parsed.path == "/api/analyze/start":

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -1652,10 +1652,18 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 return
 
             if parsed.path.startswith("/api/handoff-packets/"):
+                if not pid:
+                    self._json({"error": "run_analyze_first"}, 400)
+                    return
                 packet_id = parsed.path.rsplit("/", 1)[-1]
                 length = int(self.headers.get("Content-Length", "0"))
                 raw = self.rfile.read(length) if length else b"{}"
                 data = json.loads(raw.decode("utf-8"))
+                if str(data.get("state") or "") == "reviewed":
+                    review_summary = get_handoff_review_summary(conn, pid, packet_id)
+                    if not review_summary:
+                        self._json({"error": "review_summary_required"}, 409)
+                        return
                 try:
                     packet = update_handoff_packet(conn, pid, packet_id, data)
                     conn.commit()

--- a/tests/test_handoff_packet_api.py
+++ b/tests/test_handoff_packet_api.py
@@ -194,3 +194,60 @@ def test_handoff_packet_create_blocks_without_scope_or_with_invalid_state_transi
             body = json.loads(e.read().decode("utf-8"))
             assert e.code == 409
             assert body["error"] == "invalid_review_state_for_packet"
+
+
+def test_handoff_packet_patch_cannot_mark_reviewed_without_review_summary():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        _seed_handoff_api_project(conn, root_path)
+        conn.close()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        created = _post_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets",
+            {
+                "task_prompt": "Build a bounded handoff packet generator for MCP delegation.",
+                "declared_files": ["src/copyclip/mcp_server.py"],
+                "declared_modules": ["copyclip.mcp"],
+            },
+        )
+        packet_id = created["packet"]["meta"]["packet_id"]
+
+        _patch_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}",
+            {"state": "approved_for_handoff"},
+        )
+        _patch_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}",
+            {"state": "delegated"},
+        )
+        _patch_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}",
+            {"state": "change_received"},
+        )
+
+        try:
+            _patch_json(
+                f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}",
+                {"state": "reviewed"},
+            )
+            raise AssertionError("expected reviewed patch without summary to fail")
+        except HTTPError as e:
+            body = json.loads(e.read().decode("utf-8"))
+            assert e.code == 409
+            assert body["error"] == "review_summary_required"
+
+        try:
+            _get_json(f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}/review-summary")
+            raise AssertionError("expected missing review summary to remain missing")
+        except HTTPError as e:
+            body = json.loads(e.read().decode("utf-8"))
+            assert e.code == 404
+            assert body["error"] == "review_summary_not_found"

--- a/tests/test_handoff_packet_api.py
+++ b/tests/test_handoff_packet_api.py
@@ -1,0 +1,196 @@
+import json
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+from urllib import request
+from urllib.error import HTTPError
+
+from copyclip.intelligence.db import connect, init_schema
+from copyclip.intelligence.server import run_server
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_port(port: int, timeout_s: float = 3.0):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError("server did not start in time")
+
+
+def _get_json(url: str):
+    with request.urlopen(url, timeout=3) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def _patch_json(url: str, payload: dict):
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(url, method="PATCH", data=data, headers={"Content-Type": "application/json"})
+    with request.urlopen(req, timeout=3) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def _post_json(url: str, payload: dict):
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(url, method="POST", data=data, headers={"Content-Type": "application/json"})
+    with request.urlopen(req, timeout=3) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def _seed_handoff_api_project(conn, root_path: str) -> int:
+    conn.execute("INSERT INTO projects(root_path,name,story) VALUES(?,?,?)", (root_path, "copyclip", "local-first control plane"))
+    pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (root_path,)).fetchone()[0]
+    conn.execute(
+        "INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)",
+        (pid, "Use bounded MCP handoff packets", "Delegation should use inspectable bounded packets.", "accepted", "manual"),
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+        (1, "file", "src/copyclip/mcp_server.py"),
+    )
+    conn.execute(
+        "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "python", 1200, 1.0, "h-mcp"),
+    )
+    conn.execute(
+        "INSERT INTO analysis_file_insights(project_id,path,module,imports_json,complexity,cognitive_debt) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "copyclip.mcp", "[]", 14, 82.0),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id,area,severity,kind,rationale,score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "high", "intent_drift", "MCP delivery can bypass bounded delegation if widened carelessly.", 93),
+    )
+    conn.commit()
+    return pid
+
+
+def test_handoff_packets_api_create_list_get_patch_and_review_summary():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        _seed_handoff_api_project(conn, root_path)
+        conn.close()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        created = _post_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets",
+            {
+                "task_prompt": "Build a bounded handoff packet generator for MCP delegation.",
+                "declared_files": ["src/copyclip/mcp_server.py"],
+                "declared_modules": ["copyclip.mcp"],
+                "do_not_touch": [{"target": "frontend", "reason": "UI excluded.", "severity": "hard_boundary"}],
+                "acceptance_criteria": ["Packet includes scope and review contract."],
+                "generated_at": "2026-04-16T12:00:00Z",
+            },
+        )
+        packet_id = created["packet"]["meta"]["packet_id"]
+        assert created["packet"]["meta"]["state"] == "ready_for_review"
+
+        listed = _get_json(f"http://127.0.0.1:{port}/api/handoff-packets")
+        assert listed["total"] == 1
+        assert listed["items"][0]["packet_id"] == packet_id
+        assert listed["items"][0]["state"] == "ready_for_review"
+
+        fetched = _get_json(f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}")
+        assert fetched["packet"]["meta"]["packet_id"] == packet_id
+        assert fetched["packet"]["agent_consumable_packet"]["allowed_write_scope"] == ["src/copyclip/mcp_server.py"]
+
+        patched = _patch_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}",
+            {"state": "approved_for_handoff", "approved_by": "samuel", "delegation_target": "claude-code"},
+        )
+        assert patched["packet"]["meta"]["state"] == "approved_for_handoff"
+        assert patched["packet"]["meta"]["approved_by"] == "samuel"
+        assert patched["packet"]["meta"]["delegation_target"] == "claude-code"
+
+        patched = _patch_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}",
+            {"state": "delegated"},
+        )
+        assert patched["packet"]["meta"]["state"] == "delegated"
+
+        patched = _patch_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}",
+            {"state": "change_received"},
+        )
+        assert patched["packet"]["meta"]["state"] == "change_received"
+
+        review = _post_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}/review-summary",
+            {
+                "review_state": "generated",
+                "result": {"summary": "Change stayed in scope.", "verdict": "accepted", "confidence": "medium"},
+                "scope_check": {"declared_scope": ["src/copyclip/mcp_server.py"], "touched_files": ["src/copyclip/mcp_server.py"], "out_of_scope_touches": [], "summary": "All touches stayed in scope."},
+            },
+        )
+        assert review["review_summary"]["meta"]["packet_id"] == packet_id
+        assert review["review_summary"]["meta"]["review_state"] == "generated"
+        assert review["packet"]["meta"]["state"] == "reviewed"
+
+        fetched = _get_json(f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}")
+        assert fetched["packet"]["meta"]["state"] == "reviewed"
+
+        fetched_review = _get_json(f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}/review-summary")
+        assert fetched_review["review_summary"]["result"]["verdict"] == "accepted"
+
+
+def test_handoff_packet_create_blocks_without_scope_or_with_invalid_state_transition():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        _seed_handoff_api_project(conn, root_path)
+        conn.close()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        created = _post_json(
+            f"http://127.0.0.1:{port}/api/handoff-packets",
+            {"task_prompt": "Help with delegation.", "declared_files": [], "declared_modules": []},
+        )
+        packet_id = created["packet"]["meta"]["packet_id"]
+        assert created["packet"]["meta"]["state"] == "draft"
+
+        try:
+            _patch_json(
+                f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}",
+                {"state": "delegated"},
+            )
+            raise AssertionError("expected invalid transition to fail")
+        except HTTPError as e:
+            body = json.loads(e.read().decode("utf-8"))
+            assert e.code == 409
+            assert body["error"] == "invalid_state_transition"
+
+        try:
+            _post_json(
+                f"http://127.0.0.1:{port}/api/handoff-packets/{packet_id}/review-summary",
+                {"review_state": "generated", "result": {"summary": "too early"}},
+            )
+            raise AssertionError("expected premature review creation to fail")
+        except HTTPError as e:
+            body = json.loads(e.read().decode("utf-8"))
+            assert e.code == 409
+            assert body["error"] == "invalid_review_state_for_packet"

--- a/tests/test_intelligence_server_api.py
+++ b/tests/test_intelligence_server_api.py
@@ -667,7 +667,7 @@ def test_alert_scheduler_state_get_and_set():
 
 
 def test_analyze_job_start_and_status_endpoints():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         (root / 'src').mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- extend the local intelligence DB with handoff packet and review summary persistence tables
- add backend persistence helpers for saving, listing, fetching, and updating handoff packets and review summaries
- expose API endpoints for create/list/get/update handoff packets plus review-summary create/get flows

## Included
- DB tables:
  - `handoff_packets`
  - `handoff_review_summaries`
- persistence helpers in `src/copyclip/intelligence/handoff.py`
- API routes in `src/copyclip/intelligence/server.py`:
  - `GET /api/handoff-packets`
  - `POST /api/handoff-packets`
  - `GET /api/handoff-packets/{packet_id}`
  - `PATCH /api/handoff-packets/{packet_id}`
  - `GET /api/handoff-packets/{packet_id}/review-summary`
  - `POST /api/handoff-packets/{packet_id}/review-summary`
- lifecycle-aware review-summary persistence that transitions packet state to `reviewed`
- regression coverage for create/list/get/patch/review flows and invalid lifecycle cases

## Test Plan
- `python3 -m pytest tests/test_handoff_packet_api.py -q`
- `python3 -m pytest tests/test_handoff_packet_generator.py tests/test_handoff_packet_api.py tests/test_ask_project_evaluation.py tests/test_ask_project_ranking.py tests/test_intelligence_server_api.py tests/test_mcp_intent_oracle.py -q`
- `python3 -m pytest -q`
- `cd frontend && npm run build`

Closes #42
Part of #18
