### PR TITLE
feat: add cognitive debt remediation recommendation engine

### DIFF
--- a/src/copyclip/intelligence/debt_remediation.py
+++ b/src/copyclip/intelligence/debt_remediation.py
@@ -1,0 +1,394 @@
+"""Cognitive debt remediation engine.
+
+Given a debt breakdown from :func:`build_debt_breakdown`, produce a prioritized
+list of concrete remediation candidates with evidence-backed targets. Follows
+the "remediation hooks" section of ``docs/COGNITIVE_DEBT_CONTRACT.md``:
+candidates do not mutate the breakdown, each candidate references the factors
+it would reduce, and ``expected_impact`` is always framed as an estimate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+REMEDIATION_ACTION_TYPES = {
+    "read_this_first",
+    "review_this_recent_change",
+    "link_or_resolve_decision",
+    "add_documentation_invariants",
+    "inspect_tests_or_test_gaps",
+    "refactor_or_simplify",
+    "clarify_ownership",
+}
+
+# Minimum normalized contribution (0-100) for a factor to trigger its template.
+# High contribution → candidate is worth surfacing; low contribution → noise.
+_FACTOR_ACTIVATION_FLOOR = {
+    "agent_authored_ratio": 40.0,
+    "review_staleness": 40.0,
+    "decision_gap": 60.0,
+    "test_evidence_gap": 60.0,
+    "churn_pressure": 40.0,
+    "ownership_ambiguity": 40.0,
+    "blast_radius": 60.0,
+    "novelty_recency": 50.0,
+}
+
+
+def _factor_map(breakdown: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {f["factor_id"]: f for f in (breakdown.get("factor_breakdown") or [])}
+
+
+def _is_factor_active(factor_map: dict[str, dict[str, Any]], factor_id: str) -> bool:
+    factor = factor_map.get(factor_id)
+    if not factor or not factor.get("signal_available"):
+        return False
+    value = factor.get("normalized_contribution") or 0.0
+    return value >= _FACTOR_ACTIVATION_FLOOR.get(factor_id, 50.0)
+
+
+def _recent_commits_for_file(conn, project_id: int, path: str, limit: int = 5) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT c.sha, c.author, c.date, c.message
+        FROM file_changes fc
+        JOIN commits c ON c.sha = fc.commit_sha AND c.project_id = fc.project_id
+        WHERE fc.project_id=? AND fc.file_path=?
+        ORDER BY c.date DESC
+        LIMIT ?
+        """,
+        (project_id, path, limit),
+    ).fetchall()
+    return [
+        {"sha": str(r[0]), "author": str(r[1] or ""), "date": str(r[2] or ""), "message": str(r[3] or "")}
+        for r in rows
+        if r[0]
+    ]
+
+
+def _agent_vs_human_commits(commits: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    agent_markers = ("claude", "bot", "copilot", "gpt", "codegen", "agent")
+    agents: list[dict[str, Any]] = []
+    humans: list[dict[str, Any]] = []
+    for commit in commits:
+        author = (commit.get("author") or "").lower()
+        if any(marker in author for marker in agent_markers):
+            agents.append(commit)
+        else:
+            humans.append(commit)
+    return agents, humans
+
+
+def _target_for_scope(meta: dict[str, Any]) -> dict[str, Any]:
+    scope = meta.get("scope_kind")
+    scope_id = meta.get("scope_id")
+    if scope == "file":
+        return {"kind": "file", "id": scope_id}
+    if scope == "module":
+        return {"kind": "module", "id": scope_id, "module": scope_id}
+    return {"kind": "project", "id": scope_id}
+
+
+def _estimate_impact(factor_map: dict[str, dict[str, Any]], factor_ids: list[str], reduction: float) -> float:
+    delta = 0.0
+    for fid in factor_ids:
+        factor = factor_map.get(fid)
+        if not factor or not factor.get("signal_available"):
+            continue
+        delta += factor["weight"] * (factor["normalized_contribution"] or 0.0) * reduction
+    return round(-delta, 2)
+
+
+def _candidate_for_human_review(factor_map, target, evidence_ids, agent_commits) -> dict[str, Any] | None:
+    if not _is_factor_active(factor_map, "agent_authored_ratio") and not _is_factor_active(factor_map, "review_staleness"):
+        return None
+    delta = _estimate_impact(factor_map, ["agent_authored_ratio", "review_staleness"], reduction=0.5)
+    commit_evidence = [f"commit:{c['sha']}" for c in agent_commits[:3]]
+    return {
+        "id": "human_review_recent_changes",
+        "action_type": "review_this_recent_change",
+        "label": "Human-review the recent agent-authored changes to restore continuity",
+        "target": target,
+        "reduces_factors": ["agent_authored_ratio", "review_staleness"],
+        "expected_impact": {"score_delta": delta, "confidence": "medium"},
+        "rationale": "Human review of recent non-human commits is the cheapest single reduction for drift and staleness.",
+        "evidence": evidence_ids + commit_evidence,
+    }
+
+
+def _candidate_for_link_decision(factor_map, target) -> dict[str, Any] | None:
+    if not _is_factor_active(factor_map, "decision_gap"):
+        return None
+    delta = _estimate_impact(factor_map, ["decision_gap"], reduction=0.8)
+    return {
+        "id": "link_or_propose_decision",
+        "action_type": "link_or_resolve_decision",
+        "label": "Link an accepted decision to this area or propose one if none applies",
+        "target": target,
+        "reduces_factors": ["decision_gap"],
+        "expected_impact": {"score_delta": delta, "confidence": "medium"},
+        "rationale": "An anchored decision turns an unexplained area into a documented constraint, which collapses the decision gap almost fully.",
+        "evidence": [f"{target['kind']}:{target.get('id') or target.get('module')}"],
+    }
+
+
+def _candidate_for_add_test(factor_map, target, module) -> dict[str, Any] | None:
+    if not _is_factor_active(factor_map, "test_evidence_gap"):
+        return None
+    delta = _estimate_impact(factor_map, ["test_evidence_gap"], reduction=0.9)
+    module_label = module or target.get("module") or target.get("id") or "scope"
+    return {
+        "id": "add_targeted_test",
+        "action_type": "inspect_tests_or_test_gaps",
+        "label": f"Add at least one targeted test for {module_label}",
+        "target": target if target.get("kind") != "file" else {"kind": "module", "id": module_label, "module": module_label},
+        "reduces_factors": ["test_evidence_gap"],
+        "expected_impact": {"score_delta": delta, "confidence": "medium"},
+        "rationale": "A single deterministic test against the module's critical path dramatically reduces the test evidence gap.",
+        "evidence": [f"module:{module_label}"],
+    }
+
+
+def _candidate_for_churn_note(factor_map, target, commits) -> dict[str, Any] | None:
+    active = _is_factor_active(factor_map, "churn_pressure") or _is_factor_active(factor_map, "novelty_recency")
+    if not active:
+        return None
+    delta = _estimate_impact(factor_map, ["churn_pressure", "novelty_recency"], reduction=0.3)
+    commit_evidence = [f"commit:{c['sha']}" for c in commits[:3]]
+    return {
+        "id": "capture_churn_in_decision_note",
+        "action_type": "add_documentation_invariants",
+        "label": "Summarize the recent churn pattern in a decision or invariant note",
+        "target": target,
+        "reduces_factors": ["churn_pressure", "novelty_recency"],
+        "expected_impact": {"score_delta": delta, "confidence": "low"},
+        "rationale": "Writing down what the churn was for converts churn into acknowledged decisions, lowering uncertainty.",
+        "evidence": [f"{target['kind']}:{target.get('id') or target.get('module')}"] + commit_evidence,
+    }
+
+
+def _candidate_for_ownership(factor_map, target) -> dict[str, Any] | None:
+    if not _is_factor_active(factor_map, "ownership_ambiguity"):
+        return None
+    delta = _estimate_impact(factor_map, ["ownership_ambiguity"], reduction=0.5)
+    return {
+        "id": "clarify_ownership",
+        "action_type": "clarify_ownership",
+        "label": "Name a primary reviewer or owner for this area",
+        "target": target,
+        "reduces_factors": ["ownership_ambiguity"],
+        "expected_impact": {"score_delta": delta, "confidence": "low"},
+        "rationale": "Assigning a primary reviewer turns ambient co-authorship into a clear escalation path.",
+        "evidence": [f"{target['kind']}:{target.get('id') or target.get('module')}"],
+    }
+
+
+def _candidate_for_blast_radius(factor_map, target) -> dict[str, Any] | None:
+    if not _is_factor_active(factor_map, "blast_radius"):
+        return None
+    delta = _estimate_impact(factor_map, ["blast_radius"], reduction=0.3)
+    return {
+        "id": "isolate_blast_radius",
+        "action_type": "refactor_or_simplify",
+        "label": "Isolate side effects so the module's blast radius shrinks",
+        "target": target,
+        "reduces_factors": ["blast_radius"],
+        "expected_impact": {"score_delta": delta, "confidence": "low"},
+        "rationale": "High fan-out areas cascade small changes into wide impact; tightening boundaries is a slow but compounding win.",
+        "evidence": [f"{target['kind']}:{target.get('id') or target.get('module')}"],
+    }
+
+
+def _candidate_for_read_anchor(factor_map, target, human_commits, last_human_ts) -> dict[str, Any] | None:
+    if not human_commits:
+        return None
+    if not (_is_factor_active(factor_map, "agent_authored_ratio") or _is_factor_active(factor_map, "review_staleness")):
+        return None
+    delta = _estimate_impact(factor_map, ["agent_authored_ratio", "review_staleness"], reduction=0.2)
+    first_human = human_commits[0]
+    return {
+        "id": "read_last_human_anchor",
+        "action_type": "read_this_first",
+        "label": f"Read the last human-authored anchor commit ({first_human['sha'][:7]})",
+        "target": target,
+        "reduces_factors": ["agent_authored_ratio", "review_staleness"],
+        "expected_impact": {"score_delta": delta, "confidence": "low"},
+        "rationale": "Re-anchoring on the last human-authored version of this area is the fastest context-restore step.",
+        "evidence": [f"{target['kind']}:{target.get('id') or target.get('module')}", f"commit:{first_human['sha']}"],
+    }
+
+
+def _read_first_sequence(target, human_commits, agent_commits, breakdown) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    # 1. last human-authored commit — restores continuity
+    if human_commits:
+        commit = human_commits[0]
+        item_id = f"commit:{commit['sha']}"
+        if item_id not in seen:
+            items.append({
+                "id": item_id,
+                "kind": "commit",
+                "sha": commit["sha"],
+                "author_kind": "human",
+                "reason": "Re-anchor on the last human-authored change to reset mental model.",
+            })
+            seen.add(item_id)
+
+    # 2. up to two recent agent-authored commits worth reviewing
+    for commit in agent_commits[:2]:
+        item_id = f"commit:{commit['sha']}"
+        if item_id not in seen:
+            items.append({
+                "id": item_id,
+                "kind": "commit",
+                "sha": commit["sha"],
+                "author_kind": "agent",
+                "reason": "Review recent agent-authored change to verify intent alignment.",
+            })
+            seen.add(item_id)
+
+    # 3. linked decisions (if any) so the human rechecks constraints
+    decision_factor = next((f for f in breakdown.get("factor_breakdown") or [] if f["factor_id"] == "decision_gap"), None)
+    if decision_factor and decision_factor.get("signal_available"):
+        for decision_id in (decision_factor.get("raw_signal") or {}).get("linked_decisions") or []:
+            item_id = f"decision:{decision_id}"
+            if item_id not in seen:
+                items.append({
+                    "id": item_id,
+                    "kind": "decision",
+                    "decision_id": decision_id,
+                    "reason": "Re-read the decision anchoring this area before making changes.",
+                })
+                seen.add(item_id)
+
+    # 4. the target file / module itself for direct inspection
+    target_id = f"{target['kind']}:{target.get('id') or target.get('module')}"
+    if target_id not in seen:
+        items.append({
+            "id": target_id,
+            "kind": target["kind"],
+            "reason": "Inspect the target in its current state before proposing changes.",
+        })
+        seen.add(target_id)
+
+    return items
+
+
+def _total_impact_with_diminishing_returns(candidates: list[dict[str, Any]]) -> float:
+    # Order candidates by |score_delta| descending; each subsequent candidate
+    # contributes at a decaying factor so the total impact stays realistic.
+    ordered = sorted(candidates, key=lambda c: c["expected_impact"]["score_delta"])
+    total = 0.0
+    decay = 1.0
+    for candidate in ordered:
+        total += candidate["expected_impact"]["score_delta"] * decay
+        decay *= 0.7
+    return round(total, 2)
+
+
+def build_remediation_plan(conn, project_id: int, breakdown: dict[str, Any]) -> dict[str, Any]:
+    """Produce an ordered list of remediation candidates and a read_first sequence for a breakdown."""
+    meta = dict(breakdown.get("meta") or {})
+    factor_map = _factor_map(breakdown)
+    target = _target_for_scope(meta)
+    scope_kind = meta.get("scope_kind")
+    scope_id = meta.get("scope_id")
+
+    # Gather scope-dependent context
+    commits: list[dict[str, Any]] = []
+    module_for_file = None
+    last_human_ts = None
+    if scope_kind == "file" and scope_id:
+        commits = _recent_commits_for_file(conn, project_id, scope_id)
+        row = conn.execute(
+            "SELECT module, last_human_ts FROM analysis_file_insights WHERE project_id=? AND path=?",
+            (project_id, scope_id),
+        ).fetchone()
+        if row:
+            module_for_file = row[0]
+            last_human_ts = row[1]
+    elif scope_kind == "module":
+        file_rows = conn.execute(
+            "SELECT path FROM analysis_file_insights WHERE project_id=? AND module=?",
+            (project_id, scope_id),
+        ).fetchall()
+        for file_row in file_rows:
+            commits.extend(_recent_commits_for_file(conn, project_id, file_row[0], limit=2))
+
+    agent_commits, human_commits = _agent_vs_human_commits(commits)
+
+    scope_evidence_ids = [f"{target['kind']}:{target.get('id') or target.get('module')}"]
+
+    candidates: list[dict[str, Any]] = []
+    for builder, args in [
+        (_candidate_for_human_review, (factor_map, target, scope_evidence_ids, agent_commits)),
+        (_candidate_for_link_decision, (factor_map, target)),
+        (_candidate_for_add_test, (factor_map, target, module_for_file)),
+        (_candidate_for_churn_note, (factor_map, target, commits)),
+        (_candidate_for_ownership, (factor_map, target)),
+        (_candidate_for_blast_radius, (factor_map, target)),
+        (_candidate_for_read_anchor, (factor_map, target, human_commits, last_human_ts)),
+    ]:
+        candidate = builder(*args)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    # Dedupe by (action_type, target kind/id) keeping the first (highest-impact by construction).
+    seen_keys: set[tuple[str, str, str]] = set()
+    deduped: list[dict[str, Any]] = []
+    for candidate in candidates:
+        key = (candidate["action_type"], candidate["target"].get("kind", ""), str(candidate["target"].get("id") or candidate["target"].get("module", "")))
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        deduped.append(candidate)
+
+    # Rank by |expected score reduction| descending (most negative score_delta first).
+    deduped.sort(key=lambda c: c["expected_impact"]["score_delta"])
+    deduped = deduped[:6]
+
+    # Compute top factors (available + positive contribution) ordered by weighted_contribution desc
+    ranked_factors = sorted(
+        [f for f in (breakdown.get("factor_breakdown") or []) if f.get("signal_available") and (f.get("weighted_contribution") or 0) > 0],
+        key=lambda f: f["weighted_contribution"],
+        reverse=True,
+    )
+    top_factor_ids = [f["factor_id"] for f in ranked_factors[:3]]
+
+    read_first = _read_first_sequence(target, human_commits, agent_commits, breakdown)
+
+    total_delta = _total_impact_with_diminishing_returns(deduped) if deduped else 0.0
+    confidence_labels = [c["expected_impact"]["confidence"] for c in deduped]
+    confidence = (
+        "low"
+        if not confidence_labels or "low" in confidence_labels and "medium" not in confidence_labels
+        else ("high" if confidence_labels and all(c == "high" for c in confidence_labels) else "medium")
+    )
+
+    plan = {
+        "meta": {
+            "project": meta.get("project"),
+            "generated_at": meta.get("generated_at"),
+            "contract_version": meta.get("contract_version"),
+            "scope_kind": scope_kind,
+            "scope_id": scope_id,
+            "score": (breakdown.get("score") or {}).get("value"),
+            "severity": (breakdown.get("score") or {}).get("severity"),
+        },
+        "top_factors": top_factor_ids,
+        "remediation_candidates": deduped,
+        "read_first": read_first,
+        "expected_total_impact": {"score_delta": total_delta, "confidence": confidence},
+        "notes": [],
+    }
+
+    if not deduped:
+        plan["notes"].append({
+            "kind": "no_action_needed",
+            "message": "No factor exceeded its activation floor; current debt is within acceptable bounds.",
+        })
+
+    return plan

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -17,6 +17,7 @@ from urllib.parse import parse_qs, urlparse
 from .context_bundle_builder import build_context_bundle
 from .ask_project import build_ask_response
 from .cognitive_debt import build_debt_breakdown
+from .debt_remediation import build_remediation_plan
 from .handoff import (
     build_handoff_packet,
     build_handoff_review_summary,
@@ -474,6 +475,32 @@ def run_server(project_root: str, port: int = 4310) -> None:
                     self._json({"error": msg}, 400)
                     return
                 self._json(with_meta({"breakdown": breakdown}))
+                return
+
+            if parsed.path == "/api/cognitive-debt/remediation":
+                if not pid:
+                    self._json({"error": "project_not_indexed"}, 404)
+                    return
+                q = parse_qs(parsed.query or "")
+                scope_kind = (q.get("scope", ["file"])[0] or "file").strip()
+                scope_id = (q.get("id", [""])[0] or "").strip()
+                if scope_kind not in {"file", "module", "project"}:
+                    self._json({"error": "invalid_scope_kind"}, 400)
+                    return
+                if scope_kind in {"file", "module"} and not scope_id:
+                    self._json({"error": "scope_id_required"}, 400)
+                    return
+                try:
+                    breakdown = build_debt_breakdown(conn, pid, scope_kind, scope_id)
+                except ValueError as e:
+                    msg = str(e)
+                    if msg.startswith("module_not_found:"):
+                        self._json({"error": "module_not_found", "module": msg.split(":", 1)[1]}, 404)
+                        return
+                    self._json({"error": msg}, 400)
+                    return
+                plan = build_remediation_plan(conn, pid, breakdown)
+                self._json(with_meta({"breakdown": breakdown, "plan": plan}))
                 return
 
             if parsed.path == "/api/cognitive-load":

--- a/tests/test_debt_remediation.py
+++ b/tests/test_debt_remediation.py
@@ -1,0 +1,208 @@
+"""TDD suite for the cognitive debt remediation engine.
+
+The engine takes a debt breakdown (from build_debt_breakdown) and produces a
+prioritized, evidence-backed action plan that agents and humans can consume.
+"""
+
+from copyclip.intelligence.db import connect, init_schema, get_or_create_project
+from copyclip.intelligence.cognitive_debt import build_debt_breakdown
+from copyclip.intelligence.debt_remediation import (
+    REMEDIATION_ACTION_TYPES,
+    build_remediation_plan,
+)
+
+
+def _seed(conn, root: str) -> int:
+    pid = get_or_create_project(conn, root, name="copyclip")
+    files = [
+        ("src/copyclip/mcp_server.py", "copyclip.mcp", 82.0, 0.72, 1_600_000_000.0),  # high agent ratio, old human review
+        ("src/copyclip/intelligence/server.py", "copyclip.intelligence", 40.0, None, None),
+        ("tests/test_mcp.py", "tests", 2.0, 0.0, 1_700_000_000.0),
+    ]
+    for path, module, debt, ratio, last_human in files:
+        conn.execute(
+            "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+            (pid, path, "python", 1200, 1.0, f"h-{path}"),
+        )
+        conn.execute(
+            "INSERT INTO analysis_file_insights(project_id,path,module,imports_json,complexity,cognitive_debt,agent_line_ratio,last_human_ts) VALUES(?,?,?,?,?,?,?,?)",
+            (pid, path, module, "[]", 10, debt, ratio, last_human),
+        )
+    # commits + file_changes so the file appears in churn
+    for i, (sha, author, date) in enumerate([
+        ("sha-a", "samuel", "2026-04-10T10:00:00+00:00"),
+        ("sha-b", "claude-bot", "2026-04-15T12:00:00+00:00"),
+        ("sha-c", "claude-bot", "2026-04-18T09:00:00+00:00"),
+    ]):
+        conn.execute("INSERT INTO commits(project_id,sha,author,date,message) VALUES(?,?,?,?,?)", (pid, sha, author, date, f"m-{sha}"))
+        conn.execute(
+            "INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) VALUES(?,?,?,?,?)",
+            (pid, sha, "src/copyclip/mcp_server.py", 20, 5),
+        )
+    # decisions (covers mcp_server)
+    conn.execute("INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)", (pid, "Use bounded MCP handoff packets", "Bounded delegation.", "accepted", "manual"))
+    conn.execute("INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)", (1, "file", "src/copyclip/mcp_server.py"))
+    conn.commit()
+    return pid
+
+
+_NOW_TS = 1_713_600_000.0
+
+
+def test_plan_has_meta_and_top_factors_sorted_by_contribution(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=_NOW_TS)
+
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    assert plan["meta"]["scope_kind"] == "file"
+    assert plan["meta"]["scope_id"] == "src/copyclip/mcp_server.py"
+    assert plan["meta"]["contract_version"] == breakdown["meta"]["contract_version"]
+    # top_factors should be factor_ids sorted by weighted_contribution desc
+    contributions = [
+        (f["factor_id"], f["weighted_contribution"])
+        for f in breakdown["factor_breakdown"]
+        if f["signal_available"]
+    ]
+    contributions.sort(key=lambda t: t[1], reverse=True)
+    expected_top = [fid for fid, _ in contributions if _ > 0]
+    assert plan["top_factors"] == expected_top[: len(plan["top_factors"])]
+
+
+def test_high_agent_ratio_produces_human_review_candidate(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=_NOW_TS)
+
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    action_types = {c["action_type"] for c in plan["remediation_candidates"]}
+    assert "review_this_recent_change" in action_types
+    review = next(c for c in plan["remediation_candidates"] if c["action_type"] == "review_this_recent_change")
+    assert "agent_authored_ratio" in review["reduces_factors"]
+    assert review["expected_impact"]["score_delta"] < 0
+    # must reference concrete commits in evidence
+    assert any(ev.startswith("commit:") for ev in review["evidence"])
+
+
+def test_high_decision_gap_produces_link_or_propose_decision(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/intelligence/server.py", now_ts=_NOW_TS)
+
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    action_types = {c["action_type"] for c in plan["remediation_candidates"]}
+    assert "link_or_resolve_decision" in action_types
+    link = next(c for c in plan["remediation_candidates"] if c["action_type"] == "link_or_resolve_decision")
+    assert "decision_gap" in link["reduces_factors"]
+
+
+def test_high_test_evidence_gap_produces_add_test(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/intelligence/server.py", now_ts=_NOW_TS)
+
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    action_types = {c["action_type"] for c in plan["remediation_candidates"]}
+    assert "inspect_tests_or_test_gaps" in action_types
+
+
+def test_read_first_is_ordered_unique_and_references_targets(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=_NOW_TS)
+
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    assert plan["read_first"]
+    ids = [item["id"] for item in plan["read_first"]]
+    assert len(ids) == len(set(ids))  # unique
+    # should include at least one human-authored commit first (to restore continuity)
+    assert any(item["kind"] == "commit" and item.get("author_kind") == "human" for item in plan["read_first"])
+
+
+def test_expected_total_impact_aggregates_candidates_with_diminishing_returns(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=_NOW_TS)
+
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    total = plan["expected_total_impact"]["score_delta"]
+    # can't exceed the sum of individual candidate deltas (no negative surplus)
+    individual_sum = sum(c["expected_impact"]["score_delta"] for c in plan["remediation_candidates"])
+    # diminishing returns: |total| <= |individual_sum|
+    assert abs(total) <= abs(individual_sum) + 1e-6
+    # but still negative (reducing the score)
+    assert total <= 0
+
+
+def test_low_debt_file_returns_empty_plan_with_explicit_note(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "tests/test_mcp.py", now_ts=_NOW_TS)
+    # The tests file has very low agent ratio + module has tests + low churn → low debt
+
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    # ensure the plan still returns meta and at worst notes
+    assert plan["meta"]["scope_id"] == "tests/test_mcp.py"
+    if not plan["remediation_candidates"]:
+        assert any(note.get("kind") == "no_action_needed" for note in plan["notes"])
+
+
+def test_action_types_are_a_subset_of_registered_set(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=_NOW_TS)
+
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    for candidate in plan["remediation_candidates"]:
+        assert candidate["action_type"] in REMEDIATION_ACTION_TYPES
+
+
+def test_candidates_are_deterministic_for_same_inputs(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=_NOW_TS, generated_at="2026-04-20T10:00:00Z")
+
+    plan_a = build_remediation_plan(conn, pid, breakdown)
+    plan_b = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    assert plan_a == plan_b
+
+
+def test_module_scope_plan_references_module_targets(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = _seed(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "module", "copyclip.mcp", now_ts=_NOW_TS)
+
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    assert plan["meta"]["scope_kind"] == "module"
+    # at least one candidate should target the module
+    assert any(c["target"].get("kind") == "module" or c["target"].get("module") == "copyclip.mcp" for c in plan["remediation_candidates"])

--- a/tests/test_debt_remediation_api.py
+++ b/tests/test_debt_remediation_api.py
@@ -1,0 +1,98 @@
+import json
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+from urllib import request
+from urllib.error import HTTPError
+
+from copyclip.intelligence.db import connect, init_schema
+from copyclip.intelligence.server import run_server
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_port(port: int, timeout_s: float = 3.0):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError("server did not start in time")
+
+
+def _get_json(url: str):
+    with request.urlopen(url, timeout=3) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def _seed(conn, root: str) -> int:
+    conn.execute("INSERT INTO projects(root_path,name,story) VALUES(?,?,?)", (root, "copyclip", "bounded delegation"))
+    pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (root,)).fetchone()[0]
+    conn.execute(
+        "INSERT INTO analysis_file_insights(project_id,path,module,imports_json,complexity,cognitive_debt,agent_line_ratio,last_human_ts) VALUES(?,?,?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "copyclip.mcp", "[]", 14, 82.0, 0.72, 1_600_000_000.0),
+    )
+    for sha, author in [("sha-1", "samuel"), ("sha-2", "claude-bot"), ("sha-3", "claude-bot")]:
+        conn.execute("INSERT INTO commits(project_id,sha,author,date,message) VALUES(?,?,?,?,?)", (pid, sha, author, "2026-04-15T10:00:00+00:00", f"m-{sha}"))
+        conn.execute("INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) VALUES(?,?,?,?,?)", (pid, sha, "src/copyclip/mcp_server.py", 10, 2))
+    conn.commit()
+    return pid
+
+
+def test_remediation_endpoint_returns_breakdown_and_plan():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        _seed(conn, root_path)
+        conn.close()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        resp = _get_json(
+            f"http://127.0.0.1:{port}/api/cognitive-debt/remediation?scope=file&id=src/copyclip/mcp_server.py"
+        )
+        assert "breakdown" in resp
+        assert "plan" in resp
+        plan = resp["plan"]
+        assert plan["meta"]["scope_id"] == "src/copyclip/mcp_server.py"
+        assert plan["remediation_candidates"]
+        action_types = {c["action_type"] for c in plan["remediation_candidates"]}
+        assert "review_this_recent_change" in action_types
+        assert plan["read_first"]
+
+
+def test_remediation_endpoint_rejects_invalid_scope():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        _seed(conn, root_path)
+        conn.close()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        try:
+            _get_json(f"http://127.0.0.1:{port}/api/cognitive-debt/remediation?scope=cluster&id=x")
+            raise AssertionError("expected 400")
+        except HTTPError as e:
+            assert e.code == 400
+            assert json.loads(e.read().decode("utf-8"))["error"] == "invalid_scope_kind"


### PR DESCRIPTION
## Summary
- adds \`src/copyclip/intelligence/debt_remediation.py\` with \`build_remediation_plan(conn, project_id, breakdown)\` that maps high-contribution factors to concrete, evidence-backed candidates (human review, link/propose decision, add test, capture churn in decision note, clarify ownership, isolate blast radius, read last human anchor)
- each candidate declares \`reduces_factors\` and a score delta estimated from factor weights × current normalized contribution × a per-template reduction factor; \`expected_total_impact\` applies diminishing returns so aggregate stays realistic
- \`read_first\` sequence leads with the most recent human-authored commit, then agent-authored commits, then linked decisions, then the target artifact
- candidates dedupe by \`(action_type, target kind, target id)\` and rank by most-negative \`score_delta\`
- exposes \`GET /api/cognitive-debt/remediation?scope=file|module|project&id=...\` alongside the breakdown endpoint, with the same 400/404 error surface
- low-debt scopes return an explicit \`no_action_needed\` note rather than silence

Closes #49.

## Test plan
- [x] \`pytest\` — 242 passed, 1 skipped (+12 new)
- [x] \`tests/test_debt_remediation.py\` covers: top_factors ordering, high agent_ratio → human review, high decision_gap → link/propose, high test gap → add test, read_first ordering + uniqueness + human anchor, diminishing returns on total impact, low-debt file → empty plan with note, action_types subset of the registry, determinism, module scope plan references module targets
- [x] \`tests/test_debt_remediation_api.py\` covers the endpoint happy path and the invalid scope 400