### PR TITLE
fix: unify /api/cognitive-load score with v1 factor model

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -424,6 +424,7 @@ export type CognitiveLoadItem = {
   decision_linked: boolean
   cognitive_debt_score: number
   fog_level: 'low' | 'med' | 'high'
+  severity?: 'low' | 'medium' | 'high' | 'critical'
 }
 
 export type CognitiveLoadResponse = {

--- a/src/copyclip/intelligence/cognitive_debt.py
+++ b/src/copyclip/intelligence/cognitive_debt.py
@@ -57,6 +57,19 @@ def _severity_for(value: float) -> str:
     return "low"
 
 
+_SEVERITY_TO_FOG: dict[str, str] = {
+    "critical": "high",
+    "high": "high",
+    "medium": "med",
+    "low": "low",
+}
+
+
+def severity_to_fog(severity: str) -> str:
+    """Map a v1 severity bucket to the legacy fog_level vocabulary kept on /api/cognitive-load."""
+    return _SEVERITY_TO_FOG.get(severity, "low")
+
+
 def _confidence_for(signal_coverage: float) -> str:
     if signal_coverage >= 0.85:
         return "high"

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -16,7 +16,7 @@ from urllib.parse import parse_qs, urlparse
 
 from .context_bundle_builder import build_context_bundle
 from .ask_project import build_ask_response
-from .cognitive_debt import build_debt_breakdown
+from .cognitive_debt import build_debt_breakdown, severity_to_fog
 from .debt_remediation import build_remediation_plan
 from .handoff import (
     build_handoff_packet,
@@ -432,76 +432,70 @@ def run_server(project_root: str, port: int = 4310) -> None:
                     return
 
                 if parsed.path == "/api/cognitive-load":
+                    # Serves the v1 factor-model score from build_debt_breakdown
+                    # under the legacy field names. fog_level + decision_linked
+                    # are kept for backward-compat; severity is the v1 vocab.
                     if not pid:
-                        self._json(with_meta({"items": [], "total": 0, "generated_at": None}))
+                        self._json(with_meta({"items": [], "total": 0, "last_review_at": None}))
                         return
 
-                    # Last review proxy = last snapshot timestamp.
                     last_snap = conn.execute(
                         "SELECT generated_at FROM snapshots WHERE project_id=? ORDER BY id DESC LIMIT 1",
                         (pid,),
                     ).fetchone()
                     last_review = last_snap[0] if last_snap else None
 
-                    # Module stats from indexed insights + churn proxy from file_changes.
                     rows = conn.execute(
                         """
-                        SELECT i.module, i.path, COALESCE(i.complexity,0) AS complexity,
+                        SELECT i.module, COALESCE(i.complexity,0) AS complexity,
                                COALESCE((SELECT COUNT(*) FROM file_changes fc WHERE fc.project_id=i.project_id AND fc.file_path=i.path),0) AS churn
                         FROM analysis_file_insights i
-                        WHERE i.project_id=?
+                        WHERE i.project_id=? AND i.module IS NOT NULL AND i.module != ''
                         """,
                         (pid,),
                     ).fetchall()
 
-                    module_map = {}
+                    module_stats: dict[str, dict[str, int]] = {}
                     for r in rows:
-                        module = (r[0] or "root")
-                        complexity = int(r[2] or 0)
-                        churn = int(r[3] or 0)
-                        m = module_map.setdefault(module, {"files": 0, "complexity": 0, "churn": 0})
-                        m["files"] += 1
-                        m["complexity"] += complexity
-                        m["churn"] += churn
+                        module = r[0]
+                        agg = module_stats.setdefault(module, {"files": 0, "complexity": 0, "churn": 0})
+                        agg["files"] += 1
+                        agg["complexity"] += int(r[1] or 0)
+                        agg["churn"] += int(r[2] or 0)
 
-                    # Decision-link coverage proxy per module.
-                    lrows = conn.execute(
+                    decision_link_rows = conn.execute(
                         "SELECT link_type, target_pattern FROM decision_links WHERE project_id=?",
                         (pid,),
                     ).fetchall()
 
-                    items = []
-                    for module, agg in module_map.items():
-                        files = max(1, int(agg["files"]))
-                        avg_complexity = agg["complexity"] / files
-                        churn = int(agg["churn"])
-
-                        covered = False
-                        for lr in lrows:
+                    def _module_decision_linked(module: str) -> bool:
+                        for lr in decision_link_rows:
                             ltype = (lr[0] or "").strip()
                             pattern = (lr[1] or "").strip()
                             if ltype == "module" and pattern == module:
-                                covered = True
-                                break
-                            if ltype == "file_glob" and module != "root" and (module in pattern):
-                                covered = True
-                                break
+                                return True
+                            if ltype == "file_glob" and module in pattern:
+                                return True
+                        return False
 
-                        # CognitiveDebt v1 proxy:
-                        # generated_ratio~churn pressure + complexity pressure, amplified when not decision-linked.
-                        generated_ratio = min(1.0, (churn / max(1, files * 12)) + (avg_complexity / 120.0))
-                        time_factor = 1.0  # snapshot cadence not yet per-module; keep neutral for v1
-                        debt = generated_ratio * time_factor * (1.25 if not covered else 1.0)
-                        score = round(min(100.0, debt * 100.0), 2)
-
+                    items = []
+                    for module, agg in module_stats.items():
+                        try:
+                            breakdown = build_debt_breakdown(conn, pid, "module", module)
+                        except ValueError:
+                            # Module visible in insights but no aggregate rows — skip rather than guess.
+                            continue
+                        files = max(1, int(agg["files"]))
+                        severity = breakdown["score"]["severity"]
                         items.append({
                             "module": module,
                             "files": files,
-                            "churn": churn,
-                            "avg_complexity": round(avg_complexity, 2),
-                            "decision_linked": covered,
-                            "cognitive_debt_score": score,
-                            "fog_level": "high" if score >= 70 else ("med" if score >= 40 else "low"),
+                            "churn": int(agg["churn"]),
+                            "avg_complexity": round(agg["complexity"] / files, 2),
+                            "decision_linked": _module_decision_linked(module),
+                            "cognitive_debt_score": breakdown["score"]["value"],
+                            "severity": severity,
+                            "fog_level": severity_to_fog(severity),
                         })
 
                     items.sort(key=lambda x: x["cognitive_debt_score"], reverse=True)

--- a/tests/test_cognitive_load_unification.py
+++ b/tests/test_cognitive_load_unification.py
@@ -1,0 +1,152 @@
+"""Contract tests for the unified /api/cognitive-load endpoint.
+
+The endpoint used to compute its own proxy score inline. After unification it
+must serve the v1 factor-model score from ``build_debt_breakdown`` while
+preserving the legacy fields the frontend already consumes.
+"""
+
+import json
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+from urllib import request
+
+from copyclip.intelligence import cognitive_debt
+from copyclip.intelligence.cognitive_debt import build_debt_breakdown
+from copyclip.intelligence.db import connect, init_schema
+from copyclip.intelligence.server import run_server
+
+from tests.fixtures.cog_debt_fixtures import STABLE_NOW_TS, seed_mixed_debt_project
+
+
+SEVERITY_TO_FOG = {"critical": "high", "high": "high", "medium": "med", "low": "low"}
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_port(port: int, timeout_s: float = 3.0) -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError("server did not start in time")
+
+
+def _get_json(url: str):
+    with request.urlopen(url, timeout=3) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def _start_server_with_seed(tmp_path: Path, monkeypatch, seed_fn) -> tuple[int, int]:
+    monkeypatch.setattr(cognitive_debt, "_now_ts", lambda: STABLE_NOW_TS)
+    root_path = str(tmp_path)
+    conn = connect(root_path)
+    init_schema(conn)
+    pid = seed_fn(conn, root_path)
+    conn.close()
+    port = _free_port()
+    th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+    th.start()
+    _wait_port(port)
+    return pid, port
+
+
+def test_cognitive_load_score_equals_factor_model_for_each_module(tmp_path, monkeypatch):
+    pid, port = _start_server_with_seed(tmp_path, monkeypatch, seed_mixed_debt_project)
+    payload = _get_json(f"http://127.0.0.1:{port}/api/cognitive-load")
+    items = payload["items"]
+    assert items, "mixed_debt fixture should produce at least one module item"
+
+    conn = connect(str(tmp_path))
+    try:
+        for item in items:
+            module = item["module"]
+            breakdown = build_debt_breakdown(conn, pid, "module", module)
+            assert item["cognitive_debt_score"] == breakdown["score"]["value"], (
+                f"score mismatch for module {module}: "
+                f"endpoint={item['cognitive_debt_score']} factor_model={breakdown['score']['value']}"
+            )
+            assert item["severity"] == breakdown["score"]["severity"], (
+                f"severity mismatch for module {module}"
+            )
+    finally:
+        conn.close()
+
+
+def test_cognitive_load_reaches_high_or_critical_on_mixed_fixture(tmp_path, monkeypatch):
+    _, port = _start_server_with_seed(tmp_path, monkeypatch, seed_mixed_debt_project)
+    payload = _get_json(f"http://127.0.0.1:{port}/api/cognitive-load")
+    severities = {item["severity"] for item in payload["items"]}
+    assert severities & {"high", "critical"}, (
+        f"expected at least one high/critical module on the mixed_debt fixture, got {severities}"
+    )
+
+
+def test_cognitive_load_fog_level_maps_from_severity(tmp_path, monkeypatch):
+    _, port = _start_server_with_seed(tmp_path, monkeypatch, seed_mixed_debt_project)
+    payload = _get_json(f"http://127.0.0.1:{port}/api/cognitive-load")
+    for item in payload["items"]:
+        expected_fog = SEVERITY_TO_FOG[item["severity"]]
+        assert item["fog_level"] == expected_fog, (
+            f"module {item['module']}: severity={item['severity']} -> "
+            f"expected fog={expected_fog}, got {item['fog_level']}"
+        )
+        assert item["fog_level"] in {"low", "med", "high"}
+
+
+def test_cognitive_load_preserves_legacy_fields(tmp_path, monkeypatch):
+    _, port = _start_server_with_seed(tmp_path, monkeypatch, seed_mixed_debt_project)
+    payload = _get_json(f"http://127.0.0.1:{port}/api/cognitive-load")
+    assert payload["items"], "fixture must yield items"
+    for item in payload["items"]:
+        for key in ("module", "files", "churn", "avg_complexity", "decision_linked",
+                    "cognitive_debt_score", "fog_level", "severity"):
+            assert key in item, f"missing legacy/new field {key} on item {item}"
+        assert isinstance(item["files"], int) and item["files"] >= 1
+        assert isinstance(item["churn"], int)
+        assert isinstance(item["avg_complexity"], (int, float))
+        assert isinstance(item["decision_linked"], bool)
+        assert item["severity"] in {"low", "medium", "high", "critical"}
+
+
+def test_cognitive_load_returns_empty_when_no_project(tmp_path, monkeypatch):
+    monkeypatch.setattr(cognitive_debt, "_now_ts", lambda: STABLE_NOW_TS)
+    root_path = str(tmp_path)
+    conn = connect(root_path)
+    init_schema(conn)
+    conn.close()
+    port = _free_port()
+    th = threading.Thread(target=run_server, args=(root_path, port), daemon=True)
+    th.start()
+    _wait_port(port)
+    payload = _get_json(f"http://127.0.0.1:{port}/api/cognitive-load")
+    assert payload["items"] == []
+    assert payload["total"] == 0
+    assert payload["last_review_at"] is None
+
+
+def test_cognitive_load_does_not_use_legacy_proxy_formula(tmp_path, monkeypatch):
+    """Sanity check: at least one module on the mixed fixture should diverge from
+    the legacy proxy. The legacy formula would put copyclip.mcp around the
+    medium band (debt~churn+complexity, capped/decayed by the decision link),
+    whereas the factor model lands it firmly in high/critical territory.
+    """
+    pid, port = _start_server_with_seed(tmp_path, monkeypatch, seed_mixed_debt_project)
+    payload = _get_json(f"http://127.0.0.1:{port}/api/cognitive-load")
+    mcp_items = [it for it in payload["items"] if it["module"] == "copyclip.mcp"]
+    assert mcp_items, "expected copyclip.mcp in the mixed_debt fixture"
+    mcp = mcp_items[0]
+    assert mcp["severity"] in {"high", "critical"}, (
+        f"factor model must mark copyclip.mcp as high/critical (got {mcp['severity']})"
+    )


### PR DESCRIPTION
## Summary
- `/api/cognitive-load` used to compute its own proxy score (churn + complexity pressure, decision-link decay) that capped out short of the critical band, so Reacquaintance (which filters severity in `{high, critical}`) never saw the darkest modules even when the factor model flagged them.
- Replace the inline formula with a per-module call to `build_debt_breakdown` and emit the v1 `severity` alongside the legacy `cognitive_debt_score`/`fog_level` fields the dashboard still reads.
- New `severity_to_fog` helper keeps the legacy fog vocabulary in lock-step with the v1 severity buckets (`critical|high → high`, `medium → med`, `low → low`).

## Why this matters
The factor model in `cognitive_debt.py` is the contract (see `docs/COGNITIVE_DEBT_CONTRACT.md`). The legacy formula was a parallel implementation of the same field name with incompatible semantics. After this change the score served on `/api/cognitive-load` is the same value `build_debt_breakdown(conn, pid, "module", module)["score"]["value"]` returns, so Atlas, Debt Navigator, Architecture, Reacquaintance, and Ask all observe one number.

## Consumers
- `frontend/src/pages/AtlasPage.tsx`, `DebtNavigatorPage.tsx`, `ArchitecturePage.tsx`: unchanged — they keep reading `cognitive_debt_score` and `fog_level`.
- `frontend/src/types/api.ts`: `CognitiveLoadItem.severity?` added as optional so callers can opt in to the v1 vocabulary.
- Empty-pid response now uses `last_review_at: null` (matches the non-empty branch and the existing TS contract); previously it emitted a stray `generated_at` key that no consumer looked at.
- Modules with `module IS NULL` (legacy "root" bucket) are no longer emitted. The current indexer assigns every file to a real module, so this only affects degenerate DBs.

## Tests
- New `tests/test_cognitive_load_unification.py`:
  - `test_cognitive_load_score_equals_factor_model_for_each_module` — per-module equality with `build_debt_breakdown`, no tolerance.
  - `test_cognitive_load_reaches_high_or_critical_on_mixed_fixture` — proves the proxy ceiling is gone.
  - `test_cognitive_load_fog_level_maps_from_severity` — severity → fog mapping.
  - `test_cognitive_load_preserves_legacy_fields` — backward-compat for the dashboard payload.
  - `test_cognitive_load_returns_empty_when_no_project` — pid-absent fallback still 200/empty.
  - `test_cognitive_load_does_not_use_legacy_proxy_formula` — sanity check that `copyclip.mcp` in the mixed fixture lands in high/critical (the old formula put it lower).
- `_now_ts` is monkeypatched to `STABLE_NOW_TS` so the test's manual breakdown call and the server-thread's call agree byte-for-byte.

## Test plan
- [x] `pytest -q` → 302 passed, 1 skipped
- [x] `npm --prefix frontend run build` → built cleanly
- [x] Smoke against real `.copyclip/intelligence.db` → 10 modules, severities include `critical` (previously unreachable), fog mapping matches.
- [x] `grep -n "generated_ratio\|time_factor\|debt \* 100" src/copyclip/intelligence/server.py` → empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)