### PR TITLE
feat: expose bounded handoff packets through MCP tools

### DIFF
--- a/docs/HANDOFF_PACKET_CONTRACT.md
+++ b/docs/HANDOFF_PACKET_CONTRACT.md
@@ -599,6 +599,37 @@ Rules:
 
 The full object may contain richer evidence, but the delivered agent packet should only include compact summaries plus stable references.
 
+## MCP delivery
+
+Bounded packets are exposed to external agents through CopyClip's MCP server (`copyclip.mcp_server`). Three tools compose the bounded delegation flow:
+
+### `list_handoff_packets`
+- filters default to `consumable` (`approved_for_handoff` + `delegated`); pass `state: "all"` or an explicit lifecycle state to broaden
+- returns compact rows with `packet_id`, `state`, `updated_at`, and `objective_summary`
+- never returns packet bodies, evidence, or bundle manifests
+
+### `get_handoff_packet`
+- returns the bounded projection produced by `format_handoff_packet_for_mcp`
+- the projection exposes only:
+  - minimal `meta`: `packet_id`, `state`, `packet_version`, `updated_at`, `delegation_target`
+  - `agent_ready` boolean plus `warnings` (e.g. `not_ready_for_consumption`, `unresolved_blocking_questions`)
+  - `objective` and `agent_consumable_packet` verbatim
+  - flat `constraints_summary`, `risk_summary`, `questions_to_clarify`, `acceptance_criteria`
+- the projection intentionally hides `evidence_index`, `bundle_manifest`, `notes`, `approved_by`, full `relevant_decisions`, and `review_contract` so agents cannot bypass declared scope by mining reviewer-only context
+- agents should refuse to proceed when `agent_ready` is `false`
+
+### `submit_handoff_review`
+- takes `packet_id` and `touched_files`; requires the packet to be in `change_received` or `reviewed` state
+- calls `build_handoff_review_summary` to derive scope violations, decision conflicts, blast radius, dark zone entry, and unresolved questions, persists the summary, and transitions the packet to `reviewed`
+- returns the compact review result (verdict, confidence, summary) plus the structured sections humans use for the review surface
+
+### Delivery contract
+
+- delivered content is a projection, never a source of truth
+- lifecycle states outside `approved_for_handoff`/`delegated` are exposed as non-consumable with a `warnings` signal
+- unresolved `blocking` questions mark the packet as non-consumable even if the state looks ready
+- the packet's human-review data stays in the dashboard and `/api/handoff-packets/{id}` — MCP callers are the bounded-consumer surface
+
 ## Persistence expectations for later issues
 
 This issue defines the contract only. Later issues may persist it across:

--- a/src/copyclip/intelligence/handoff.py
+++ b/src/copyclip/intelligence/handoff.py
@@ -801,6 +801,74 @@ def save_handoff_review_summary(
     return review_summary
 
 
+MCP_CONSUMABLE_STATES = {"approved_for_handoff", "delegated"}
+
+
+def format_handoff_packet_for_mcp(packet: dict[str, Any]) -> dict[str, Any]:
+    meta = packet.get("meta") or {}
+    state = str(meta.get("state") or "draft")
+    constraints = packet.get("constraints") or []
+    risks = packet.get("risk_dark_zones") or []
+    questions = packet.get("questions_to_clarify") or []
+    acceptance = packet.get("acceptance_criteria") or []
+    agent_consumable = packet.get("agent_consumable_packet") or {}
+
+    warnings: list[str] = []
+    agent_ready = state in MCP_CONSUMABLE_STATES
+    if not agent_ready:
+        warnings.append("not_ready_for_consumption")
+    if any(q.get("blocking") and q.get("resolution") is None for q in questions):
+        warnings.append("unresolved_blocking_questions")
+
+    return {
+        "meta": {
+            "packet_id": meta.get("packet_id"),
+            "state": state,
+            "packet_version": meta.get("packet_version"),
+            "updated_at": meta.get("updated_at"),
+            "delegation_target": meta.get("delegation_target"),
+        },
+        "agent_ready": agent_ready,
+        "warnings": warnings,
+        "objective": packet.get("objective") or {},
+        "agent_consumable_packet": agent_consumable,
+        "constraints_summary": [str(item.get("summary")) for item in constraints if item.get("summary")],
+        "risk_summary": [
+            f"{item.get('kind')} in {item.get('area')}: {item.get('why_it_matters')}"
+            for item in risks
+            if item.get("area")
+        ],
+        "questions_to_clarify": [
+            {
+                "question": q.get("question"),
+                "priority": q.get("priority") or "medium",
+                "blocking": bool(q.get("blocking")),
+            }
+            for q in questions
+        ],
+        "acceptance_criteria": [item.get("summary") if isinstance(item, dict) else str(item) for item in acceptance],
+    }
+
+
+def list_mcp_handoff_packets(conn, project_id: int, states: set[str] | None = None, limit: int = 20) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT packet_id, state, objective_summary, updated_at FROM handoff_packets WHERE project_id=? ORDER BY updated_at DESC, id DESC LIMIT ?",
+        (project_id, max(1, min(limit, 200))),
+    ).fetchall()
+    items = [
+        {
+            "packet_id": row[0],
+            "state": row[1],
+            "objective_summary": row[2],
+            "updated_at": row[3],
+        }
+        for row in rows
+    ]
+    if states:
+        items = [item for item in items if item["state"] in states]
+    return items
+
+
 def get_handoff_review_summary(conn, project_id: int, packet_id: str) -> dict[str, Any] | None:
     row = conn.execute(
         "SELECT review_json FROM handoff_review_summaries WHERE project_id=? AND packet_id=?",

--- a/src/copyclip/mcp_server.py
+++ b/src/copyclip/mcp_server.py
@@ -8,6 +8,14 @@ from mcp.server.stdio import stdio_server
 import mcp.types as types
 
 from copyclip.intelligence.db import connect, init_schema
+from copyclip.intelligence.handoff import (
+    build_handoff_review_summary,
+    format_handoff_packet_for_mcp,
+    get_handoff_packet,
+    list_mcp_handoff_packets,
+    save_handoff_review_summary,
+    update_handoff_packet,
+)
 from copyclip.reader import read_files_concurrently
 from copyclip.minimizer import minimize_content
 
@@ -79,6 +87,47 @@ async def handle_list_tools() -> List[types.Tool]:
                 "required": ["path"],
             },
         ),
+        types.Tool(
+            name="list_handoff_packets",
+            description="List handoff packets available for agent consumption. By default only returns packets in 'approved_for_handoff' or 'delegated' states.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Path to the project root"},
+                    "state": {
+                        "type": "string",
+                        "description": "Filter: 'consumable' (default; approved_for_handoff + delegated), 'all', or a specific packet state",
+                    },
+                    "limit": {"type": "integer", "description": "Maximum number of packets to return (default 20)"},
+                },
+                "required": ["path"],
+            },
+        ),
+        types.Tool(
+            name="get_handoff_packet",
+            description="Retrieve a bounded handoff packet projection for agent consumption. The result intentionally hides evidence_index, bundle_manifest, and reviewer-only metadata so agents cannot bypass the declared scope.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Path to the project root"},
+                    "packet_id": {"type": "string", "description": "The handoff packet id"},
+                },
+                "required": ["path", "packet_id"],
+            },
+        ),
+        types.Tool(
+            name="submit_handoff_review",
+            description="Submit the list of files an agent touched to generate a post-change review summary (scope violations, decision conflicts, blast radius, dark zone entry). Persists the review and transitions the packet to 'reviewed'.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Path to the project root"},
+                    "packet_id": {"type": "string", "description": "The handoff packet id"},
+                    "touched_files": {"type": "array", "items": {"type": "string"}, "description": "Relative file paths the agent modified"},
+                },
+                "required": ["path", "packet_id", "touched_files"],
+            },
+        ),
     ]
 
 @server.call_tool()
@@ -110,6 +159,23 @@ async def handle_call_tool(
     if name == "get_cognitive_load":
         path = os.path.abspath(arguments.get("path", "."))
         return await _get_cognitive_load(path)
+
+    if name == "list_handoff_packets":
+        path = os.path.abspath(arguments.get("path", "."))
+        state_arg = str(arguments.get("state") or "consumable")
+        limit = int(arguments.get("limit") or 20)
+        return await _list_handoff_packets(path, state_arg, limit)
+
+    if name == "get_handoff_packet":
+        path = os.path.abspath(arguments.get("path", "."))
+        packet_id = str(arguments.get("packet_id") or "")
+        return await _get_handoff_packet_bounded(path, packet_id)
+
+    if name == "submit_handoff_review":
+        path = os.path.abspath(arguments.get("path", "."))
+        packet_id = str(arguments.get("packet_id") or "")
+        touched_files = [str(f) for f in (arguments.get("touched_files") or [])]
+        return await _submit_handoff_review(path, packet_id, touched_files)
 
     raise ValueError(f"Unknown tool: {name}")
 
@@ -302,6 +368,111 @@ async def _get_cognitive_load(root: str) -> List[types.TextContent]:
         return [types.TextContent(type="text", text="\n".join(output))]
     except Exception as e:
         return [types.TextContent(type="text", text=f"Error reading cognitive map: {str(e)}")]
+
+def _project_id_for_root(conn, root: str) -> int | None:
+    row = conn.execute("SELECT id FROM projects WHERE root_path=?", (root,)).fetchone()
+    return int(row[0]) if row else None
+
+
+async def _list_handoff_packets(root: str, state_arg: str, limit: int) -> List[types.TextContent]:
+    try:
+        conn = connect(root)
+        init_schema(conn)
+        pid = _project_id_for_root(conn, root)
+        if pid is None:
+            conn.close()
+            return [types.TextContent(type="text", text="Error: Project not indexed. Run 'copyclip analyze' first.")]
+
+        if state_arg == "consumable":
+            states = {"approved_for_handoff", "delegated"}
+        elif state_arg == "all":
+            states = None
+        else:
+            states = {state_arg}
+
+        items = list_mcp_handoff_packets(conn, pid, states=states, limit=limit)
+        conn.close()
+
+        output = ["# HANDOFF PACKETS"]
+        output.append(f"filter: {state_arg} | count: {len(items)}")
+        if not items:
+            output.append("- no packets match this filter")
+        else:
+            for item in items:
+                output.append(f"- {item['packet_id']}  · state: {item['state']}  · updated: {item['updated_at']}")
+                if item.get("objective_summary"):
+                    output.append(f"    objective: {item['objective_summary']}")
+        return [types.TextContent(type="text", text="\n".join(output))]
+    except Exception as e:
+        return [types.TextContent(type="text", text=f"Error listing handoff packets: {str(e)}")]
+
+
+async def _get_handoff_packet_bounded(root: str, packet_id: str) -> List[types.TextContent]:
+    if not packet_id:
+        return [types.TextContent(type="text", text="Error: packet_id is required.")]
+    try:
+        conn = connect(root)
+        init_schema(conn)
+        pid = _project_id_for_root(conn, root)
+        if pid is None:
+            conn.close()
+            return [types.TextContent(type="text", text="Error: Project not indexed. Run 'copyclip analyze' first.")]
+        packet = get_handoff_packet(conn, pid, packet_id)
+        conn.close()
+        if not packet:
+            return [types.TextContent(type="text", text=f"Error: handoff packet '{packet_id}' not found.")]
+        bounded = format_handoff_packet_for_mcp(packet)
+        return [types.TextContent(type="text", text=json.dumps(bounded, indent=2))]
+    except Exception as e:
+        return [types.TextContent(type="text", text=f"Error retrieving handoff packet: {str(e)}")]
+
+
+async def _submit_handoff_review(root: str, packet_id: str, touched_files: List[str]) -> List[types.TextContent]:
+    if not packet_id:
+        return [types.TextContent(type="text", text="Error: packet_id is required.")]
+    try:
+        conn = connect(root)
+        init_schema(conn)
+        pid = _project_id_for_root(conn, root)
+        if pid is None:
+            conn.close()
+            return [types.TextContent(type="text", text="Error: Project not indexed. Run 'copyclip analyze' first.")]
+        packet = get_handoff_packet(conn, pid, packet_id)
+        if not packet:
+            conn.close()
+            return [types.TextContent(type="text", text=f"Error: handoff packet '{packet_id}' not found.")]
+        packet_state = str((packet.get("meta") or {}).get("state") or "draft")
+        if packet_state not in {"change_received", "reviewed"}:
+            conn.close()
+            return [types.TextContent(type="text", text=f"Error: packet state '{packet_state}' is not eligible for review submission. Expected 'change_received' or 'reviewed'.")]
+
+        review = build_handoff_review_summary(conn, pid, packet, proposed_changes={"touched_files": touched_files})
+        try:
+            conn.execute("BEGIN")
+            save_handoff_review_summary(conn, pid, packet_id, review, commit=False)
+            update_handoff_packet(conn, pid, packet_id, {"state": "reviewed"})
+            conn.commit()
+        except ValueError:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        return [types.TextContent(type="text", text=json.dumps({
+            "packet_id": packet_id,
+            "review_id": review["meta"]["review_id"],
+            "verdict": review["result"]["verdict"],
+            "confidence": review["result"]["confidence"],
+            "summary": review["result"]["summary"],
+            "scope_check": review["scope_check"],
+            "decision_conflicts": review["decision_conflicts"],
+            "blast_radius": review["blast_radius"],
+            "dark_zone_entry": review["dark_zone_entry"],
+            "unresolved_questions": review["unresolved_questions"],
+        }, indent=2))]
+    except Exception as e:
+        return [types.TextContent(type="text", text=f"Error submitting handoff review: {str(e)}")]
+
 
 async def main():
     """Run the MCP server over STDIO."""

--- a/tests/test_handoff_mcp_format.py
+++ b/tests/test_handoff_mcp_format.py
@@ -1,0 +1,115 @@
+from copyclip.intelligence.db import connect, init_schema, get_or_create_project
+from copyclip.intelligence.handoff import (
+    build_handoff_packet,
+    format_handoff_packet_for_mcp,
+)
+
+
+def _seed(conn, root: str) -> int:
+    pid = get_or_create_project(conn, root, name="copyclip")
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type) VALUES(?,?,?,?,?)",
+        (pid, "Use bounded MCP handoff packets", "Delegation should use bounded packets.", "accepted", "manual"),
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id, ref_type, ref_value) VALUES(?,?,?)",
+        (1, "file", "src/copyclip/mcp_server.py"),
+    )
+    conn.execute(
+        "INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "python", 1200, 1.0, "h-mcp"),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "high", "intent_drift", "MCP delivery can bypass bounded delegation.", 93),
+    )
+    conn.execute(
+        "INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "copyclip.mcp", "[]", 14, 82.0),
+    )
+    conn.commit()
+    return pid
+
+
+def test_format_mcp_packet_exposes_only_bounded_agent_fields(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    packet = build_handoff_packet(
+        conn,
+        pid,
+        task_prompt="Build bounded MCP delegation.",
+        declared_files=["src/copyclip/mcp_server.py"],
+        do_not_touch=[{"target": "frontend", "reason": "UI excluded.", "severity": "hard_boundary"}],
+        acceptance_criteria=["Stay bounded."],
+        delegation_target="claude-code",
+        generated_at="2026-04-20T10:00:00Z",
+    )
+    # add private-looking data the MCP view must not expose
+    packet["notes"] = ["internal reviewer note"]
+    packet["meta"]["approved_by"] = "samuel"
+
+    bounded = format_handoff_packet_for_mcp(packet)
+    conn.close()
+
+    assert set(bounded["meta"].keys()) <= {"packet_id", "state", "updated_at", "delegation_target", "packet_version"}
+    assert "approved_by" not in bounded["meta"]
+    assert "evidence_index" not in bounded
+    assert "bundle_manifest" not in bounded
+    assert "notes" not in bounded
+
+    # agent-facing fields exist
+    assert bounded["objective"]["summary"] == "Build bounded MCP delegation."
+    assert bounded["agent_consumable_packet"]["allowed_write_scope"] == ["src/copyclip/mcp_server.py"]
+    assert "frontend" in bounded["agent_consumable_packet"]["do_not_touch"]
+    assert bounded["constraints_summary"]
+    assert any("MCP" in line or "bounded" in line.lower() for line in bounded["constraints_summary"])
+    assert bounded["risk_summary"]
+    assert any("intent_drift" in line for line in bounded["risk_summary"])
+    assert isinstance(bounded["questions_to_clarify"], list)
+    assert isinstance(bounded["acceptance_criteria"], list)
+    assert "Stay bounded." in bounded["acceptance_criteria"]
+
+
+def test_format_mcp_packet_blocks_consumption_when_packet_not_ready(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    packet = build_handoff_packet(
+        conn,
+        pid,
+        task_prompt="Still drafting.",
+        declared_files=[],
+        declared_modules=[],
+    )
+    conn.close()
+    assert packet["meta"]["state"] == "draft"
+
+    bounded = format_handoff_packet_for_mcp(packet)
+    assert bounded["meta"]["state"] == "draft"
+    assert bounded["agent_ready"] is False
+    assert "not_ready_for_consumption" in bounded["warnings"]
+
+
+def test_format_mcp_packet_marks_ready_when_approved_or_delegated(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    packet = build_handoff_packet(
+        conn,
+        pid,
+        task_prompt="Approved.",
+        declared_files=["src/copyclip/mcp_server.py"],
+        acceptance_criteria=["OK."],
+        generated_at="2026-04-20T10:00:00Z",
+    )
+    conn.close()
+
+    packet["meta"]["state"] = "approved_for_handoff"
+    bounded_approved = format_handoff_packet_for_mcp(packet)
+    assert bounded_approved["agent_ready"] is True
+    assert bounded_approved["warnings"] == []
+
+    packet["meta"]["state"] = "delegated"
+    bounded_delegated = format_handoff_packet_for_mcp(packet)
+    assert bounded_delegated["agent_ready"] is True

--- a/tests/test_mcp_handoff.py
+++ b/tests/test_mcp_handoff.py
@@ -1,0 +1,172 @@
+import json
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from copyclip.intelligence.db import init_schema
+from copyclip.mcp_server import handle_call_tool, handle_list_tools
+
+
+def _seed_project(db_file, root: str) -> int:
+    conn = sqlite3.connect(str(db_file))
+    conn.row_factory = sqlite3.Row
+    init_schema(conn)
+    conn.execute("INSERT INTO projects(root_path, name, story) VALUES(?,?,?)", (root, "copyclip", "bounded delegation"))
+    pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (root,)).fetchone()[0]
+    conn.execute(
+        "INSERT INTO decisions(project_id, title, summary, status, source_type) VALUES(?,?,?,?,?)",
+        (pid, "Use bounded MCP handoff packets", "Delegation should use bounded packets.", "accepted", "manual"),
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id, ref_type, ref_value) VALUES(?,?,?)",
+        (1, "file", "src/copyclip/mcp_server.py"),
+    )
+    conn.execute(
+        "INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "python", 1200, 1.0, "h-mcp"),
+    )
+    conn.execute(
+        "INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "high", "intent_drift", "MCP delivery can bypass bounded delegation.", 93),
+    )
+    conn.execute(
+        "INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "copyclip.mcp", "[]", 14, 82.0),
+    )
+    conn.commit()
+    conn.close()
+    return pid
+
+
+@pytest.fixture
+def temp_project(tmp_path):
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / ".copyclip").mkdir()
+    db_file = root / ".copyclip" / "intelligence.db"
+    _seed_project(db_file, str(root))
+    return root
+
+
+@pytest.mark.asyncio
+async def test_list_tools_includes_handoff_tools():
+    tools = await handle_list_tools()
+    names = [t.name for t in tools]
+    assert "list_handoff_packets" in names
+    assert "get_handoff_packet" in names
+    assert "submit_handoff_review" in names
+
+
+@pytest.mark.asyncio
+async def test_list_handoff_packets_returns_only_consumable_states_by_default(temp_project):
+    db_file = temp_project / ".copyclip" / "intelligence.db"
+    with patch("copyclip.intelligence.db.db_path", return_value=str(db_file)):
+        # create a draft packet (blocks consumption) and a ready_for_review packet via create endpoint path
+        from copyclip.intelligence.db import connect as _connect
+        from copyclip.intelligence.handoff import build_handoff_packet, save_handoff_packet, update_handoff_packet
+
+        conn = _connect(str(temp_project))
+        pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (str(temp_project),)).fetchone()[0]
+
+        draft = build_handoff_packet(conn, pid, task_prompt="Help", declared_files=[], declared_modules=[], generated_at="2026-04-20T10:00:00Z")
+        save_handoff_packet(conn, pid, draft)  # state=draft
+
+        ready = build_handoff_packet(conn, pid, task_prompt="Bounded MCP", declared_files=["src/copyclip/mcp_server.py"], acceptance_criteria=["ok"], generated_at="2026-04-20T10:05:00Z")
+        save_handoff_packet(conn, pid, ready)  # state=ready_for_review
+
+        approved = build_handoff_packet(conn, pid, task_prompt="Approved work", declared_files=["src/copyclip/mcp_server.py"], acceptance_criteria=["ok"], generated_at="2026-04-20T10:10:00Z")
+        save_handoff_packet(conn, pid, approved)
+        update_handoff_packet(conn, pid, approved["meta"]["packet_id"], {"state": "approved_for_handoff", "approved_by": "samuel", "delegation_target": "claude-code"})
+        conn.commit()
+        conn.close()
+
+        res = await handle_call_tool("list_handoff_packets", {"path": str(temp_project)})
+        text = res[0].text
+        assert "approved_for_handoff" in text
+        # default filter excludes draft and ready_for_review
+        assert "draft" not in text.lower() or "draft_packets=0" in text.lower() or "- state: draft" not in text
+
+        res_all = await handle_call_tool("list_handoff_packets", {"path": str(temp_project), "state": "all"})
+        text_all = res_all[0].text
+        assert "draft" in text_all.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_handoff_packet_returns_bounded_projection(temp_project):
+    db_file = temp_project / ".copyclip" / "intelligence.db"
+    with patch("copyclip.intelligence.db.db_path", return_value=str(db_file)):
+        from copyclip.intelligence.db import connect as _connect
+        from copyclip.intelligence.handoff import build_handoff_packet, save_handoff_packet, update_handoff_packet
+
+        conn = _connect(str(temp_project))
+        pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (str(temp_project),)).fetchone()[0]
+        packet = build_handoff_packet(
+            conn, pid,
+            task_prompt="Bounded MCP delegation.",
+            declared_files=["src/copyclip/mcp_server.py"],
+            do_not_touch=[{"target": "frontend", "reason": "UI excluded.", "severity": "hard_boundary"}],
+            acceptance_criteria=["Delegation stays bounded."],
+            generated_at="2026-04-20T10:00:00Z",
+        )
+        save_handoff_packet(conn, pid, packet)
+        update_handoff_packet(conn, pid, packet["meta"]["packet_id"], {"state": "approved_for_handoff", "approved_by": "samuel", "delegation_target": "claude-code"})
+        conn.commit()
+        packet_id = packet["meta"]["packet_id"]
+        conn.close()
+
+        res = await handle_call_tool("get_handoff_packet", {"path": str(temp_project), "packet_id": packet_id})
+        text = res[0].text
+        assert packet_id in text
+        assert "allowed_write_scope" in text
+        assert "src/copyclip/mcp_server.py" in text
+        assert "frontend" in text
+        # bounded: must not leak internal fields
+        assert "evidence_index" not in text
+        assert "bundle_manifest" not in text
+        assert "approved_by" not in text
+
+
+@pytest.mark.asyncio
+async def test_submit_handoff_review_generates_and_persists_review(temp_project):
+    db_file = temp_project / ".copyclip" / "intelligence.db"
+    with patch("copyclip.intelligence.db.db_path", return_value=str(db_file)):
+        from copyclip.intelligence.db import connect as _connect
+        from copyclip.intelligence.handoff import (
+            build_handoff_packet,
+            get_handoff_review_summary,
+            save_handoff_packet,
+            update_handoff_packet,
+        )
+
+        conn = _connect(str(temp_project))
+        pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (str(temp_project),)).fetchone()[0]
+        packet = build_handoff_packet(
+            conn, pid,
+            task_prompt="Bounded MCP delegation.",
+            declared_files=["src/copyclip/mcp_server.py"],
+            acceptance_criteria=["OK"],
+            generated_at="2026-04-20T10:00:00Z",
+        )
+        save_handoff_packet(conn, pid, packet)
+        pid_str = packet["meta"]["packet_id"]
+        update_handoff_packet(conn, pid, pid_str, {"state": "approved_for_handoff", "approved_by": "samuel", "delegation_target": "claude-code"})
+        update_handoff_packet(conn, pid, pid_str, {"state": "delegated"})
+        update_handoff_packet(conn, pid, pid_str, {"state": "change_received"})
+        conn.commit()
+        conn.close()
+
+        res = await handle_call_tool(
+            "submit_handoff_review",
+            {"path": str(temp_project), "packet_id": pid_str, "touched_files": ["src/copyclip/mcp_server.py"]},
+        )
+        text = res[0].text
+        assert "verdict" in text.lower()
+        assert "accepted" in text.lower()
+
+        # persisted
+        conn = _connect(str(temp_project))
+        summary = get_handoff_review_summary(conn, pid, pid_str)
+        conn.close()
+        assert summary is not None
+        assert summary["meta"]["packet_id"] == pid_str


### PR DESCRIPTION
## Summary
- adds three MCP tools so external agents can consume bounded handoff packets through CopyClip's tooling layer:
  - `list_handoff_packets` — filters to `consumable` (`approved_for_handoff` + `delegated`) by default; accepts `all` or an explicit lifecycle state
  - `get_handoff_packet` — returns the bounded projection produced by `format_handoff_packet_for_mcp`, intentionally hiding `evidence_index`, `bundle_manifest`, `notes`, `approved_by`, and full `relevant_decisions` so agents cannot mine reviewer-only context
  - `submit_handoff_review` — accepts touched files, generates + persists a review via `build_handoff_review_summary`, transitions the packet to `reviewed`
- `format_handoff_packet_for_mcp` surfaces `agent_ready` + `warnings` (e.g. `not_ready_for_consumption`, `unresolved_blocking_questions`) so agents can refuse non-ready packets
- documents the MCP delivery contract in `docs/HANDOFF_PACKET_CONTRACT.md`

Closes #44.

## Test plan
- [x] `pytest` (144 passed, 1 skipped)
- [x] `tests/test_handoff_mcp_format.py` verifies the bounded projection does not leak `evidence_index`/`bundle_manifest`/`approved_by`, plus `agent_ready` rules for draft/approved/delegated
- [x] `tests/test_mcp_handoff.py` covers tool exposure, default state filter, bounded `get_handoff_packet` output, and `submit_handoff_review` end-to-end including persistence and state transition