### PR TITLE
test: add safe delegation fixtures and handoff review regressions

### DIFF
--- a/tests/fixtures/handoff_fixtures.py
+++ b/tests/fixtures/handoff_fixtures.py
@@ -1,0 +1,121 @@
+"""Shared fixtures for handoff packet / review tests.
+
+Two scenarios are exposed:
+
+- ``seed_bounded_delegation_project``: a realistic project with an MCP delegation
+  decision, a frontend evidence-first decision, a do-not-touch frontend boundary,
+  and a high-risk analytics hotspot that is NOT in declared scope. Built to cover
+  the common "safe delegation" narrative.
+- ``seed_minimal_project``: an empty project with only a project row, to exercise
+  edge cases (missing scope, missing decisions, etc.).
+
+Plus helpers to build packets in each canonical lifecycle state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from copyclip.intelligence.db import get_or_create_project
+from copyclip.intelligence.handoff import build_handoff_packet, save_handoff_packet, update_handoff_packet
+
+
+def seed_bounded_delegation_project(conn, root: str) -> int:
+    """Seed a realistic handoff scenario.
+
+    - decision #1: "Use bounded MCP handoff packets" (accepted) linked to src/copyclip/mcp_server.py
+    - decision #2: "Frontend must stay evidence-first" (accepted) linked to frontend/src/pages/AskPage.tsx
+    - files: mcp_server.py, intelligence/server.py, analytics/hotspot.py (out of scope + high risk), AskPage.tsx
+    - risks: intent_drift on mcp_server (high), complexity on hotspot (high)
+    - analysis_file_insights with modules and cognitive_debt signals
+    """
+    pid = get_or_create_project(conn, root, name="copyclip")
+    rows: list[tuple[str, tuple[Any, ...]]] = [
+        ("INSERT INTO decisions(project_id, title, summary, status, source_type) VALUES(?,?,?,?,?)",
+            (pid, "Use bounded MCP handoff packets", "Delegation should use inspectable bounded packets.", "accepted", "manual")),
+        ("INSERT INTO decision_refs(decision_id, ref_type, ref_value) VALUES(?,?,?)",
+            (1, "file", "src/copyclip/mcp_server.py")),
+        ("INSERT INTO decisions(project_id, title, summary, status, source_type) VALUES(?,?,?,?,?)",
+            (pid, "Frontend must stay evidence-first", "AskPage must preserve evidence-first rendering.", "accepted", "manual")),
+        ("INSERT INTO decision_refs(decision_id, ref_type, ref_value) VALUES(?,?,?)",
+            (2, "file", "frontend/src/pages/AskPage.tsx")),
+        ("INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+            (pid, "src/copyclip/mcp_server.py", "python", 1200, 1.0, "h-mcp")),
+        ("INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+            (pid, "src/copyclip/intelligence/server.py", "python", 2400, 1.0, "h-server")),
+        ("INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+            (pid, "src/copyclip/analytics/hotspot.py", "python", 900, 1.0, "h-hotspot")),
+        ("INSERT INTO files(project_id, path, language, size_bytes, mtime, hash) VALUES(?,?,?,?,?,?)",
+            (pid, "frontend/src/pages/AskPage.tsx", "tsx", 4800, 1.0, "h-ask")),
+        ("INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+            (pid, "src/copyclip/mcp_server.py", "high", "intent_drift", "MCP delivery can bypass bounded delegation.", 93)),
+        ("INSERT INTO risks(project_id, area, severity, kind, rationale, score) VALUES(?,?,?,?,?,?)",
+            (pid, "src/copyclip/analytics/hotspot.py", "high", "complexity", "Hot area with high churn.", 99)),
+        ("INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+            (pid, "src/copyclip/mcp_server.py", "copyclip.mcp", "[]", 14, 82.0)),
+        ("INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+            (pid, "src/copyclip/intelligence/server.py", "copyclip.intelligence", "[]", 22, 55.0)),
+        ("INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+            (pid, "src/copyclip/analytics/hotspot.py", "copyclip.analytics", "[]", 33, 88.0)),
+        ("INSERT INTO analysis_file_insights(project_id, path, module, imports_json, complexity, cognitive_debt) VALUES(?,?,?,?,?,?)",
+            (pid, "frontend/src/pages/AskPage.tsx", "frontend.pages", "[]", 9, 30.0)),
+    ]
+    for sql, args in rows:
+        conn.execute(sql, args)
+    conn.commit()
+    return pid
+
+
+def seed_minimal_project(conn, root: str) -> int:
+    return get_or_create_project(conn, root, name="copyclip-minimal")
+
+
+def build_standard_bounded_packet(
+    conn,
+    pid: int,
+    *,
+    declared_files: list[str] | None = None,
+    do_not_touch: list[dict[str, Any]] | None = None,
+    acceptance_criteria: list[str] | None = None,
+    generated_at: str = "2026-04-20T10:00:00Z",
+) -> dict[str, Any]:
+    """Standard scenario packet: bounded MCP work with AskPage excluded."""
+    return build_handoff_packet(
+        conn,
+        pid,
+        task_prompt="Tighten bounded MCP delegation without touching the evidence-first Ask UI.",
+        declared_files=declared_files if declared_files is not None else ["src/copyclip/mcp_server.py"],
+        do_not_touch=do_not_touch if do_not_touch is not None else [
+            {"target": "frontend/src/pages/AskPage.tsx", "reason": "Ask UI is excluded.", "severity": "hard_boundary"},
+        ],
+        acceptance_criteria=acceptance_criteria if acceptance_criteria is not None else ["Delegation stays bounded."],
+        generated_at=generated_at,
+    )
+
+
+def advance_packet_to(conn, pid: int, packet: dict[str, Any], target_state: str) -> dict[str, Any]:
+    """Persist the packet then walk it through the allowed lifecycle sequence to reach target_state."""
+    save_handoff_packet(conn, pid, packet)
+    packet_id = packet["meta"]["packet_id"]
+    sequence: list[tuple[str, dict[str, Any]]] = []
+    path_to = {
+        "draft": [],
+        "ready_for_review": [],
+        "approved_for_handoff": [("approved_for_handoff", {"approved_by": "samuel", "delegation_target": "claude-code"})],
+        "delegated": [
+            ("approved_for_handoff", {"approved_by": "samuel", "delegation_target": "claude-code"}),
+            ("delegated", {}),
+        ],
+        "change_received": [
+            ("approved_for_handoff", {"approved_by": "samuel", "delegation_target": "claude-code"}),
+            ("delegated", {}),
+            ("change_received", {}),
+        ],
+    }
+    if target_state not in path_to:
+        raise ValueError(f"unsupported target state: {target_state}")
+    sequence = path_to[target_state]
+    for state, extras in sequence:
+        update_handoff_packet(conn, pid, packet_id, {"state": state, **extras})
+    conn.commit()
+    return packet

--- a/tests/test_handoff_contract_schema.py
+++ b/tests/test_handoff_contract_schema.py
@@ -1,0 +1,162 @@
+"""Contract invariants for the handoff packet and review summary shapes.
+
+These tests enforce the schema described in docs/HANDOFF_PACKET_CONTRACT.md so
+that packet / review generators cannot silently drop required fields.
+"""
+
+from copyclip.intelligence.db import connect, init_schema
+from copyclip.intelligence.handoff import (
+    PACKET_TRANSITIONS,
+    REVIEW_STATES,
+    build_handoff_review_summary,
+)
+
+from tests.fixtures.handoff_fixtures import (
+    build_standard_bounded_packet,
+    seed_bounded_delegation_project,
+)
+
+
+REQUIRED_PACKET_KEYS = {
+    "meta",
+    "objective",
+    "scope",
+    "constraints",
+    "do_not_touch",
+    "relevant_decisions",
+    "risk_dark_zones",
+    "questions_to_clarify",
+    "acceptance_criteria",
+    "agent_consumable_packet",
+    "review_contract",
+    "evidence_index",
+    "notes",
+}
+
+REQUIRED_META_KEYS = {
+    "packet_id",
+    "packet_version",
+    "state",
+    "created_at",
+    "updated_at",
+    "project",
+    "created_by",
+    "approved_by",
+    "delegation_target",
+    "source_task",
+}
+
+REQUIRED_AGENT_CONSUMABLE_KEYS = {
+    "objective",
+    "allowed_write_scope",
+    "read_scope",
+    "constraints",
+    "do_not_touch",
+    "questions_to_clarify",
+    "acceptance_criteria",
+}
+
+REQUIRED_REVIEW_CONTRACT_KEYS = {
+    "expected_review_type",
+    "compare_scope_against_touched_files",
+    "check_decision_conflicts",
+    "check_dark_zone_entry",
+    "check_blast_radius",
+    "required_human_questions",
+}
+
+REQUIRED_REVIEW_KEYS = {
+    "meta",
+    "result",
+    "scope_check",
+    "decision_conflicts",
+    "blast_radius",
+    "dark_zone_entry",
+    "unresolved_questions",
+    "review_evidence",
+}
+
+
+def test_packet_has_all_required_top_level_and_meta_keys(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid)
+    conn.close()
+
+    assert REQUIRED_PACKET_KEYS.issubset(packet.keys())
+    assert REQUIRED_META_KEYS.issubset(packet["meta"].keys())
+    assert REQUIRED_AGENT_CONSUMABLE_KEYS.issubset(packet["agent_consumable_packet"].keys())
+    assert REQUIRED_REVIEW_CONTRACT_KEYS.issubset(packet["review_contract"].keys())
+
+
+def test_packet_state_is_in_known_lifecycle_set(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid)
+    conn.close()
+
+    allowed_states = set(PACKET_TRANSITIONS.keys())
+    assert packet["meta"]["state"] in allowed_states
+
+
+def test_review_summary_has_all_required_sections_and_state_is_valid(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid)
+
+    summary = build_handoff_review_summary(
+        conn,
+        pid,
+        packet,
+        proposed_changes={"touched_files": ["src/copyclip/mcp_server.py"]},
+        generated_at="2026-04-20T11:00:00Z",
+    )
+    conn.close()
+
+    assert REQUIRED_REVIEW_KEYS.issubset(summary.keys())
+    assert summary["meta"]["review_state"] in REVIEW_STATES
+    assert summary["result"]["verdict"] in {"accepted", "changes_requested", "needs_human_review"}
+    assert summary["result"]["confidence"] in {"low", "medium", "high"}
+
+
+def test_agent_consumable_packet_lists_are_disjoint_projections(tmp_path):
+    """allowed_write_scope and do_not_touch should never overlap by construction."""
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid)
+    conn.close()
+
+    write_scope = set(packet["agent_consumable_packet"]["allowed_write_scope"])
+    do_not_touch = set(packet["agent_consumable_packet"]["do_not_touch"])
+    assert write_scope.isdisjoint(do_not_touch)
+
+
+def test_review_contract_fields_drive_review_sections(tmp_path):
+    """If the review_contract declares check_decision_conflicts, the review pipeline must populate the section (even if empty)."""
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid)
+
+    assert packet["review_contract"]["check_decision_conflicts"] is True
+    assert packet["review_contract"]["check_dark_zone_entry"] is True
+    assert packet["review_contract"]["check_blast_radius"] is True
+
+    summary = build_handoff_review_summary(
+        conn,
+        pid,
+        packet,
+        proposed_changes={"touched_files": ["src/copyclip/mcp_server.py"]},
+        generated_at="2026-04-20T11:00:00Z",
+    )
+    conn.close()
+
+    assert "decision_conflicts" in summary
+    assert "dark_zone_entry" in summary
+    assert "blast_radius" in summary
+    assert "impacted_modules" in summary["blast_radius"]
+    assert "estimated_size" in summary["blast_radius"]

--- a/tests/test_handoff_delegation_scenarios.py
+++ b/tests/test_handoff_delegation_scenarios.py
@@ -1,0 +1,140 @@
+"""End-to-end delegation narratives that exercise the full handoff pipeline.
+
+Each test composes a packet, walks the lifecycle, generates a review summary via
+``build_handoff_review_summary``, and asserts the verdict + key signals against
+a realistic scenario drawn from docs/HANDOFF_PACKET_CONTRACT.md.
+"""
+
+from copyclip.intelligence.db import connect, init_schema
+from copyclip.intelligence.handoff import (
+    build_handoff_review_summary,
+    save_handoff_packet,
+    save_handoff_review_summary,
+    update_handoff_packet,
+)
+
+from tests.fixtures.handoff_fixtures import (
+    build_standard_bounded_packet,
+    seed_bounded_delegation_project,
+)
+
+
+def test_happy_path_clean_change_is_accepted(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid)
+    save_handoff_packet(conn, pid, packet)
+    packet_id = packet["meta"]["packet_id"]
+
+    update_handoff_packet(conn, pid, packet_id, {"state": "approved_for_handoff", "approved_by": "samuel", "delegation_target": "claude-code"})
+    update_handoff_packet(conn, pid, packet_id, {"state": "delegated"})
+    update_handoff_packet(conn, pid, packet_id, {"state": "change_received"})
+    conn.commit()
+
+    summary = build_handoff_review_summary(
+        conn, pid, packet,
+        proposed_changes={"touched_files": ["src/copyclip/mcp_server.py"]},
+        generated_at="2026-04-20T11:00:00Z",
+    )
+    save_handoff_review_summary(conn, pid, packet_id, summary)
+    final = update_handoff_packet(conn, pid, packet_id, {"state": "reviewed"})
+    conn.close()
+
+    assert summary["result"]["verdict"] == "accepted"
+    assert summary["scope_check"]["out_of_scope_touches"] == []
+    assert summary["scope_check"]["boundary_violations"] == []
+    assert summary["decision_conflicts"] == []
+    assert final["meta"]["state"] == "reviewed"
+
+
+def test_boundary_violation_requires_changes(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid)
+    conn.close()
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+
+    summary = build_handoff_review_summary(
+        conn, pid, packet,
+        proposed_changes={"touched_files": [
+            "src/copyclip/mcp_server.py",
+            "frontend/src/pages/AskPage.tsx",
+        ]},
+    )
+    conn.close()
+
+    assert summary["result"]["verdict"] == "changes_requested"
+    assert any(v["target"] == "frontend/src/pages/AskPage.tsx" for v in summary["scope_check"]["boundary_violations"])
+    # decision #2 (Frontend evidence-first) touches the same boundary target and must appear in conflicts
+    assert any(c["decision_id"] == 2 for c in summary["decision_conflicts"])
+
+
+def test_unexpected_dark_zone_excursion_requires_changes(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid)
+
+    summary = build_handoff_review_summary(
+        conn, pid, packet,
+        proposed_changes={"touched_files": [
+            "src/copyclip/mcp_server.py",
+            "src/copyclip/analytics/hotspot.py",  # high risk + high debt, NOT in declared scope
+        ]},
+    )
+    conn.close()
+
+    assert summary["result"]["verdict"] == "changes_requested"
+    unexpected = [entry for entry in summary["dark_zone_entry"] if not entry.get("expected")]
+    assert any(entry["area"] == "src/copyclip/analytics/hotspot.py" for entry in unexpected)
+    assert "src/copyclip/analytics/hotspot.py" in summary["scope_check"]["out_of_scope_touches"]
+
+
+def test_unresolved_questions_push_verdict_to_human_review(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid, acceptance_criteria=[])
+
+    # The packet generator surfaces a non-blocking question when acceptance_criteria is empty
+    assert any(q.get("question") for q in packet["questions_to_clarify"])
+
+    summary = build_handoff_review_summary(
+        conn, pid, packet,
+        proposed_changes={"touched_files": ["src/copyclip/mcp_server.py"]},
+    )
+    conn.close()
+
+    assert summary["result"]["verdict"] == "needs_human_review"
+    assert summary["result"]["confidence"] == "medium"
+    assert summary["unresolved_questions"]
+
+
+def test_scenario_pipeline_survives_resumed_review(tmp_path):
+    """Running the review twice for the same packet + inputs should be idempotent by design."""
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet = build_standard_bounded_packet(conn, pid)
+    save_handoff_packet(conn, pid, packet)
+    packet_id = packet["meta"]["packet_id"]
+    update_handoff_packet(conn, pid, packet_id, {"state": "approved_for_handoff", "approved_by": "samuel", "delegation_target": "claude-code"})
+    update_handoff_packet(conn, pid, packet_id, {"state": "delegated"})
+    update_handoff_packet(conn, pid, packet_id, {"state": "change_received"})
+    conn.commit()
+
+    proposed = {"touched_files": ["src/copyclip/mcp_server.py"]}
+    first = build_handoff_review_summary(conn, pid, packet, proposed, generated_at="2026-04-20T11:00:00Z")
+    save_handoff_review_summary(conn, pid, packet_id, first)
+    update_handoff_packet(conn, pid, packet_id, {"state": "reviewed"})
+
+    # re-run review with the same inputs; persist again (valid: reviewed can be overwritten when the review summary mutates)
+    second = build_handoff_review_summary(conn, pid, packet, proposed, generated_at="2026-04-20T11:00:00Z")
+    save_handoff_review_summary(conn, pid, packet_id, second)
+    conn.close()
+
+    assert first == second
+    assert first["meta"]["review_id"] == second["meta"]["review_id"]

--- a/tests/test_handoff_lifecycle_transitions.py
+++ b/tests/test_handoff_lifecycle_transitions.py
@@ -1,0 +1,159 @@
+"""Lifecycle transition coverage for handoff packets and review summaries.
+
+PACKET_TRANSITIONS and REVIEW_STATES are the authoritative definitions; these
+tests enumerate every allowed transition and a representative set of disallowed
+ones so regressions in the lifecycle machine surface immediately.
+"""
+
+import pytest
+
+from copyclip.intelligence.db import connect, init_schema
+from copyclip.intelligence.handoff import (
+    PACKET_TRANSITIONS,
+    REVIEW_STATES,
+    save_handoff_packet,
+    save_handoff_review_summary,
+    update_handoff_packet,
+)
+
+from tests.fixtures.handoff_fixtures import (
+    build_standard_bounded_packet,
+    seed_bounded_delegation_project,
+)
+
+
+ALLOWED_PACKET_TRANSITIONS = [
+    (src, dst)
+    for src, destinations in PACKET_TRANSITIONS.items()
+    for dst in destinations
+]
+
+ALL_PACKET_STATES = set(PACKET_TRANSITIONS.keys())
+DISALLOWED_PACKET_TRANSITIONS = [
+    (src, dst)
+    for src in PACKET_TRANSITIONS
+    for dst in ALL_PACKET_STATES
+    if dst not in PACKET_TRANSITIONS[src] and dst != src
+]
+
+
+def _prime_packet(conn, pid: int, state: str) -> str:
+    packet = build_standard_bounded_packet(conn, pid, generated_at=f"2026-04-20T10:{hash(state) % 60:02d}:00Z")
+    save_handoff_packet(conn, pid, packet)
+    packet_id = packet["meta"]["packet_id"]
+    # walk the packet from ready_for_review to the requested start state using allowed transitions
+    path = {
+        "draft": [],
+        "ready_for_review": [],
+        "approved_for_handoff": [("approved_for_handoff", {"approved_by": "samuel", "delegation_target": "claude-code"})],
+        "delegated": [
+            ("approved_for_handoff", {"approved_by": "samuel", "delegation_target": "claude-code"}),
+            ("delegated", {}),
+        ],
+        "change_received": [
+            ("approved_for_handoff", {"approved_by": "samuel", "delegation_target": "claude-code"}),
+            ("delegated", {}),
+            ("change_received", {}),
+        ],
+        "reviewed": [
+            ("approved_for_handoff", {"approved_by": "samuel", "delegation_target": "claude-code"}),
+            ("delegated", {}),
+            ("change_received", {}),
+            ("reviewed", {}),
+        ],
+        "superseded": [("superseded", {})],
+        "cancelled": [
+            ("approved_for_handoff", {"approved_by": "samuel", "delegation_target": "claude-code"}),
+            ("cancelled", {}),
+        ],
+    }
+    if state == "draft":
+        # packet was built with a scope, so it's ready_for_review; demote to draft explicitly
+        update_handoff_packet(conn, pid, packet_id, {"state": "draft"})
+    for target, extras in path.get(state, []):
+        update_handoff_packet(conn, pid, packet_id, {"state": target, **extras})
+    conn.commit()
+    return packet_id
+
+
+@pytest.mark.parametrize("src_state,dst_state", ALLOWED_PACKET_TRANSITIONS)
+def test_allowed_packet_transition(tmp_path, src_state, dst_state):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet_id = _prime_packet(conn, pid, src_state)
+
+    # reviewed requires a persisted review summary to transition into it
+    if dst_state == "reviewed":
+        review_stub = {
+            "meta": {"review_id": f"review_{packet_id}_stub", "packet_id": packet_id, "review_state": "generated", "generated_at": "2026-04-20T11:00:00Z"},
+            "result": {"summary": "stub", "verdict": "accepted", "confidence": "medium"},
+            "scope_check": {"declared_scope": [], "touched_files": [], "out_of_scope_touches": [], "boundary_violations": [], "summary": "noop"},
+            "decision_conflicts": [],
+            "blast_radius": {"impacted_modules": [], "touched_file_count": 0, "estimated_size": "small", "impact_summary": "stub"},
+            "dark_zone_entry": [],
+            "unresolved_questions": [],
+            "review_evidence": [],
+        }
+        save_handoff_review_summary(conn, pid, packet_id, review_stub)
+
+    extras = {}
+    if dst_state == "approved_for_handoff":
+        extras = {"approved_by": "samuel", "delegation_target": "claude-code"}
+    updated = update_handoff_packet(conn, pid, packet_id, {"state": dst_state, **extras})
+    conn.close()
+    assert updated["meta"]["state"] == dst_state
+
+
+@pytest.mark.parametrize("src_state,dst_state", DISALLOWED_PACKET_TRANSITIONS)
+def test_disallowed_packet_transition_raises(tmp_path, src_state, dst_state):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet_id = _prime_packet(conn, pid, src_state)
+    with pytest.raises(ValueError) as exc:
+        update_handoff_packet(conn, pid, packet_id, {"state": dst_state})
+    conn.close()
+    assert str(exc.value).startswith("invalid_state_transition:")
+    assert f"{src_state}->{dst_state}" in str(exc.value)
+
+
+@pytest.mark.parametrize("review_state", sorted(REVIEW_STATES))
+def test_all_review_states_are_persistable(tmp_path, review_state):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet_id = _prime_packet(conn, pid, "change_received")
+
+    review = {
+        "meta": {"review_id": f"review_{packet_id}_{review_state}", "packet_id": packet_id, "review_state": review_state, "generated_at": "2026-04-20T12:00:00Z"},
+        "result": {"summary": "stub", "verdict": "accepted", "confidence": "medium"},
+        "scope_check": {"declared_scope": [], "touched_files": [], "out_of_scope_touches": [], "boundary_violations": [], "summary": "noop"},
+        "decision_conflicts": [],
+        "blast_radius": {"impacted_modules": [], "touched_file_count": 0, "estimated_size": "small", "impact_summary": "stub"},
+        "dark_zone_entry": [],
+        "unresolved_questions": [],
+        "review_evidence": [],
+    }
+    save_handoff_review_summary(conn, pid, packet_id, review)
+    row = conn.execute(
+        "SELECT review_state FROM handoff_review_summaries WHERE project_id=? AND packet_id=?",
+        (pid, packet_id),
+    ).fetchone()
+    conn.close()
+    assert row[0] == review_state
+
+
+def test_invalid_review_state_rejected(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_bounded_delegation_project(conn, str(tmp_path))
+    packet_id = _prime_packet(conn, pid, "change_received")
+    review = {
+        "meta": {"review_id": f"review_{packet_id}_bad", "packet_id": packet_id, "review_state": "bogus_state", "generated_at": "2026-04-20T12:00:00Z"},
+        "result": {}, "scope_check": {}, "decision_conflicts": [], "blast_radius": {}, "dark_zone_entry": [], "unresolved_questions": [], "review_evidence": [],
+    }
+    with pytest.raises(ValueError) as exc:
+        save_handoff_review_summary(conn, pid, packet_id, review)
+    conn.close()
+    assert str(exc.value) == "invalid_review_state"


### PR DESCRIPTION
## Summary
- adds `tests/fixtures/handoff_fixtures.py` with `seed_bounded_delegation_project` (MCP decision, evidence-first frontend decision, high-risk analytics hotspot, AskPage hard boundary) + `build_standard_bounded_packet` + `advance_packet_to`
- adds `test_handoff_contract_schema.py` enforcing required fields on packet / meta / agent_consumable_packet / review_contract and verifying state/verdict/confidence value sets
- adds `test_handoff_lifecycle_transitions.py` with every allowed transition and every disallowed transition as parametrized cases (plus review state persistence)
- adds `test_handoff_delegation_scenarios.py` covering the full delegation narrative: happy path, boundary violation, unexpected dark zone, unresolved blocking questions, and idempotent re-review

Closes #46 and completes the safe handoff contract epic #18.

## Test plan
- [x] `pytest` — 216 passed, 1 skipped (+72 new)
- [x] All lifecycle transitions are parametrized; regressions in `PACKET_TRANSITIONS` / `REVIEW_STATES` surface immediately
- [x] Scenario tests pin down verdict behavior across the four canonical delegation outcomes