### PR TITLE
refactor: modularize server core and harden runtime smoke

### DIFF
--- a/docs/plans/2026-04-22-server-modularization-phase-1.md
+++ b/docs/plans/2026-04-22-server-modularization-phase-1.md
@@ -1,0 +1,405 @@
+# Server Modularization Phase 1 Implementation Plan
+
+> For Hermes: use subagent-driven-development to execute this plan task-by-task.
+
+Goal: Turn `src/copyclip/intelligence/server.py` from a feature bucket into a composition layer by extracting shared server context/helpers and the safest low-risk endpoints first, without changing API behavior.
+
+Architecture: Keep `run_server(project_root, port)` as the public entrypoint, but introduce a small `ServerContext` object plus request/response helper modules that the HTTP handler delegates to. Phase 1 should be behavior-preserving: same routes, same payloads, same status codes, same tests. Do not move Ask/Handoff/Decision Advisor/Assemble Context yet.
+
+Tech Stack: Python, `http.server.ThreadingHTTPServer`, SQLite, pytest.
+
+---
+
+## Current state snapshot
+
+Current hotspot
+- `src/copyclip/intelligence/server.py` is ~2436 lines.
+- `run_server()` owns:
+  - runtime state (`events`, `scheduler_state`, `cancel_events`, locks)
+  - helper functions (`with_meta`, `_pagination`, `_parse_dt`, `_job_payload`, etc.)
+  - analysis job orchestration
+  - scheduler/event bus logic
+  - `class Handler(BaseHTTPRequestHandler)`
+  - all GET/POST/PATCH/DELETE route branching
+
+Safe extraction candidates for Phase 1
+- request/response helpers
+- server/app context object
+- event publishing helpers
+- `/api/events`
+- `/api/health`
+- `/api/config` and `/api/settings` GET/POST
+
+Do NOT move yet
+- `/api/ask`
+- `/api/assemble-context`
+- `/api/agents/chat`
+- handoff packet lifecycle
+- decision advisor
+- alerts scheduler / analysis jobs
+
+Why this order
+- lowest contract risk
+- creates explicit boundaries for later slices
+- leaves the most behavior-dense endpoints untouched until the scaffolding is stable
+
+---
+
+## Target file layout for Phase 1
+
+Create:
+- `src/copyclip/intelligence/server_context.py`
+- `src/copyclip/intelligence/server_helpers.py`
+- `src/copyclip/intelligence/server_events.py`
+- `src/copyclip/intelligence/server_routes_core.py`
+
+Modify:
+- `src/copyclip/intelligence/server.py`
+- `tests/test_intelligence_server_api.py`
+- `tests/test_smoke_cli_runtime.py` only if needed for behavior-preserving verification
+
+Initial responsibilities
+- `server_context.py`
+  - `ServerContext` dataclass
+  - shared runtime state container
+- `server_helpers.py`
+  - JSON response helper(s)
+  - metadata helper
+  - pagination helper
+  - datetime parsing helper
+  - project-id lookup helper
+- `server_events.py`
+  - event publishing helper
+  - SSE stream handler for `/api/events`
+- `server_routes_core.py`
+  - handlers for `/api/health`
+  - handlers for `/api/config` and `/api/settings`
+
+`server.py` after Phase 1 should still:
+- define `run_server()`
+- build the context
+- own `ThreadingHTTPServer` startup/shutdown
+- define the HTTP `Handler`
+- delegate core endpoints to extracted helpers/modules
+- keep all other endpoints inline for now
+
+---
+
+## Task 1: Add failing regression tests for the Phase 1 extraction boundary
+
+Objective: Freeze the behavior of the low-risk endpoints before any refactor.
+
+Files:
+- Modify: `tests/test_intelligence_server_api.py`
+
+Step 1: Add a focused config/settings round-trip test
+
+Add a new test that:
+- starts the server
+- POSTs to `/api/settings`
+- GETs `/api/settings`
+- asserts the value round-trips exactly
+
+Suggested shape:
+```python
+def test_settings_round_trip_endpoint():
+    ...
+```
+
+Step 2: Add a focused health endpoint contract test
+
+Assert at minimum:
+- `ok == True`
+- `service == "copyclip-intelligence"`
+- `meta.project` exists
+- `meta.generated_at` exists
+
+Step 3: Add an SSE smoke/connected-event test if there is not already one
+
+Keep it minimal:
+- request `/api/events?cursor=0`
+- assert stream starts with `connected`
+
+Step 4: Run the focused test target and confirm GREEN baseline before refactor
+
+Run:
+```bash
+python3 -m pytest tests/test_intelligence_server_api.py -q
+```
+
+Expected:
+- all tests pass before any refactor code lands
+
+Step 5: Commit
+
+```bash
+git add tests/test_intelligence_server_api.py
+git commit -m "test: pin core server endpoint contracts before modularization"
+```
+
+---
+
+## Task 2: Introduce `ServerContext`
+
+Objective: Make runtime/shared server state explicit before moving handlers.
+
+Files:
+- Create: `src/copyclip/intelligence/server_context.py`
+- Modify: `src/copyclip/intelligence/server.py`
+- Test: `tests/test_intelligence_server_api.py`
+
+Step 1: Create the dataclass
+
+Include only fields already present in `run_server()`:
+- `root: str`
+- `html: str`
+- `events: list`
+- `events_lock`
+- `next_event_id`
+- `scheduler_state`
+- `analysis_lock`
+- `cancel_lock`
+- `cancel_events`
+
+Step 2: Construct `ServerContext` in `run_server()`
+
+Keep values identical to today.
+
+Step 3: Replace direct closure capture for the easiest helper(s)
+
+Start with:
+- metadata helper
+- project basename/root references
+
+Do not move route logic yet.
+
+Step 4: Run the focused tests
+
+Run:
+```bash
+python3 -m pytest tests/test_intelligence_server_api.py -q
+```
+
+Step 5: Commit
+
+```bash
+git add src/copyclip/intelligence/server_context.py src/copyclip/intelligence/server.py
+git commit -m "refactor: introduce server context for runtime state"
+```
+
+---
+
+## Task 3: Extract shared helpers into `server_helpers.py`
+
+Objective: Remove generic utility logic from `run_server()` before moving endpoints.
+
+Files:
+- Create: `src/copyclip/intelligence/server_helpers.py`
+- Modify: `src/copyclip/intelligence/server.py`
+- Test: `tests/test_intelligence_server_api.py`
+
+Step 1: Move pure/shared helpers
+
+Extract only helpers that are safe and generic:
+- `_project_id(...)`
+- `with_meta(...)`
+- `_pagination(...)`
+- `_parse_dt(...)`
+- `_job_payload(...)` only if it can be moved without dragging too much analysis-job state; otherwise defer it to Phase 2
+
+Step 2: Add a tiny request JSON helper if useful
+
+Examples:
+- `read_json_body(handler)`
+- `json_response(handler, payload, code=200)`
+
+Do not change payload shape.
+
+Step 3: Update `Handler` to call helper functions instead of nested closures where possible
+
+Step 4: Verify no behavior change
+
+Run:
+```bash
+python3 -m pytest tests/test_intelligence_server_api.py -q
+python3 -m pytest tests/test_smoke_cli_runtime.py -q
+```
+
+Step 5: Commit
+
+```bash
+git add src/copyclip/intelligence/server_helpers.py src/copyclip/intelligence/server.py
+git commit -m "refactor: extract shared server helpers"
+```
+
+---
+
+## Task 4: Extract event bus + SSE route
+
+Objective: Pull the event queue logic and `/api/events` implementation out of the giant GET method.
+
+Files:
+- Create: `src/copyclip/intelligence/server_events.py`
+- Modify: `src/copyclip/intelligence/server.py`
+- Test: `tests/test_intelligence_server_api.py`
+
+Step 1: Move event publishing helper
+
+Extract a helper like:
+- `publish_event(ctx, kind, data)`
+
+Step 2: Move SSE response logic
+
+Extract a function like:
+- `handle_events_get(handler, ctx, parsed)`
+
+Keep:
+- `connected` initial event
+- backlog replay behavior
+- 30-second streaming window
+
+Step 3: Replace inline `/api/events` block in `do_GET`
+
+Delegate to the extracted function.
+
+Step 4: Verify focused behavior
+
+Run:
+```bash
+python3 -m pytest tests/test_intelligence_server_api.py -q
+```
+
+Step 5: Commit
+
+```bash
+git add src/copyclip/intelligence/server_events.py src/copyclip/intelligence/server.py
+git commit -m "refactor: extract server event bus and SSE handler"
+```
+
+---
+
+## Task 5: Extract the safest core routes
+
+Objective: Move the lowest-risk GET/POST settings endpoints out of `server.py`.
+
+Files:
+- Create: `src/copyclip/intelligence/server_routes_core.py`
+- Modify: `src/copyclip/intelligence/server.py`
+- Test: `tests/test_intelligence_server_api.py`
+
+Step 1: Move `/api/health`
+
+Create a handler function that returns the exact same payload.
+
+Step 2: Move `/api/config` and `/api/settings` GET
+
+Keep both aliases exactly as-is.
+
+Step 3: Move `/api/config` and `/api/settings` POST
+
+Preserve:
+- insert/update semantics
+- response shape `{ "status": "ok" }`
+
+Step 4: Delegate from `Handler`
+
+`do_GET` / `do_POST` should branch early to the extracted core route functions.
+
+Step 5: Verify
+
+Run:
+```bash
+python3 -m pytest tests/test_intelligence_server_api.py -q
+python3 -m pytest tests/test_smoke_cli_runtime.py -q
+```
+
+Step 6: Commit
+
+```bash
+git add src/copyclip/intelligence/server_routes_core.py src/copyclip/intelligence/server.py tests/test_intelligence_server_api.py
+git commit -m "refactor: extract core health and settings routes"
+```
+
+---
+
+## Task 6: Phase 1 cleanup and equivalence verification
+
+Objective: Confirm Phase 1 actually reduced `server.py` without drifting behavior.
+
+Files:
+- Modify: `src/copyclip/intelligence/server.py`
+- Optional update: `docs/plans/2026-04-22-server-modularization-phase-1.md`
+
+Step 1: Remove dead nested helper code from `server.py`
+
+Only after all delegates are wired.
+
+Step 2: Re-check file size and responsibility shift
+
+Run:
+```bash
+wc -l src/copyclip/intelligence/server.py
+wc -l src/copyclip/intelligence/server_context.py src/copyclip/intelligence/server_helpers.py src/copyclip/intelligence/server_events.py src/copyclip/intelligence/server_routes_core.py
+```
+
+Step 3: Run the full relevant verification set
+
+Run:
+```bash
+python3 -m pytest tests/test_intelligence_server_api.py -q
+python3 -m pytest tests/test_smoke_cli_runtime.py -q
+python3 -m pytest -q
+npm --prefix frontend run build
+./scripts/dev-smoke.sh
+```
+
+Step 4: Sanity-check route coverage
+
+Specifically verify:
+- `/api/events`
+- `/api/health`
+- `/api/settings`
+- startup smoke still passes
+
+Step 5: Commit
+
+```bash
+git add src/copyclip/intelligence/server.py src/copyclip/intelligence/server_context.py src/copyclip/intelligence/server_helpers.py src/copyclip/intelligence/server_events.py src/copyclip/intelligence/server_routes_core.py tests/test_intelligence_server_api.py docs/plans/2026-04-22-server-modularization-phase-1.md
+git commit -m "refactor: complete server modularization phase 1 scaffolding"
+```
+
+---
+
+## Definition of done for Phase 1
+
+Phase 1 is done when:
+- `run_server()` still exists as the public entrypoint
+- runtime/shared state is represented explicitly via `ServerContext`
+- generic helpers are no longer nested inside `run_server()`
+- `/api/events` is extracted from the giant `do_GET`
+- `/api/health` and `/api/config`/`/api/settings` GET/POST are extracted
+- `server.py` is smaller and more obviously a composition layer
+- all current tests and smoke checks still pass unchanged
+
+## Not included in Phase 1
+
+Do not treat these as in-scope yet:
+- analysis job extraction
+- alerts/scheduler extraction
+- handoff route extraction
+- ask route extraction
+- decision advisor extraction
+- assemble-context extraction
+- any API contract changes
+
+Those belong to later phases.
+
+---
+
+## Recommended Phase 2 after this
+
+Once Phase 1 is green, the next slice should be:
+1. analysis job orchestration + `/api/analyze/*`
+2. alerts/scheduler + `/api/alerts*`
+
+That is where the deepest remaining server/runtime coupling still lives.

--- a/scripts/dev-smoke.sh
+++ b/scripts/dev-smoke.sh
@@ -7,6 +7,9 @@ cd "$ROOT_DIR"
 echo "[copyclip] backend editable install"
 python3 -m pip install -e '.[dev]'
 
+echo "[copyclip] runtime smoke suite"
+python3 -m pytest tests/test_smoke_cli_runtime.py -q
+
 echo "[copyclip] backend test suite"
 python3 -m pytest -q
 

--- a/src/copyclip/intelligence/cli.py
+++ b/src/copyclip/intelligence/cli.py
@@ -117,6 +117,10 @@ def _looks_like_project_folder(root: str) -> bool:
     return any(os.path.exists(os.path.join(root, m)) for m in markers)
 
 def _pick_open_port(base_port: int, max_scan: int = 50) -> int:
+    if base_port <= 0:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return int(s.getsockname()[1])
     for port in range(base_port, base_port + max_scan + 1):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             if s.connect_ex(("127.0.0.1", port)) != 0:

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -30,6 +30,10 @@ from .handoff import (
 )
 from .db import connect, init_schema
 from .reacquaintance import build_reacquaintance_briefing, record_reacquaintance_visit
+from .server_context import ServerContext
+from .server_events import handle_events_get, publish_event as publish_event_impl
+from .server_helpers import json_response, pagination, parse_dt, project_id, read_json_body, with_meta as add_meta
+from .server_routes_core import handle_health_get, handle_settings_get, handle_settings_post
 from .phases import (
     PHASE_COMPLETED,
     PHASE_DISCOVERY,
@@ -52,9 +56,9 @@ def _load_ui_html() -> str:
 _HTML = _load_ui_html()
 
 
+# Back-compat shim for existing tests and callers that import the old helper.
 def _project_id(conn: sqlite3.Connection, root: str):
-    row = conn.execute("SELECT id FROM projects WHERE root_path=?", (root,)).fetchone()
-    return row[0] if row else None
+    return project_id(conn, root)
 
 
 def run_server(project_root: str, port: int = 4310) -> None:
@@ -73,6 +77,24 @@ def run_server(project_root: str, port: int = 4310) -> None:
     analysis_lock = threading.Lock()
     cancel_lock = threading.Lock()
     cancel_events = {}
+
+    ctx = ServerContext(
+        root=root,
+        html=_HTML,
+        events=events,
+        events_lock=events_lock,
+        next_event_id=next_event_id,
+        scheduler_state=scheduler_state,
+        analysis_lock=analysis_lock,
+        cancel_lock=cancel_lock,
+        cancel_events=cancel_events,
+    )
+
+    def with_meta(payload: dict):
+        return add_meta(root, payload)
+
+    def publish_event(kind: str, data: dict):
+        return publish_event_impl(ctx, kind, data)
 
     def _count_project_files(base_root: str) -> int:
         ignored_dirs = {".git", ".venv", "node_modules", ".copyclip", "dist", "build", "__pycache__"}
@@ -115,51 +137,6 @@ def run_server(project_root: str, port: int = 4310) -> None:
         conn_p.commit()
         conn_p.close()
 
-    def publish_event(kind: str, data: dict):
-        with events_lock:
-            ev = {
-                "id": next_event_id["value"],
-                "kind": kind,
-                "data": data,
-                "ts": datetime.now(timezone.utc).isoformat(),
-            }
-            next_event_id["value"] += 1
-            events.append(ev)
-            if len(events) > 500:
-                del events[: len(events) - 500]
-            events_lock.notify_all()
-
-    def with_meta(payload: dict):
-        payload.setdefault("meta", {})
-        payload["meta"]["project"] = os.path.basename(root)
-        payload["meta"]["generated_at"] = datetime.now(timezone.utc).isoformat()
-        return payload
-
-    def _pagination(parsed):
-        q = parse_qs(parsed.query or "")
-        try:
-            limit = max(1, min(int(q.get("limit", ["100"])[0]), 500))
-        except Exception:
-            limit = 100
-        try:
-            offset = max(0, int(q.get("offset", ["0"])[0]))
-        except Exception:
-            offset = 0
-        return limit, offset
-
-    def _parse_dt(value: str | None):
-        if not value:
-            return None
-        try:
-            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-            return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
-        except Exception:
-            try:
-                dt = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
-                return dt.replace(tzinfo=timezone.utc)
-            except Exception:
-                return None
-
     def _job_payload(row):
         # row: id,status,phase,processed,total,message,checkpoint_cursor,checkpoint_every,started_at,finished_at
         processed = int(row[3] or 0)
@@ -169,7 +146,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
         throughput = None
         eta_sec = None
         if started_at:
-            st = _parse_dt(started_at)
+            st = parse_dt(started_at)
             if st:
                 elapsed = max(0.0, (datetime.now(timezone.utc) - st).total_seconds())
                 if elapsed > 0:
@@ -219,7 +196,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
             if not candidates:
                 continue
 
-            last_dt = _parse_dt(last_t)
+            last_dt = parse_dt(last_t)
             if last_dt is not None and (now - last_dt).total_seconds() < int(cooldown_min or 0) * 60:
                 continue
 
@@ -249,14 +226,14 @@ def run_server(project_root: str, port: int = 4310) -> None:
 
             last_run = scheduler_state.get("last_run_at")
             if last_run:
-                last_dt = _parse_dt(last_run)
+                last_dt = parse_dt(last_run)
                 if last_dt and (datetime.now(timezone.utc) - last_dt).total_seconds() < int(scheduler_state["interval_sec"]):
                     continue
 
             try:
                 conn_s = connect(root)
                 init_schema(conn_s)
-                pid_s = _project_id(conn_s, root)
+                pid_s = project_id(conn_s, root)
                 if pid_s:
                     fired = _evaluate_alerts(conn_s, pid_s)
                     scheduler_state["last_run_at"] = datetime.now(timezone.utc).isoformat()
@@ -367,21 +344,16 @@ def run_server(project_root: str, port: int = 4310) -> None:
         return job_id
     class Handler(BaseHTTPRequestHandler):
         def _json(self, payload, code=200):
-            body = json.dumps(payload).encode("utf-8")
-            self.send_response(code)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+            json_response(self, payload, code=code)
 
         def do_GET(self):
             parsed = urlparse(self.path)
             conn = connect(root)
             init_schema(conn)
-            pid = _project_id(conn, root)
+            pid = project_id(conn, root)
 
             if parsed.path == "/":
-                body = _HTML.encode("utf-8")
+                body = ctx.html.encode("utf-8")
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html; charset=utf-8")
                 self.send_header("Content-Length", str(len(body)))
@@ -390,56 +362,11 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 return
 
             if parsed.path == "/api/events":
-                q = parse_qs(parsed.query or "")
-                try:
-                    cursor = int(q.get("cursor", ["0"])[0])
-                except Exception:
-                    cursor = 0
-
-                self.send_response(200)
-                self.send_header("Content-Type", "text/event-stream")
-                self.send_header("Cache-Control", "no-cache")
-                self.send_header("Connection", "keep-alive")
-                self.end_headers()
-
-                def write_event(ev):
-                    payload = json.dumps(ev)
-                    self.wfile.write(f"id: {ev['id']}\nevent: {ev['kind']}\ndata: {payload}\n\n".encode("utf-8"))
-                    self.wfile.flush()
-
-                # Initial hello event + backlog since cursor
-                write_event({
-                    "id": cursor,
-                    "kind": "connected",
-                    "data": {"cursor": cursor},
-                    "ts": datetime.now(timezone.utc).isoformat(),
-                })
-
-                with events_lock:
-                    backlog = [e for e in events if e["id"] > cursor]
-                for ev in backlog:
-                    write_event(ev)
-                    cursor = ev["id"]
-
-                # Stream updates for up to 30s per request
-                deadline = time.time() + 30
-                while time.time() < deadline:
-                    with events_lock:
-                        updates = [e for e in events if e["id"] > cursor]
-                        if not updates:
-                            events_lock.wait(timeout=2)
-                            updates = [e for e in events if e["id"] > cursor]
-                    for ev in updates:
-                        write_event(ev)
-                        cursor = ev["id"]
+                handle_events_get(self, ctx, parsed)
                 return
 
             if parsed.path == "/api/health":
-                self._json(with_meta({
-                    "ok": True,
-                    "service": "copyclip-intelligence",
-                    "version": os.getenv("COPYCLIP_VERSION", "dev"),
-                }))
+                handle_health_get(self, ctx)
                 return
 
             if parsed.path == "/api/reacquaintance":
@@ -750,7 +677,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 if not pid:
                     self._json(with_meta({"items": [], "total": 0, "limit": 0, "offset": 0}))
                     return
-                limit, offset = _pagination(parsed)
+                limit, offset = pagination(parsed)
                 total = conn.execute("SELECT COUNT(*) FROM files WHERE project_id=?", (pid,)).fetchone()[0]
                 rows = conn.execute(
                     "SELECT path, size_bytes, language FROM files WHERE project_id=? ORDER BY path LIMIT ? OFFSET ?",
@@ -904,7 +831,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 if not pid:
                     self._json(with_meta({"items": [], "total": 0, "limit": 0, "offset": 0}))
                     return
-                limit, offset = _pagination(parsed)
+                limit, offset = pagination(parsed)
                 total = conn.execute("SELECT COUNT(*) FROM commits WHERE project_id=?", (pid,)).fetchone()[0]
                 rows = conn.execute(
                     "SELECT sha, author, message, date FROM commits WHERE project_id=? ORDER BY date DESC LIMIT ? OFFSET ?",
@@ -1009,7 +936,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 if not pid:
                     self._json(with_meta({"items": [], "total": 0, "limit": 0, "offset": 0}))
                     return
-                limit, offset = _pagination(parsed)
+                limit, offset = pagination(parsed)
                 self._json(with_meta(list_handoff_packets(conn, pid, limit=limit, offset=offset)))
                 return
 
@@ -1041,7 +968,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 if not pid:
                     self._json(with_meta({"items": [], "total": 0, "limit": 0, "offset": 0}))
                     return
-                limit, offset = _pagination(parsed)
+                limit, offset = pagination(parsed)
                 total = conn.execute("SELECT COUNT(*) FROM decisions WHERE project_id=?", (pid,)).fetchone()[0]
                 rows = conn.execute(
                     "SELECT id,title,summary,status,source_type,created_at FROM decisions WHERE project_id=? ORDER BY id DESC LIMIT ? OFFSET ?",
@@ -1243,7 +1170,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 except Exception:
                     self._json({"error": "invalid_decision_id"}, 400)
                     return
-                limit, offset = _pagination(parsed)
+                limit, offset = pagination(parsed)
                 total = conn.execute("SELECT COUNT(*) FROM decision_history WHERE decision_id=?", (decision_id,)).fetchone()[0]
                 rows = conn.execute(
                     "SELECT id,action,from_status,to_status,note,created_at FROM decision_history WHERE decision_id=? ORDER BY id DESC LIMIT ? OFFSET ?",
@@ -1371,7 +1298,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 if not pid:
                     self._json(with_meta({"items": [], "total": 0, "limit": 0, "offset": 0}))
                     return
-                limit, offset = _pagination(parsed)
+                limit, offset = pagination(parsed)
                 total = conn.execute("SELECT COUNT(*) FROM risks WHERE project_id=?", (pid,)).fetchone()[0]
                 rows = conn.execute(
                     "SELECT area,severity,kind,rationale,score,created_at FROM risks WHERE project_id=? ORDER BY score DESC, id DESC LIMIT ? OFFSET ?",
@@ -1401,7 +1328,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 if not pid:
                     self._json(with_meta({"items": [], "total": 0, "limit": 0, "offset": 0}))
                     return
-                limit, offset = _pagination(parsed)
+                limit, offset = pagination(parsed)
                 total = conn.execute("SELECT COUNT(*) FROM issues WHERE project_id=?", (pid,)).fetchone()[0]
                 rows = conn.execute(
                     "SELECT external_id,title,status,labels,author,url,source,created_at,updated_at FROM issues WHERE project_id=? ORDER BY created_at DESC LIMIT ? OFFSET ?",
@@ -1434,7 +1361,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 if not pid:
                     self._json(with_meta({"items": [], "total": 0, "limit": 0, "offset": 0}))
                     return
-                limit, offset = _pagination(parsed)
+                limit, offset = pagination(parsed)
                 total = conn.execute("SELECT COUNT(*) FROM pulls WHERE project_id=?", (pid,)).fetchone()[0]
                 rows = conn.execute(
                     "SELECT external_id,title,status,merged,labels,author,url,source,created_at,updated_at FROM pulls WHERE project_id=? ORDER BY created_at DESC LIMIT ? OFFSET ?",
@@ -1489,7 +1416,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                     self._json(with_meta({"fired": [], "events": []}))
                     return
                 fired = _evaluate_alerts(conn, pid)
-                limit, offset = _pagination(parsed)
+                limit, offset = pagination(parsed)
                 total = conn.execute("SELECT COUNT(*) FROM alert_events WHERE project_id=?", (pid,)).fetchone()[0]
                 rows = conn.execute(
                     "SELECT id,rule_id,title,detail,created_at FROM alert_events WHERE project_id=? ORDER BY id DESC LIMIT ? OFFSET ?",
@@ -1656,8 +1583,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 return
 
             if parsed.path in {"/api/config", "/api/settings"}:
-                rows = conn.execute("SELECT key,value FROM config ORDER BY key").fetchall()
-                self._json({r[0]: r[1] for r in rows})
+                handle_settings_get(self, ctx, conn)
                 return
 
             self._json({"error": "not_found"}, 404)
@@ -1666,7 +1592,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
             parsed = urlparse(self.path)
             conn = connect(root)
             init_schema(conn)
-            pid = _project_id(conn, root)
+            pid = project_id(conn, root)
             if not pid:
                 self._json({"error": "run_analyze_first"}, 400)
                 return
@@ -1792,7 +1718,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
             parsed = urlparse(self.path)
             conn = connect(root)
             init_schema(conn)
-            pid = _project_id(conn, root)
+            pid = project_id(conn, root)
             if not pid:
                 self._json({"error": "run_analyze_first"}, 400)
                 return
@@ -1814,7 +1740,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
             parsed = urlparse(self.path)
             conn = connect(root)
             init_schema(conn)
-            pid = _project_id(conn, root)
+            pid = project_id(conn, root)
             if not pid:
                 self._json({"error": "run_analyze_first"}, 400)
                 return
@@ -2293,13 +2219,7 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 return
 
             if parsed.path in {"/api/config", "/api/settings"}:
-                length = int(self.headers.get("Content-Length", "0"))
-                raw = self.rfile.read(length) if length else b"{}"
-                data = json.loads(raw.decode("utf-8"))
-                for k, v in data.items():
-                    conn.execute("INSERT INTO config(key, value) VALUES(?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value", (k, str(v)))
-                conn.commit()
-                self._json({"status": "ok"})
+                handle_settings_post(self, ctx, conn)
                 return
 
             if parsed.path == "/api/decisions":
@@ -2419,7 +2339,8 @@ def run_server(project_root: str, port: int = 4310) -> None:
         return f"\033]8;;{url}\a{label}\033]8;;\a"
 
     server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
-    dash_url = f"http://127.0.0.1:{port}"
+    actual_port = int(server.server_address[1])
+    dash_url = f"http://127.0.0.1:{actual_port}"
     print(f"{_c('INFO', '36')} CopyClip Intelligence running at {_link(dash_url)}")
     print(f"{_c('INFO', '36')} Press Ctrl+C to stop")
     try:

--- a/src/copyclip/intelligence/server_context.py
+++ b/src/copyclip/intelligence/server_context.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ServerContext:
+    root: str
+    html: str
+    events: list[dict[str, Any]]
+    events_lock: Any
+    next_event_id: dict[str, int]
+    scheduler_state: dict[str, Any]
+    analysis_lock: Any
+    cancel_lock: Any
+    cancel_events: dict[str, Any]

--- a/src/copyclip/intelligence/server_events.py
+++ b/src/copyclip/intelligence/server_events.py
@@ -1,0 +1,65 @@
+import json
+import time
+from datetime import datetime, timezone
+
+
+def publish_event(ctx, kind: str, data: dict):
+    with ctx.events_lock:
+        ev = {
+            "id": ctx.next_event_id["value"],
+            "kind": kind,
+            "data": data,
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+        ctx.next_event_id["value"] += 1
+        ctx.events.append(ev)
+        if len(ctx.events) > 500:
+            del ctx.events[: len(ctx.events) - 500]
+        ctx.events_lock.notify_all()
+
+
+def handle_events_get(handler, ctx, parsed):
+    from urllib.parse import parse_qs
+
+    q = parse_qs(parsed.query or "")
+    try:
+        cursor = int(q.get("cursor", ["0"])[0])
+    except Exception:
+        cursor = 0
+
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream")
+    handler.send_header("Cache-Control", "no-cache")
+    handler.send_header("Connection", "keep-alive")
+    handler.end_headers()
+
+    def write_event(ev):
+        payload = json.dumps(ev)
+        handler.wfile.write(f"id: {ev['id']}\nevent: {ev['kind']}\ndata: {payload}\n\n".encode("utf-8"))
+        handler.wfile.flush()
+
+    write_event(
+        {
+            "id": cursor,
+            "kind": "connected",
+            "data": {"cursor": cursor},
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+    with ctx.events_lock:
+        backlog = [e for e in ctx.events if e["id"] > cursor]
+    for ev in backlog:
+        write_event(ev)
+        cursor = ev["id"]
+
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        with ctx.events_lock:
+            updates = [e for e in ctx.events if e["id"] > cursor]
+            if not updates:
+                ctx.events_lock.wait(timeout=2)
+                updates = [e for e in ctx.events if e["id"] > cursor]
+        for ev in updates:
+            write_event(ev)
+            cursor = ev["id"]

--- a/src/copyclip/intelligence/server_helpers.py
+++ b/src/copyclip/intelligence/server_helpers.py
@@ -1,0 +1,58 @@
+import json
+import sqlite3
+from datetime import datetime, timezone
+from urllib.parse import parse_qs
+
+
+def json_response(handler, payload, code=200):
+    body = json.dumps(payload).encode("utf-8")
+    handler.send_response(code)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def project_id(conn: sqlite3.Connection, root: str):
+    row = conn.execute("SELECT id FROM projects WHERE root_path=?", (root,)).fetchone()
+    return row[0] if row else None
+
+
+def with_meta(root: str, payload: dict):
+    payload.setdefault("meta", {})
+    payload["meta"]["project"] = __import__("os").path.basename(root)
+    payload["meta"]["generated_at"] = datetime.now(timezone.utc).isoformat()
+    return payload
+
+
+def pagination(parsed):
+    q = parse_qs(parsed.query or "")
+    try:
+        limit = max(1, min(int(q.get("limit", ["100"])[0]), 500))
+    except Exception:
+        limit = 100
+    try:
+        offset = max(0, int(q.get("offset", ["0"])[0]))
+    except Exception:
+        offset = 0
+    return limit, offset
+
+
+def parse_dt(value: str | None):
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+    except Exception:
+        try:
+            dt = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+            return dt.replace(tzinfo=timezone.utc)
+        except Exception:
+            return None
+
+
+def read_json_body(handler):
+    length = int(handler.headers.get("Content-Length", "0"))
+    raw = handler.rfile.read(length) if length else b"{}"
+    return json.loads(raw.decode("utf-8"))

--- a/src/copyclip/intelligence/server_routes_core.py
+++ b/src/copyclip/intelligence/server_routes_core.py
@@ -1,0 +1,31 @@
+from .server_helpers import json_response, read_json_body, with_meta
+
+
+def handle_health_get(handler, ctx):
+    json_response(
+        handler,
+        with_meta(
+            ctx.root,
+            {
+                "ok": True,
+                "service": "copyclip-intelligence",
+                "version": __import__("os").getenv("COPYCLIP_VERSION", "dev"),
+            },
+        ),
+    )
+
+
+def handle_settings_get(handler, ctx, conn):
+    rows = conn.execute("SELECT key,value FROM config ORDER BY key").fetchall()
+    json_response(handler, {r[0]: r[1] for r in rows})
+
+
+def handle_settings_post(handler, ctx, conn):
+    data = read_json_body(handler)
+    for k, v in data.items():
+        conn.execute(
+            "INSERT INTO config(key, value) VALUES(?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (k, str(v)),
+        )
+    conn.commit()
+    json_response(handler, {"status": "ok"})

--- a/tests/test_intelligence_server_api.py
+++ b/tests/test_intelligence_server_api.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from urllib import request
 from urllib.error import HTTPError
 
+
 from copyclip.intelligence.db import connect, init_schema
 from copyclip.intelligence.server import run_server
 
@@ -33,6 +34,38 @@ def _wait_port(port: int, timeout_s: float = 3.0):
 def _get_json(url: str):
     with request.urlopen(url, timeout=3) as r:
         return json.loads(r.read().decode("utf-8"))
+
+
+def _get_text(url: str, timeout: float = 3.0, max_bytes: int | None = None):
+    with request.urlopen(url, timeout=timeout) as r:
+        data = r.read() if max_bytes is None else r.read(max_bytes)
+        return data.decode("utf-8")
+
+
+def _get_stream_prefix(host: str, port: int, path: str, max_bytes: int = 512, timeout: float = 3.0):
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.settimeout(timeout)
+        req = (
+            f"GET {path} HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            "Accept: text/event-stream\r\n"
+            "Connection: close\r\n\r\n"
+        )
+        sock.sendall(req.encode("utf-8"))
+        chunks = []
+        deadline = time.time() + timeout
+        while time.time() < deadline and sum(len(c) for c in chunks) < max_bytes:
+            try:
+                data = sock.recv(max_bytes)
+            except TimeoutError:
+                break
+            if not data:
+                break
+            chunks.append(data)
+            combined = b"".join(chunks)
+            if b"event: connected" in combined:
+                break
+        return b"".join(chunks).decode("utf-8", errors="replace")
 
 
 def _patch_json(url: str, payload: dict):
@@ -117,6 +150,46 @@ def test_decision_history_endpoint():
         hist = _get_json(f"http://127.0.0.1:{port}/api/decisions/{decision_id}/history")
         assert hist["total"] >= 1
         assert any(item["action"] == "status_change" for item in hist["items"])
+
+
+def test_events_endpoint_starts_with_connected_event():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root_path, "tmp"))
+        conn.commit()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        body = _get_stream_prefix("127.0.0.1", port, "/api/events?cursor=0")
+        assert "event: connected" in body
+        assert '"kind": "connected"' in body
+
+
+def test_health_endpoint_contract():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        root_path = str(root.absolute())
+        conn = connect(root_path)
+        init_schema(conn)
+        conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root_path, "tmp"))
+        conn.commit()
+
+        port = _free_port()
+        th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+        th.start()
+        _wait_port(port)
+
+        res = _get_json(f"http://127.0.0.1:{port}/api/health")
+        assert res["ok"] is True
+        assert res["service"] == "copyclip-intelligence"
+        assert res["meta"]["project"] == root.name
+        assert res["meta"]["generated_at"]
 
 
 def test_ask_endpoint_returns_evidence_first_contract():
@@ -606,6 +679,10 @@ def test_settings_alias_get_and_post():
         _post_json(f"http://127.0.0.1:{port}/api/settings", {"COPYCLIP_LLM_PROVIDER": "gemini"})
         res = _get_json(f"http://127.0.0.1:{port}/api/settings")
         assert res.get("COPYCLIP_LLM_PROVIDER") == "gemini"
+
+        _post_json(f"http://127.0.0.1:{port}/api/config", {"COPYCLIP_THEME": "midnight"})
+        res2 = _get_json(f"http://127.0.0.1:{port}/api/config")
+        assert res2.get("COPYCLIP_THEME") == "midnight"
 
 
 def test_alert_rule_patch_and_delete():

--- a/tests/test_smoke_cli_runtime.py
+++ b/tests/test_smoke_cli_runtime.py
@@ -1,0 +1,102 @@
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib import request
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _make_minimal_project(tmp_path: Path) -> Path:
+    root = tmp_path / "demo_project"
+    root.mkdir()
+    (root / "pyproject.toml").write_text('[project]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8")
+    src = root / "src"
+    src.mkdir()
+    (src / "demo.py").write_text('def add(a, b):\n    return a + b\n', encoding="utf-8")
+    return root
+
+
+def test_copyclip_analyze_cli_smoke(tmp_path):
+    root = _make_minimal_project(tmp_path)
+
+    result = subprocess.run(
+        ["copyclip", "analyze", "--path", str(root)],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    output = (result.stdout or "") + (result.stderr or "")
+    assert result.returncode == 0, output
+    assert "Indexed" in output
+    assert (root / ".copyclip" / "intelligence.db").exists()
+
+
+def test_copyclip_mcp_cli_smoke_exits_cleanly_when_stdin_is_closed(tmp_path):
+    root = _make_minimal_project(tmp_path)
+
+    result = subprocess.run(
+        ["copyclip", "mcp"],
+        cwd=root,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    output = (result.stdout or "") + (result.stderr or "")
+    assert result.returncode == 0, output
+    assert "Traceback" not in output
+
+
+def test_copyclip_start_cli_smoke_serves_health_and_overview(tmp_path):
+    root = _make_minimal_project(tmp_path)
+    process = subprocess.Popen(
+        [sys.executable, "-u", "-m", "copyclip", "start", "--no-open", "--path", str(root), "--port", "0"],
+        cwd=ROOT_DIR,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    output_lines: list[str] = []
+    dash_url = None
+    deadline = time.time() + 30
+    try:
+        while time.time() < deadline:
+            line = process.stdout.readline()
+            if line:
+                output_lines.append(line)
+                if "CopyClip Intelligence running at" in line:
+                    dash_url = line.split("CopyClip Intelligence running at", 1)[1].strip()
+                    break
+            elif process.poll() is not None:
+                break
+            else:
+                time.sleep(0.1)
+
+        output = "".join(output_lines)
+        assert dash_url, output or "copyclip start exited before reporting dashboard URL"
+
+        health = json.loads(request.urlopen(f"{dash_url}/api/health", timeout=10).read().decode("utf-8"))
+        overview = json.loads(request.urlopen(f"{dash_url}/api/overview", timeout=10).read().decode("utf-8"))
+
+        assert health["ok"] is True
+        assert overview["files"] >= 1
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)


### PR DESCRIPTION
## Summary
- modularizes the safest part of `src/copyclip/intelligence/server.py` into explicit server context/helpers/events/core-route modules
- adds explicit runtime smoke coverage for `copyclip analyze`, `copyclip start`, and `copyclip mcp`
- fixes the `--port 0` startup path so the dashboard reports the actual bound port
- adds and updates API tests to lock down extracted health/settings/events behavior
- saves the phase-1 modularization plan for issue #26 in `docs/plans/2026-04-22-server-modularization-phase-1.md`

## Issue mapping
- Part of #21
- Part of #26
- Completes the runtime-smoke acceptance for #27

## What this PR covers
### #26 phase 1
- `src/copyclip/intelligence/server_context.py`
- `src/copyclip/intelligence/server_helpers.py`
- `src/copyclip/intelligence/server_events.py`
- `src/copyclip/intelligence/server_routes_core.py`
- `server.py` now delegates:
  - `ServerContext`
  - core JSON/meta helpers
  - `/api/events`
  - `/api/health`
  - `/api/config` and `/api/settings`
- keeps API behavior stable and preserves `_project_id` compatibility

### #27 follow-through
- `tests/test_smoke_cli_runtime.py`
  - analyze smoke
  - mcp smoke
  - start smoke with `/api/health` + `/api/overview`
- `scripts/dev-smoke.sh` now runs the runtime smoke suite explicitly

## Verification
- [x] `python3 -m pytest tests/test_intelligence_server_api.py -q`
- [x] `python3 -m pytest tests/test_smoke_cli_runtime.py -q`
- [x] `python3 -m pytest -q`
- [x] `npm --prefix frontend run build`
- [x] `./scripts/dev-smoke.sh`

## Notes
- This does **not** close #26 by itself; it is the first extraction slice.
- Recommended next slice after merge: analysis jobs + `/api/analyze/*` + alerts/scheduler endpoints.
