### PR TITLE
fix: unify quick_debt_signal with v1 factor model

### DIFF
--- a/src/copyclip/intelligence/cognitive_debt.py
+++ b/src/copyclip/intelligence/cognitive_debt.py
@@ -609,29 +609,30 @@ def build_debt_breakdown(
 
 
 def quick_debt_signal(conn, project_id: int, path: str) -> dict[str, Any] | None:
-    """Return a cheap debt summary for ``path`` without running the full breakdown.
+    """Return a cheap debt summary for ``path`` derived from the v1 factor model.
 
-    Suitable for integration callers (Reacquaintance, Ask Project) that only need
-    to know "is this file dark, and roughly why" to adjust prioritization.
+    Delegates to :func:`build_debt_breakdown` so callers (Reacquaintance, Ask Project)
+    see the same value/severity as ``/api/cognitive-load``. ``primary_signal`` is the
+    factor with the largest weighted contribution among the available signals.
     """
     row = conn.execute(
-        "SELECT cognitive_debt, agent_line_ratio, last_human_ts FROM analysis_file_insights WHERE project_id=? AND path=?",
+        "SELECT 1 FROM analysis_file_insights WHERE project_id=? AND path=? LIMIT 1",
         (project_id, path),
     ).fetchone()
     if not row:
         return None
-    value = float(row[0] or 0.0)
-    agent_ratio = row[1]
-    last_human_ts = row[2]
-    primary_signal: str | None = None
-    if agent_ratio is not None and float(agent_ratio) >= 0.5:
-        primary_signal = "agent_authored_ratio"
-    elif last_human_ts is None and value >= 40:
-        primary_signal = "review_staleness"
+
+    try:
+        breakdown = build_debt_breakdown(conn, project_id, "file", path)
+    except ValueError:
+        return None
+
+    available = [f for f in breakdown.get("factor_breakdown") or [] if f.get("signal_available")]
+    primary = max(available, key=lambda f: f.get("weighted_contribution") or 0.0, default=None)
     return {
-        "value": round(value, 2),
-        "severity": _severity_for(value),
-        "primary_signal": primary_signal,
+        "value": round(float(breakdown["score"]["value"] or 0.0), 2),
+        "severity": breakdown["score"]["severity"],
+        "primary_signal": primary["factor_id"] if primary else None,
     }
 
 

--- a/tests/test_debt_integration.py
+++ b/tests/test_debt_integration.py
@@ -64,8 +64,11 @@ def test_quick_debt_signal_returns_severity_and_primary_signal(tmp_path):
     conn.close()
 
     assert signal is not None
-    assert signal["value"] >= 75
-    assert signal["severity"] == "critical"
+    # Under the v1 factor model the dark file lands in "high" or "critical"
+    # depending on how aged the seeded blame is at test runtime; the heaviest
+    # weighted factor for this fixture is the agent-authored ratio.
+    assert signal["value"] >= 50
+    assert signal["severity"] in {"high", "critical"}
     assert signal["primary_signal"] == "agent_authored_ratio"
 
 
@@ -147,10 +150,44 @@ def test_ask_response_biases_drill_down_to_critical_debt_file(tmp_path):
 
 
 def test_ask_response_low_debt_file_does_not_appear_in_debt_hints(tmp_path):
+    import time
+
     root = str(tmp_path)
     conn = connect(root)
     init_schema(conn)
-    pid = _seed_debt_project(conn, root, debt_for_server=10.0, debt_for_ask=5.0)
+    pid = get_or_create_project(conn, root, name="copyclip-low-debt")
+    # Engineer a v1-low file: recent human edit, no agent authorship, decision-linked,
+    # tests present in the module → all factors fall well below the medium threshold.
+    recent_human = time.time() - 86_400
+    for path, module in [
+        ("src/copyclip/ask/answer.py", "copyclip.ask"),
+        ("tests/copyclip/ask/test_answer.py", "tests"),
+    ]:
+        conn.execute(
+            "INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(?,?,?,?,?,?)",
+            (pid, path, "python", 600, 1.0, f"h-{path}"),
+        )
+        conn.execute(
+            "INSERT INTO analysis_file_insights(project_id,path,module,imports_json,complexity,cognitive_debt,agent_line_ratio,last_human_ts) VALUES(?,?,?,?,?,?,?,?)",
+            (pid, path, module, "[]", 4, 4.0, 0.0, recent_human),
+        )
+    conn.execute(
+        "INSERT INTO commits(project_id,sha,author,date,message) VALUES(?,?,?,?,?)",
+        (pid, "sha-ask-low", "samuel", "2026-05-01T10:00:00+00:00", "ask refactor"),
+    )
+    conn.execute(
+        "INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) VALUES(?,?,?,?,?)",
+        (pid, "sha-ask-low", "src/copyclip/ask/answer.py", 4, 1),
+    )
+    conn.execute(
+        "INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)",
+        (pid, "Ask answers are evidence-first", "Grounded.", "accepted", "manual"),
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+        (1, "file", "src/copyclip/ask/answer.py"),
+    )
+    conn.commit()
 
     response = build_ask_response(conn, pid, "evidence first ask implementation")
     conn.close()

--- a/tests/test_debt_scenarios.py
+++ b/tests/test_debt_scenarios.py
@@ -93,15 +93,49 @@ def test_quick_debt_signal_matches_full_breakdown_severity(tmp_path):
     conn = connect(str(tmp_path))
     init_schema(conn)
     pid = seed_mixed_debt_project(conn, str(tmp_path))
-    for path in ["src/copyclip/mcp_server.py", "src/copyclip/ask/answer.py"]:
+    # quick_debt_signal uses datetime.now() internally; share that reference by
+    # also letting full default to datetime.now() so the two calls agree.
+    for path in ["src/copyclip/mcp_server.py", "src/copyclip/ask/answer.py", "src/copyclip/new_module.py"]:
         quick = quick_debt_signal(conn, pid, path)
-        full = build_debt_breakdown(conn, pid, "file", path, now_ts=STABLE_NOW_TS)
-        # severity should be stable: quick uses the stored cognitive_debt column, full recomputes from factors.
-        # Under the v1 contract the two may disagree by at most one bucket; we assert same severity for the
-        # critical-dark file which is the most important case for prioritization.
-        if path == "src/copyclip/mcp_server.py":
-            assert quick["severity"] == "critical"
-            assert full["score"]["severity"] in {"critical", "high"}
+        full = build_debt_breakdown(conn, pid, "file", path)
+        assert quick is not None
+        assert quick["severity"] == full["score"]["severity"]
+        assert quick["value"] == round(float(full["score"]["value"]), 2)
+    conn.close()
+
+
+def test_quick_debt_signal_primary_signal_matches_top_weighted_factor(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    for path in ["src/copyclip/mcp_server.py", "src/copyclip/ask/answer.py", "src/copyclip/new_module.py"]:
+        quick = quick_debt_signal(conn, pid, path)
+        full = build_debt_breakdown(conn, pid, "file", path)
+        available = [f for f in full["factor_breakdown"] if f["signal_available"]]
+        if not available:
+            assert quick["primary_signal"] is None
+            continue
+        top = max(available, key=lambda f: f["weighted_contribution"])
+        assert quick["primary_signal"] == top["factor_id"]
+    conn.close()
+
+
+def test_quick_debt_signal_for_greenfield_path_avoids_unavailable_blame_factors(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_greenfield_project(conn, str(tmp_path))
+    quick = quick_debt_signal(conn, pid, "src/copyclip/new/alpha.py")
+    assert quick is not None
+    # blame-dependent factors are unavailable; primary_signal must not be one of them.
+    assert quick["primary_signal"] not in {"agent_authored_ratio", "review_staleness"}
+    conn.close()
+
+
+def test_quick_debt_signal_returns_none_for_path_missing_from_insights(tmp_path):
+    conn = connect(str(tmp_path))
+    init_schema(conn)
+    pid = seed_mixed_debt_project(conn, str(tmp_path))
+    assert quick_debt_signal(conn, pid, "src/does/not/exist.py") is None
     conn.close()
 
 


### PR DESCRIPTION
## Summary

- `quick_debt_signal` was the second source of truth for cognitive debt: it read `analysis_file_insights.cognitive_debt` (an older analyzer-pipeline scalar) and inferred `primary_signal` from two ad-hoc heuristics. Reacquaintance and Ask Project therefore saw a value that drifted from the v1 contract `/api/cognitive-load` unified to in #77 (A1 of the review).
- Signature is preserved: `(conn, project_id, path) -> {value, severity, primary_signal} | None`. Internally we now delegate to `build_debt_breakdown(conn, project_id, "file", path)` and derive the three fields from the breakdown.
- `primary_signal` is the `factor_id` with the largest `weighted_contribution` among factors where `signal_available` is true (`None` if no factor is available). A `SELECT 1` sanity check keeps the "return `None` for paths missing from `analysis_file_insights`" contract — `build_debt_breakdown` otherwise silently falls back to defaults for unknown paths.
- No caching added; performance comfortably under the agreed budgets.

## How `primary_signal` is derived now

```
available = [f for f in breakdown["factor_breakdown"] if f["signal_available"]]
primary   = max(available, key=lambda f: f["weighted_contribution"], default=None)
```

For greenfield files (`agent_authored_ratio`, `review_staleness`, `ownership_ambiguity`, `novelty_recency` all unavailable) this falls back to one of the always-available factors (`test_evidence_gap`, `decision_gap`, `blast_radius`, `churn_pressure`) instead of returning `"review_staleness"` from the old heuristic.

## Performance (3-sample mean, copyclip's own `.copyclip/intelligence.db`)

| Call | OLD (main) | NEW | Δ | Budget |
| --- | --- | --- | --- | --- |
| `build_reacquaintance_briefing('.', baseline_mode='last_seen', window='7d')` | 48 ms | 122 ms | +74 ms | < 800 ms |
| `build_ask_response(...)` *(query touching 2–4 files)* | 5–6 ms | 7–11 ms | +2–5 ms | < 1500 ms |

The increase is the cost of `build_debt_breakdown` doing ~6 indexed queries per file vs. the old single `SELECT`. Both calls remain well below the agreed thresholds, so this PR does not introduce a cache — if production usage shifts and we approach the budget, the followup is to persist the v1 score on `analysis_file_insights` during analyze (separate PR).

## Tests

Rewritten:
- `tests/test_debt_scenarios.py::test_quick_debt_signal_matches_full_breakdown_severity` — was `quick may disagree by at most one bucket`; now asserts `quick.severity == full.severity` and `quick.value == round(full.value, 2)` for all three mixed-project paths. Both calls let `now_ts` default so they share a `datetime.now()` reference.
- `tests/test_debt_integration.py::test_quick_debt_signal_returns_severity_and_primary_signal` — was `value >= 75 and severity == "critical"`, which leaned on the old scalar. The v1 score for the fixture lands in `high` (≈ 62) rather than `critical`; assertion is relaxed to `value >= 50 and severity in {"high","critical"}` with `primary_signal == "agent_authored_ratio"` preserved.
- `tests/test_debt_integration.py::test_ask_response_low_debt_file_does_not_appear_in_debt_hints` — was driven by `debt_for_server=10` (the now-ignored column). Replaced with an inline seed that produces a v1-low file (recent human edit, no agent authorship, decision-linked, tests present in the module).

New:
- `test_quick_debt_signal_primary_signal_matches_top_weighted_factor` — confirms `primary_signal` matches the top weighted available factor for every fixture path.
- `test_quick_debt_signal_for_greenfield_path_avoids_unavailable_blame_factors` — confirms `primary_signal` is never `agent_authored_ratio` or `review_staleness` when blame is missing.
- `test_quick_debt_signal_returns_none_for_path_missing_from_insights` — covers the `SELECT 1` guard against `build_debt_breakdown` returning a silent default for an unknown path.

## What this PR does *not* touch

- Analyzer pipeline / `analysis_file_insights.cognitive_debt` column — still written, just no longer consumed by `quick_debt_signal`.
- Reacquaintance and Ask Project caller code — both keep reading `signal["value"]`, `signal["severity"]`, `signal["primary_signal"]` unchanged.
- No new logging, no caching, no schema changes, no signature changes.
- Other review findings (M3 silent `(0,0)`, M4 fingerprint includes `generated_at`, M5 `_module_has_tests` `LIKE`, M6 divergent empty states) are left for follow-up PRs as instructed.

## Test plan

- [x] `pytest -q` — 305 passed, 1 skipped.
- [x] `npm --prefix frontend run build` — succeeds (47 modules, 437 ms).
- [x] `grep cognitive_debt[^_]` inside `quick_debt_signal` body — clean.
- [x] Performance measured against `.copyclip/intelligence.db` (3-run mean) on both main and the feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)