### PR TITLE
test: add cognitive debt fixtures and regression scenarios

### DIFF
--- a/tests/fixtures/cog_debt_fixtures.py
+++ b/tests/fixtures/cog_debt_fixtures.py
@@ -1,0 +1,158 @@
+"""Shared fixtures for cognitive debt tests.
+
+Three scenarios cover the realistic shapes a debt breakdown has to handle:
+
+- ``seed_mixed_debt_project``: one critical dark file (mcp_server with high agent
+  ratio + stale human review + churn), one healthy file (ask answer with low
+  agent ratio + recent human review + decision link + tests), one greenfield
+  file with no blame data (forces signal_coverage to drop).
+- ``seed_clean_project``: a small project where no file reaches activation
+  floors; used to verify remediation returns a ``no_action_needed`` note.
+- ``seed_greenfield_project``: persisted rows without blame so
+  ``agent_authored_ratio`` and ``review_staleness`` are unavailable and
+  confidence must fall to ``low`` or ``medium``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from copyclip.intelligence.db import get_or_create_project
+
+
+_MCP_COMMITS = [
+    ("sha-mcp-1", "samuel", "2026-04-05T10:00:00+00:00", "first refactor"),
+    ("sha-mcp-2", "claude-bot", "2026-04-15T12:00:00+00:00", "agent tighten"),
+    ("sha-mcp-3", "claude-bot", "2026-04-18T09:00:00+00:00", "agent polish"),
+]
+
+
+def seed_mixed_debt_project(conn, root: str) -> int:
+    """Three contrasting files: critical-dark, healthy, greenfield."""
+    pid = get_or_create_project(conn, root, name="copyclip")
+    files: list[tuple[str, str, float, float | None, float | None]] = [
+        ("src/copyclip/mcp_server.py", "copyclip.mcp", 86.0, 0.72, 1_600_000_000.0),
+        ("src/copyclip/ask/answer.py", "copyclip.ask", 8.0, 0.05, 1_712_000_000.0),
+        ("src/copyclip/new_module.py", "copyclip.new", 22.0, None, None),
+        ("tests/test_ask.py", "tests", 1.0, 0.0, 1_712_000_000.0),
+    ]
+    for path, module, debt, ratio, last_human in files:
+        conn.execute(
+            "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+            (pid, path, "python", 1000, 1.0, f"h-{path}"),
+        )
+        conn.execute(
+            "INSERT INTO analysis_file_insights(project_id,path,module,imports_json,complexity,cognitive_debt,agent_line_ratio,last_human_ts) VALUES(?,?,?,?,?,?,?,?)",
+            (pid, path, module, "[]", 14 if "mcp_server" in path else 6, debt, ratio, last_human),
+        )
+    # mcp_server has churn + mixed authors
+    for sha, author, date, message in _MCP_COMMITS:
+        conn.execute(
+            "INSERT INTO commits(project_id,sha,author,date,message) VALUES(?,?,?,?,?)",
+            (pid, sha, author, date, message),
+        )
+        conn.execute(
+            "INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) VALUES(?,?,?,?,?)",
+            (pid, sha, "src/copyclip/mcp_server.py", 20, 5),
+        )
+    # ask/answer has a single recent human touch
+    conn.execute(
+        "INSERT INTO commits(project_id,sha,author,date,message) VALUES(?,?,?,?,?)",
+        (pid, "sha-ask-1", "samuel", "2026-04-17T12:00:00+00:00", "recent ask refactor"),
+    )
+    conn.execute(
+        "INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) VALUES(?,?,?,?,?)",
+        (pid, "sha-ask-1", "src/copyclip/ask/answer.py", 12, 2),
+    )
+    # decision anchored on ask/answer and mcp_server
+    conn.execute(
+        "INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)",
+        (pid, "Evidence-first Ask responses", "Answers must be grounded.", "accepted", "manual"),
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+        (1, "file", "src/copyclip/ask/answer.py"),
+    )
+    conn.execute(
+        "INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)",
+        (pid, "Use bounded MCP handoff packets", "Bounded delegation.", "accepted", "manual"),
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+        (2, "file", "src/copyclip/mcp_server.py"),
+    )
+    # risk on mcp to align with the dark narrative
+    conn.execute(
+        "INSERT INTO risks(project_id,area,severity,kind,rationale,score) VALUES(?,?,?,?,?,?)",
+        (pid, "src/copyclip/mcp_server.py", "high", "intent_drift", "MCP delivery drift.", 93),
+    )
+    conn.commit()
+    return pid
+
+
+def seed_clean_project(conn, root: str) -> int:
+    """A project where every file is healthy and below activation floors."""
+    pid = get_or_create_project(conn, root, name="copyclip-clean")
+    # Very recent human review so review_staleness stays below its activation floor.
+    _recent_human = 1_714_400_000.0
+    files = [
+        ("src/copyclip/ok/one.py", "copyclip.ok", 4.0, 0.0, _recent_human),
+        ("src/copyclip/ok/two.py", "copyclip.ok", 2.0, 0.0, _recent_human),
+        ("tests/copyclip/ok/test_one.py", "tests", 1.0, 0.0, _recent_human),
+        ("tests/copyclip/ok/test_two.py", "tests", 1.0, 0.0, _recent_human),
+    ]
+    for path, module, debt, ratio, last_human in files:
+        conn.execute(
+            "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+            (pid, path, "python", 600, 1.0, f"h-{path}"),
+        )
+        conn.execute(
+            "INSERT INTO analysis_file_insights(project_id,path,module,imports_json,complexity,cognitive_debt,agent_line_ratio,last_human_ts) VALUES(?,?,?,?,?,?,?,?)",
+            (pid, path, module, "[]", 4, debt, ratio, last_human),
+        )
+    conn.execute(
+        "INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)",
+        (pid, "Keep ok module simple", "Simplicity is the point.", "accepted", "manual"),
+    )
+    conn.execute("INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)", (1, "file", "src/copyclip/ok/one.py"))
+    conn.execute("INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)", (1, "file", "src/copyclip/ok/two.py"))
+    conn.commit()
+    return pid
+
+
+def seed_greenfield_project(conn, root: str) -> int:
+    """A new project with no blame data — factors that need blame go unavailable."""
+    pid = get_or_create_project(conn, root, name="copyclip-greenfield")
+    for path in ["src/copyclip/new/alpha.py", "src/copyclip/new/beta.py"]:
+        conn.execute(
+            "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+            (pid, path, "python", 400, 1.0, f"h-{path}"),
+        )
+        conn.execute(
+            "INSERT INTO analysis_file_insights(project_id,path,module,imports_json,complexity,cognitive_debt,agent_line_ratio,last_human_ts) VALUES(?,?,?,?,?,?,?,?)",
+            (pid, path, "copyclip.new", "[]", 3, 0.0, None, None),
+        )
+    conn.commit()
+    return pid
+
+
+STABLE_NOW_TS: float = 1_714_500_000.0  # ~2026-04-30 UTC for deterministic age computations
+
+
+def debt_counts_by_severity(factor_list: list[dict[str, Any]]) -> dict[str, int]:
+    """Handy helper for tests asserting how many factors landed in each severity bucket."""
+    counts = {"low": 0, "medium": 0, "high": 0, "critical": 0, "unavailable": 0}
+    for factor in factor_list:
+        if not factor.get("signal_available"):
+            counts["unavailable"] += 1
+            continue
+        value = factor.get("normalized_contribution") or 0
+        if value >= 75:
+            counts["critical"] += 1
+        elif value >= 50:
+            counts["high"] += 1
+        elif value >= 25:
+            counts["medium"] += 1
+        else:
+            counts["low"] += 1
+    return counts

--- a/tests/test_cognitive_debt_contract.py
+++ b/tests/test_cognitive_debt_contract.py
@@ -1,0 +1,106 @@
+"""Contract invariants for the cognitive debt factor model.
+
+Pins weights, severity thresholds, confidence thresholds, and the clamp
+invariant so later weight tuning cannot silently break the public contract
+described in ``docs/COGNITIVE_DEBT_CONTRACT.md``.
+"""
+
+import pytest
+
+from copyclip.intelligence.cognitive_debt import (
+    COGNITIVE_DEBT_FACTORS,
+    CONTRACT_VERSION,
+    SEVERITY_BUCKETS,
+    _confidence_for,
+    _severity_for,
+    build_debt_breakdown,
+)
+from copyclip.intelligence.db import connect, init_schema
+
+from tests.fixtures.cog_debt_fixtures import STABLE_NOW_TS, seed_mixed_debt_project
+
+
+def test_factor_weights_sum_to_one():
+    total = sum(f["weight"] for f in COGNITIVE_DEBT_FACTORS)
+    assert abs(total - 1.0) < 1e-9
+
+
+def test_factor_ids_are_unique():
+    ids = [f["id"] for f in COGNITIVE_DEBT_FACTORS]
+    assert len(ids) == len(set(ids))
+
+
+def test_severity_buckets_cover_zero_to_hundred_without_gaps():
+    # SEVERITY_BUCKETS is ordered with critical first (highest threshold) → low
+    ordered = sorted(SEVERITY_BUCKETS, key=lambda entry: entry[1])
+    thresholds = [entry[1] for entry in ordered]
+    assert thresholds[0] == 0.0
+    # strictly increasing thresholds (no duplicates)
+    assert all(later > earlier for earlier, later in zip(thresholds, thresholds[1:]))
+
+
+@pytest.mark.parametrize("value,expected", [
+    (0.0, "low"),
+    (24.0, "low"),
+    (25.0, "medium"),
+    (49.9, "medium"),
+    (50.0, "high"),
+    (74.0, "high"),
+    (75.0, "critical"),
+    (100.0, "critical"),
+])
+def test_severity_mapping_matches_contract(value, expected):
+    assert _severity_for(value) == expected
+
+
+@pytest.mark.parametrize("coverage,expected", [
+    (0.0, "low"),
+    (0.59, "low"),
+    (0.6, "medium"),
+    (0.84, "medium"),
+    (0.85, "high"),
+    (1.0, "high"),
+])
+def test_confidence_mapping_matches_contract(coverage, expected):
+    assert _confidence_for(coverage) == expected
+
+
+def test_contract_version_is_exposed_on_breakdown(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=STABLE_NOW_TS)
+    conn.close()
+    assert breakdown["meta"]["contract_version"] == CONTRACT_VERSION
+
+
+def test_score_stays_in_bounds_across_scopes(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    for scope_kind, scope_id in [
+        ("file", "src/copyclip/mcp_server.py"),
+        ("file", "src/copyclip/ask/answer.py"),
+        ("file", "src/copyclip/new_module.py"),
+        ("module", "copyclip.mcp"),
+        ("project", "copyclip"),
+    ]:
+        breakdown = build_debt_breakdown(conn, pid, scope_kind, scope_id, now_ts=STABLE_NOW_TS)
+        assert 0.0 <= breakdown["score"]["value"] <= 100.0
+        assert breakdown["score"]["severity"] in {"low", "medium", "high", "critical"}
+        assert breakdown["score"]["confidence"] in {"low", "medium", "high"}
+    conn.close()
+
+
+def test_weighted_contribution_matches_weight_times_normalized(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=STABLE_NOW_TS)
+    conn.close()
+    for factor in breakdown["factor_breakdown"]:
+        if not factor["signal_available"]:
+            assert factor["weighted_contribution"] == 0.0
+            continue
+        expected = round(factor["weight"] * factor["normalized_contribution"], 4)
+        assert abs(factor["weighted_contribution"] - expected) < 1e-9

--- a/tests/test_debt_scenarios.py
+++ b/tests/test_debt_scenarios.py
@@ -1,0 +1,133 @@
+"""End-to-end debt scenarios across scoring, recommendations, and integrations.
+
+Each test runs ``build_debt_breakdown`` followed by ``build_remediation_plan`` on a
+realistic fixture and asserts the verdict + recommendation mapping against the
+narrative we expect from the contract.
+"""
+
+from copyclip.intelligence.cognitive_debt import build_debt_breakdown, quick_debt_signal
+from copyclip.intelligence.debt_remediation import REMEDIATION_ACTION_TYPES, build_remediation_plan
+from copyclip.intelligence.db import connect, init_schema
+
+from tests.fixtures.cog_debt_fixtures import (
+    STABLE_NOW_TS,
+    seed_clean_project,
+    seed_greenfield_project,
+    seed_mixed_debt_project,
+)
+
+
+def test_critical_dark_file_produces_high_severity_and_multiple_remediations(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=STABLE_NOW_TS)
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    assert breakdown["score"]["severity"] in {"high", "critical"}
+    assert len(plan["remediation_candidates"]) >= 2
+    action_types = {c["action_type"] for c in plan["remediation_candidates"]}
+    assert "review_this_recent_change" in action_types
+    # scope is in declared decision link; decision_gap factor should be suppressed → no link candidate
+    assert "link_or_resolve_decision" not in action_types
+
+
+def test_healthy_file_in_mixed_project_returns_no_action_needed(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_clean_project(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/ok/one.py", now_ts=STABLE_NOW_TS)
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    assert breakdown["score"]["severity"] == "low"
+    assert plan["remediation_candidates"] == []
+    assert any(note.get("kind") == "no_action_needed" for note in plan["notes"])
+
+
+def test_greenfield_file_lowers_confidence_without_zeroing_score(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_greenfield_project(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/new/alpha.py", now_ts=STABLE_NOW_TS)
+    conn.close()
+
+    # blame-dependent factors unavailable
+    unavailable = {f["factor_id"] for f in breakdown["factor_breakdown"] if not f["signal_available"]}
+    assert "agent_authored_ratio" in unavailable
+    assert "review_staleness" in unavailable
+    # confidence must drop below "high"
+    assert breakdown["score"]["confidence"] in {"low", "medium"}
+    # score still bounded and defined
+    assert 0.0 <= breakdown["score"]["value"] <= 100.0
+
+
+def test_module_breakdown_severity_tracks_worst_file_when_relevant(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    module_breakdown = build_debt_breakdown(conn, pid, "module", "copyclip.mcp", now_ts=STABLE_NOW_TS)
+    file_breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=STABLE_NOW_TS)
+    conn.close()
+
+    # mcp module only contains mcp_server; module score should be close to file score
+    assert abs(module_breakdown["score"]["value"] - file_breakdown["score"]["value"]) < 5.0
+    assert module_breakdown["meta"]["scope_kind"] == "module"
+
+
+def test_remediation_action_types_are_valid_for_mixed_scope(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    for scope_id in ["src/copyclip/mcp_server.py", "src/copyclip/ask/answer.py", "src/copyclip/new_module.py"]:
+        breakdown = build_debt_breakdown(conn, pid, "file", scope_id, now_ts=STABLE_NOW_TS)
+        plan = build_remediation_plan(conn, pid, breakdown)
+        for candidate in plan["remediation_candidates"]:
+            assert candidate["action_type"] in REMEDIATION_ACTION_TYPES
+            assert candidate["expected_impact"]["score_delta"] <= 0
+    conn.close()
+
+
+def test_quick_debt_signal_matches_full_breakdown_severity(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    for path in ["src/copyclip/mcp_server.py", "src/copyclip/ask/answer.py"]:
+        quick = quick_debt_signal(conn, pid, path)
+        full = build_debt_breakdown(conn, pid, "file", path, now_ts=STABLE_NOW_TS)
+        # severity should be stable: quick uses the stored cognitive_debt column, full recomputes from factors.
+        # Under the v1 contract the two may disagree by at most one bucket; we assert same severity for the
+        # critical-dark file which is the most important case for prioritization.
+        if path == "src/copyclip/mcp_server.py":
+            assert quick["severity"] == "critical"
+            assert full["score"]["severity"] in {"critical", "high"}
+    conn.close()
+
+
+def test_read_first_anchor_prefers_human_commit(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=STABLE_NOW_TS)
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    if plan["read_first"]:
+        first = plan["read_first"][0]
+        if first["kind"] == "commit":
+            # when read_first leads with a commit, it should be the human anchor
+            assert first.get("author_kind") == "human"
+
+
+def test_low_debt_project_surfaces_empty_plan_but_keeps_meta(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_clean_project(conn, str(tmp_path))
+    breakdown = build_debt_breakdown(conn, pid, "project", "copyclip-clean", now_ts=STABLE_NOW_TS)
+    plan = build_remediation_plan(conn, pid, breakdown)
+    conn.close()
+
+    assert plan["meta"]["scope_kind"] == "project"
+    assert plan["remediation_candidates"] == []
+    assert any(note.get("kind") == "no_action_needed" for note in plan["notes"])


### PR DESCRIPTION
## Summary
- adds \`tests/fixtures/cog_debt_fixtures.py\` with three representative scenarios: critical-dark file, healthy file, greenfield (no blame). Plus a \`debt_counts_by_severity\` helper for future assertions.
- adds \`tests/test_cognitive_debt_contract.py\` pinning factor weights to exactly 1.0, verifying severity buckets cover [0, 100] without gaps, mapping severity / confidence thresholds to the contract table, asserting \`weighted_contribution = weight * normalized\`, and confirming \`contract_version\` is exposed on breakdowns.
- adds \`tests/test_debt_scenarios.py\` running breakdown + remediation pipeline end to end: critical dark file → high/critical severity with multiple candidates and no spurious decision-link suggestion; healthy file → \`no_action_needed\`; greenfield → confidence drops but score stays bounded; module scope tracks worst file; action types stay inside the registry across scopes; read_first anchor prefers the human commit; project-scope clean plan keeps meta plus the \`no_action_needed\` note.

Closes #52 and completes the cognitive debt navigator epic #19.

## Test plan
- [x] \`pytest\` — 278 passed, 1 skipped (+28 new)
- [x] contract weights / thresholds / confidence pinned so future tuning surfaces regressions immediately
- [x] scenario tests cover the three canonical shapes from \`docs/COGNITIVE_DEBT_CONTRACT.md\`