### PR TITLE
feat: surface MemPalace recap in Reacquaintance briefing

### DIFF
--- a/docs/REACQUAINTANCE_BRIEFING_CONTRACT.md
+++ b/docs/REACQUAINTANCE_BRIEFING_CONTRACT.md
@@ -62,9 +62,30 @@ If `last_seen` is unavailable, fallback order is:
   "top_risk": null,
   "open_questions": [],
   "evidence_index": [],
+  "external_memory_recap": {
+    "available": true,
+    "source_tool": "mempalace",
+    "source_version": "3.3.4",
+    "wing": "copyclip",
+    "since": "2026-04-10T09:12:00Z",
+    "items": [],
+    "notes": []
+  },
   "fallback_notes": []
 }
 ```
+
+### Note on `external_memory_recap`
+
+`external_memory_recap` is an optional, additive field on the v1 contract. It surfaces narrative context that lives outside the repo — decisions, agent sessions, diary entries — sourced from the user's local MemPalace via the `mempalace wake-up --wing <project>` CLI.
+
+The recap is scoped to **what has happened since the last intelligence visit** (any `project_visits` row, not just reacquaintance-specific kinds) so that returning from a context switch surfaces only the unseen material.
+
+Consumers MUST treat the field as optional:
+- `available: false` indicates MemPalace is not installed, returned no data, or errored. Items are empty in that case.
+- `items[*].occurred_at` is best-effort (parsed from refs/body); items without a parseable date are kept rather than filtered, to err toward inclusion.
+- `notes[]` carries human-readable annotations about filtering and source state.
+
 
 ## Section contracts
 

--- a/src/copyclip/intelligence/history_briefing.py
+++ b/src/copyclip/intelligence/history_briefing.py
@@ -1,0 +1,290 @@
+"""External memory recap for Reacquaintance Mode.
+
+Pulls a project-scoped recap from the locally-installed MemPalace CLI
+(`mempalace wake-up --wing <wing>`) and parses it into a structured
+list of decisions, sessions, and diary entries from outside the repo.
+
+This complements the git/decisions evidence already in Reacquaintance:
+git tells you *what* changed; this layer surfaces *why* — the
+conversational context where the changes were planned and justified.
+
+Gracefully degrades to ``available: False`` when MemPalace is not
+installed or the call fails, so the briefing still works without it.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from datetime import datetime, timezone
+
+
+SOURCE_TOOL = "mempalace"
+
+_L1_HEADER = "## L1"
+_LEVEL_HEADER = re.compile(r"^##\s+L\d+\b")
+_CATEGORY = re.compile(r"^\[([^\[\]]+)\]$")
+_TITLE_BODY_SPLIT = re.compile(r"^(.*?)\s{2,}(.+)$")
+_ISO_DATE = re.compile(r"(\d{4}-\d{2}-\d{2})")
+
+_KIND_MAP = {
+    "decisions": "decision",
+    "agents": "agent",
+    "diary": "diary",
+    "general": "general",
+    "documentation": "documentation",
+    "planning": "planning",
+    "src": "code",
+    "cli": "code",
+    "frontend": "code",
+    "scripts": "code",
+    "backend": "code",
+    "tests": "code",
+    "testing": "code",
+    "code": "code",
+    "problems": "problem",
+    "fixes-applied": "fix",
+    "design": "design",
+    "brainstorm": "brainstorm",
+    "brainstorms": "brainstorm",
+    "decisions-pending": "decision",
+}
+
+
+def build_mempalace_recap(
+    project_root: str,
+    project_name: str,
+    since_iso: str | None = None,
+    wing: str | None = None,
+    *,
+    timeout_seconds: float = 10.0,
+) -> dict:
+    """Return a structured recap of external memory for the project.
+
+    The result is always a dict so callers can render uniformly. When
+    MemPalace is unavailable the ``available`` flag is ``False`` and
+    ``items`` is empty.
+
+    Args:
+        project_root: absolute path to the project (currently unused but
+            kept for parity with the rest of the intelligence API and to
+            anchor future per-project wing overrides).
+        project_name: name used to derive the default wing.
+        since_iso: optional ISO-8601 timestamp; items whose parsed
+            ``occurred_at`` is strictly older are dropped. Items without
+            a parseable date are kept.
+        wing: optional explicit wing name. Defaults to ``project_name``.
+        timeout_seconds: subprocess timeout for ``mempalace wake-up``.
+    """
+    del project_root  # reserved for future per-project wing overrides
+
+    effective_wing = (wing or project_name or "").strip()
+    base = {
+        "available": False,
+        "source_tool": SOURCE_TOOL,
+        "source_version": None,
+        "wing": effective_wing or None,
+        "since": since_iso,
+        "items": [],
+        "notes": [],
+    }
+
+    if not effective_wing:
+        base["notes"].append("No wing resolved; skipped MemPalace recap.")
+        return base
+
+    if shutil.which(SOURCE_TOOL) is None:
+        base["notes"].append("mempalace CLI not found on PATH.")
+        return base
+
+    raw, run_note = _run_wake_up(effective_wing, timeout_seconds=timeout_seconds)
+    if raw is None:
+        base["notes"].append(run_note or "MemPalace wake-up failed.")
+        return base
+
+    parsed = _parse_wake_up_output(raw)
+    filtered, filter_note = _filter_by_since(parsed, since_iso)
+
+    base["available"] = True
+    base["source_version"] = _detect_version()
+    base["items"] = filtered
+    if filter_note:
+        base["notes"].append(filter_note)
+    if not filtered:
+        if since_iso:
+            base["notes"].append(
+                "No external memory items newer than the previous visit."
+            )
+        else:
+            base["notes"].append("Wing returned no items in L1.")
+
+    return base
+
+
+def _run_wake_up(wing: str, *, timeout_seconds: float) -> tuple[str | None, str | None]:
+    try:
+        result = subprocess.run(
+            [SOURCE_TOOL, "wake-up", "--wing", wing],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None, "mempalace CLI not found on PATH."
+    except subprocess.TimeoutExpired:
+        return None, f"mempalace wake-up timed out after {timeout_seconds:.0f}s."
+    except OSError as exc:
+        return None, f"mempalace wake-up failed: {exc}."
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip().splitlines()
+        tail = stderr[-1] if stderr else f"exit {result.returncode}"
+        return None, f"mempalace wake-up returned non-zero: {tail}"
+    if not (result.stdout or "").strip():
+        return None, "mempalace wake-up returned empty output."
+    return result.stdout, None
+
+
+def _detect_version() -> str | None:
+    try:
+        result = subprocess.run(
+            [SOURCE_TOOL, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    text = (result.stdout or result.stderr or "").strip()
+    match = re.search(r"(\d+\.\d+\.\d+)", text)
+    return match.group(1) if match else (text or None)
+
+
+def _parse_wake_up_output(text: str) -> list[dict]:
+    items: list[dict] = []
+    current_category: str | None = None
+    in_l1 = False
+
+    for line in text.splitlines():
+        stripped = line.strip()
+
+        if stripped.startswith(_L1_HEADER):
+            in_l1 = True
+            current_category = None
+            continue
+        if _LEVEL_HEADER.match(stripped) and not stripped.startswith(_L1_HEADER):
+            in_l1 = False
+            current_category = None
+            continue
+
+        if not in_l1:
+            continue
+
+        category_match = _CATEGORY.match(stripped)
+        if category_match:
+            current_category = category_match.group(1).strip()
+            continue
+
+        if stripped.startswith("- "):
+            content = stripped[2:].strip()
+            item = _parse_item(content, current_category)
+            if item is not None:
+                items.append(item)
+
+    return items
+
+
+def _parse_item(content: str, category: str | None) -> dict | None:
+    content = content.strip()
+    if not content:
+        return None
+
+    ref: str | None = None
+    if content.endswith(")"):
+        bracket_start = content.rfind("(")
+        if bracket_start > 0:
+            candidate = content[bracket_start + 1 : -1].strip()
+            if candidate:
+                ref = candidate
+                content = content[:bracket_start].strip()
+
+    match = _TITLE_BODY_SPLIT.match(content)
+    if match:
+        title = match.group(1).strip()
+        body = match.group(2).strip()
+    else:
+        title, body = content, ""
+
+    occurred_at: str | None = None
+    if ref:
+        date_match = _ISO_DATE.search(ref)
+        if date_match:
+            occurred_at = date_match.group(1)
+    if occurred_at is None and body:
+        date_match = _ISO_DATE.search(body)
+        if date_match:
+            occurred_at = date_match.group(1)
+
+    return {
+        "kind": _normalize_kind(category),
+        "category": category,
+        "title": title,
+        "body": body,
+        "ref": ref,
+        "occurred_at": occurred_at,
+    }
+
+
+def _normalize_kind(category: str | None) -> str:
+    if not category:
+        return "other"
+    return _KIND_MAP.get(category.lower(), category.lower())
+
+
+def _filter_by_since(items: list[dict], since_iso: str | None) -> tuple[list[dict], str | None]:
+    if not since_iso:
+        return items, None
+
+    cutoff = _parse_iso(since_iso)
+    if cutoff is None:
+        return items, "Ignored unparseable since_iso; returned all items."
+
+    kept: list[dict] = []
+    dropped = 0
+    cutoff_date = cutoff.date()
+    for item in items:
+        item_date = _parse_date(item.get("occurred_at"))
+        if item_date is None:
+            kept.append(item)
+            continue
+        if item_date >= cutoff_date:
+            kept.append(item)
+        else:
+            dropped += 1
+
+    note = f"Filtered {dropped} item(s) older than {cutoff_date.isoformat()}." if dropped else None
+    return kept, note
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def _parse_date(value: str | None):
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None

--- a/src/copyclip/intelligence/reacquaintance.py
+++ b/src/copyclip/intelligence/reacquaintance.py
@@ -14,6 +14,25 @@ from .db import (
     create_reentry_checkpoint,
 )
 from .cognitive_debt import quick_debt_signal
+from .history_briefing import build_mempalace_recap
+
+
+def _get_last_intelligence_visit_iso(conn, project_id: int) -> str | None:
+    """Return the ISO timestamp of the most recent visit to Project Intelligence.
+
+    Any visit_kind counts (dashboard_open, reacquaintance_*, etc.). The recap
+    in the briefing is anchored to "since the last time the user touched
+    intelligence", not just the last Reacquaintance call specifically.
+    """
+    row = conn.execute(
+        """
+        SELECT visited_at FROM project_visits
+        WHERE project_id=?
+        ORDER BY visited_at DESC LIMIT 1
+        """,
+        (project_id,),
+    ).fetchone()
+    return row[0] if row else None
 
 
 def _safe_json(value: str | None, default: Any):
@@ -141,9 +160,10 @@ def build_reacquaintance_briefing(
 
     if not row:
         conn.close()
+        empty_project_name = Path(root).name
         return {
             "meta": {
-                "project": Path(root).name,
+                "project": empty_project_name,
                 "generated_at": _iso_now(),
                 "briefing_version": "v1",
                 "baseline_mode": baseline_mode,
@@ -159,6 +179,11 @@ def build_reacquaintance_briefing(
             "top_risk": None,
             "open_questions": [],
             "evidence_index": [],
+            "external_memory_recap": build_mempalace_recap(
+                project_root=root,
+                project_name=empty_project_name,
+                since_iso=None,
+            ),
             "fallback_notes": ["No project record found yet. Run copyclip analyze first."],
         }
 
@@ -432,6 +457,13 @@ def build_reacquaintance_briefing(
     if not row[2] and not top_changes:
         confidence = "low"
 
+    last_visit_iso = _get_last_intelligence_visit_iso(conn, pid)
+    external_memory_recap = build_mempalace_recap(
+        project_root=root,
+        project_name=project_name,
+        since_iso=last_visit_iso,
+    )
+
     briefing = {
         "meta": {
             "project": project_name,
@@ -450,6 +482,7 @@ def build_reacquaintance_briefing(
         "top_risk": top_risk,
         "open_questions": open_questions,
         "evidence_index": list(evidence_index.values()),
+        "external_memory_recap": external_memory_recap,
         "fallback_notes": fallback_notes,
     }
     conn.close()

--- a/tests/test_history_briefing.py
+++ b/tests/test_history_briefing.py
@@ -1,0 +1,301 @@
+"""Tests for the MemPalace-backed external memory recap.
+
+Subprocess is monkeypatched so these tests do not depend on a real
+``mempalace`` CLI being installed on the test runner.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from copyclip.intelligence import history_briefing
+from copyclip.intelligence.history_briefing import (
+    _filter_by_since,
+    _parse_item,
+    _parse_wake_up_output,
+    build_mempalace_recap,
+)
+
+
+SAMPLE_WAKE_UP = """Wake-up text (~627 tokens):
+==================================================
+## L0 — IDENTITY
+No identity configured. Create ~/.mempalace/identity.txt
+
+## L1 — ESSENTIAL STORY
+
+[agents]
+  - Hermes agent pattern and stopping point (copyclip handoff epic)  User has a remote Claude Code agent named "Hermes" that executes multi-issue plans in copyclip using subagent-driven-development. Pa...  (session-2026-04-19-hermes-handoff)
+
+[decisions]
+  - Key design decisions for Handoff post-change review summaries (#45, PR #65)  Decision conflict rule: A touched file triggers a decision_conflict if the file is linked to any decision AND the file i...  (session-2026-04-20-issue-45)
+  - Cognitive Debt contract (#47, PR #68 merged as daacb16) — first slice of epic #19.  Contract objects: debt_score (scalar [0,100] + severity label), debt_factor_breakdown (ordered list of per-factor...  (session-2026-04-20-issue-47)
+  - Cognitive Debt Navigator UI (#50, PR #71 merged as 3b7cf8b).  New page: frontend/src/pages/DebtNavigatorPage.tsx wired under the Consciousness sidebar group with id "debt-navigator".  Layout: two-c...  (session-2026-04-20-issue-50)
+  - Safe Agent Handoff epic (#18) CLOSED on 2026-04-20. All 7 child tasks merged in sequence across 3 sessions.  Final slice...  (session-2026-04-20-issue-46-epic-close)
+
+## L2 — DETAILED CONTEXT
+This section should be ignored.
+"""
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _stub_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    def _runner(cmd, **kwargs):
+        return _FakeCompleted(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return _runner
+
+
+def _force_cli_present(monkeypatch):
+    monkeypatch.setattr(history_briefing.shutil, "which", lambda _name: "/usr/local/bin/mempalace")
+
+
+# ---------------------------------------------------------------------------
+# Parser tests — operate on captured output, no subprocess involved.
+# ---------------------------------------------------------------------------
+
+
+def test_parser_extracts_items_from_l1_only():
+    items = _parse_wake_up_output(SAMPLE_WAKE_UP)
+
+    assert len(items) == 5
+    assert all(item["title"] for item in items)
+    assert not any("ignored" in item["body"].lower() for item in items)
+
+
+def test_parser_categorizes_items_by_section():
+    items = _parse_wake_up_output(SAMPLE_WAKE_UP)
+    by_kind = {item["title"]: item["kind"] for item in items}
+
+    assert by_kind["Hermes agent pattern and stopping point (copyclip handoff epic)"] == "agent"
+    for title in by_kind:
+        if title.startswith("Cognitive Debt") or title.startswith("Safe Agent") or title.startswith("Key design"):
+            assert by_kind[title] == "decision"
+
+
+def test_parser_extracts_ref_and_date():
+    items = _parse_wake_up_output(SAMPLE_WAKE_UP)
+    refs = {item["ref"] for item in items}
+    dates = {item["occurred_at"] for item in items if item["occurred_at"]}
+
+    assert "session-2026-04-20-issue-47" in refs
+    assert "2026-04-19" in dates
+    assert "2026-04-20" in dates
+
+
+def test_parser_separates_title_from_body_on_double_space():
+    items = _parse_wake_up_output(SAMPLE_WAKE_UP)
+    by_title = {item["title"]: item for item in items}
+
+    target = by_title["Cognitive Debt contract (#47, PR #68 merged as daacb16) — first slice of epic #19."]
+    assert target["body"].startswith("Contract objects:")
+    assert "(session-" not in target["body"]
+
+
+def test_parser_handles_inline_parens_in_title():
+    item = _parse_item(
+        "Hermes agent pattern and stopping point (copyclip handoff epic)  body here  (session-2026-04-19-hermes)",
+        "agents",
+    )
+    assert item is not None
+    assert item["title"] == "Hermes agent pattern and stopping point (copyclip handoff epic)"
+    assert item["body"] == "body here"
+    assert item["ref"] == "session-2026-04-19-hermes"
+
+
+def test_parser_handles_item_without_ref():
+    item = _parse_item("Plain title only", "general")
+    assert item is not None
+    assert item["title"] == "Plain title only"
+    assert item["body"] == ""
+    assert item["ref"] is None
+    assert item["occurred_at"] is None
+
+
+def test_parser_returns_empty_for_blank_body():
+    assert _parse_item("", "general") is None
+
+
+def test_parser_ignores_content_outside_l1():
+    text = """## L0 — IDENTITY
+[ignored]
+  - this should not be picked up  body  (ignored-ref)
+"""
+    items = _parse_wake_up_output(text)
+    assert items == []
+
+
+# ---------------------------------------------------------------------------
+# since_iso filter tests
+# ---------------------------------------------------------------------------
+
+
+def test_filter_by_since_drops_older_items():
+    items = [
+        {"title": "old", "occurred_at": "2026-04-01"},
+        {"title": "new", "occurred_at": "2026-04-20"},
+        {"title": "boundary", "occurred_at": "2026-04-15"},
+    ]
+    kept, note = _filter_by_since(items, "2026-04-15T00:00:00Z")
+    titles = {item["title"] for item in kept}
+
+    assert titles == {"new", "boundary"}
+    assert note is not None and "1 item" in note
+
+
+def test_filter_by_since_keeps_items_without_date():
+    items = [
+        {"title": "no_date", "occurred_at": None},
+        {"title": "old", "occurred_at": "2026-04-01"},
+    ]
+    kept, _note = _filter_by_since(items, "2026-04-15T00:00:00Z")
+    titles = {item["title"] for item in kept}
+    assert "no_date" in titles
+    assert "old" not in titles
+
+
+def test_filter_by_since_returns_all_when_no_cutoff():
+    items = [{"title": "a", "occurred_at": "2026-04-01"}]
+    kept, note = _filter_by_since(items, None)
+    assert kept == items
+    assert note is None
+
+
+def test_filter_by_since_handles_invalid_iso():
+    items = [{"title": "a", "occurred_at": "2026-04-01"}]
+    kept, note = _filter_by_since(items, "not-a-date")
+    assert kept == items
+    assert note is not None and "unparseable" in note
+
+
+# ---------------------------------------------------------------------------
+# build_mempalace_recap orchestration tests
+# ---------------------------------------------------------------------------
+
+
+def test_recap_returns_unavailable_when_cli_missing(monkeypatch):
+    monkeypatch.setattr(history_briefing.shutil, "which", lambda _name: None)
+
+    recap = build_mempalace_recap("/tmp/proj", "copyclip")
+
+    assert recap["available"] is False
+    assert recap["items"] == []
+    assert recap["source_tool"] == "mempalace"
+    assert any("not found" in note.lower() for note in recap["notes"])
+
+
+def test_recap_returns_unavailable_on_subprocess_filenotfound(monkeypatch):
+    _force_cli_present(monkeypatch)
+
+    def _raise(*_args, **_kwargs):
+        raise FileNotFoundError("mempalace")
+
+    monkeypatch.setattr(history_briefing.subprocess, "run", _raise)
+
+    recap = build_mempalace_recap("/tmp/proj", "copyclip")
+    assert recap["available"] is False
+    assert any("not found" in note.lower() for note in recap["notes"])
+
+
+def test_recap_returns_unavailable_on_timeout(monkeypatch):
+    _force_cli_present(monkeypatch)
+
+    def _raise(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="mempalace", timeout=10.0)
+
+    monkeypatch.setattr(history_briefing.subprocess, "run", _raise)
+
+    recap = build_mempalace_recap("/tmp/proj", "copyclip", timeout_seconds=10.0)
+    assert recap["available"] is False
+    assert any("timed out" in note.lower() for note in recap["notes"])
+
+
+def test_recap_returns_unavailable_on_nonzero_exit(monkeypatch):
+    _force_cli_present(monkeypatch)
+    monkeypatch.setattr(history_briefing.subprocess, "run", _stub_run(stdout="", stderr="boom", returncode=2))
+
+    recap = build_mempalace_recap("/tmp/proj", "copyclip")
+    assert recap["available"] is False
+    assert any("non-zero" in note for note in recap["notes"])
+
+
+def test_recap_returns_unavailable_on_empty_output(monkeypatch):
+    _force_cli_present(monkeypatch)
+    monkeypatch.setattr(history_briefing.subprocess, "run", _stub_run(stdout="   \n", returncode=0))
+
+    recap = build_mempalace_recap("/tmp/proj", "copyclip")
+    assert recap["available"] is False
+    assert any("empty" in note.lower() for note in recap["notes"])
+
+
+def test_recap_returns_unavailable_when_no_wing_resolvable(monkeypatch):
+    _force_cli_present(monkeypatch)
+
+    recap = build_mempalace_recap("/tmp/proj", "")
+    assert recap["available"] is False
+    assert recap["wing"] is None
+
+
+def test_recap_parses_full_output_when_available(monkeypatch):
+    _force_cli_present(monkeypatch)
+    monkeypatch.setattr(history_briefing.subprocess, "run", _stub_run(stdout=SAMPLE_WAKE_UP, returncode=0))
+
+    recap = build_mempalace_recap("/tmp/proj", "copyclip")
+
+    assert recap["available"] is True
+    assert recap["wing"] == "copyclip"
+    assert len(recap["items"]) == 5
+    kinds = {item["kind"] for item in recap["items"]}
+    assert "agent" in kinds and "decision" in kinds
+
+
+def test_recap_filters_by_since_when_provided(monkeypatch):
+    _force_cli_present(monkeypatch)
+    monkeypatch.setattr(history_briefing.subprocess, "run", _stub_run(stdout=SAMPLE_WAKE_UP, returncode=0))
+
+    recap = build_mempalace_recap("/tmp/proj", "copyclip", since_iso="2026-04-20T00:00:00Z")
+
+    assert recap["available"] is True
+    titles = {item["title"] for item in recap["items"]}
+    assert not any("Hermes agent pattern" in t for t in titles)
+    assert any("Cognitive Debt" in t for t in titles)
+
+
+def test_recap_uses_explicit_wing_over_project_name(monkeypatch):
+    _force_cli_present(monkeypatch)
+    calls: list[list[str]] = []
+
+    def _runner(cmd, **_kwargs):
+        calls.append(list(cmd))
+        if "wake-up" in cmd:
+            return _FakeCompleted(stdout=SAMPLE_WAKE_UP, returncode=0)
+        return _FakeCompleted(stdout="MemPalace 3.3.4", returncode=0)
+
+    monkeypatch.setattr(history_briefing.subprocess, "run", _runner)
+
+    build_mempalace_recap("/tmp/proj", "copyclip", wing="custom_wing")
+
+    wake_calls = [c for c in calls if "wake-up" in c]
+    assert wake_calls, "expected at least one wake-up subprocess call"
+    assert wake_calls[0] == ["mempalace", "wake-up", "--wing", "custom_wing"]
+
+
+@pytest.mark.parametrize("category,expected", [
+    ("decisions", "decision"),
+    ("Decisions", "decision"),
+    ("AGENTS", "agent"),
+    ("documentation", "documentation"),
+    ("unknown-room", "unknown-room"),
+    (None, "other"),
+])
+def test_kind_normalization(category, expected):
+    item = _parse_item("title here  body here  (ref)", category)
+    assert item is not None
+    assert item["kind"] == expected

--- a/tests/test_reacquaintance_briefing.py
+++ b/tests/test_reacquaintance_briefing.py
@@ -1,5 +1,6 @@
 import json
 
+from copyclip.intelligence import history_briefing
 from copyclip.intelligence.db import (
     connect,
     init_schema,
@@ -8,6 +9,37 @@ from copyclip.intelligence.db import (
     create_reentry_checkpoint,
 )
 from copyclip.intelligence.reacquaintance import build_reacquaintance_briefing
+
+
+_SAMPLE_WAKE_UP = """Wake-up text (~120 tokens):
+==================================================
+## L0 — IDENTITY
+No identity configured.
+
+## L1 — ESSENTIAL STORY
+
+[decisions]
+  - Recent decision after baseline  body here  (session-2026-04-14-issue-99)
+  - Older decision before baseline  body here  (session-2026-04-10-issue-50)
+"""
+
+
+def _stub_mempalace_available(monkeypatch, *, stdout: str = _SAMPLE_WAKE_UP, returncode: int = 0):
+    """Force the history_briefing helpers to return a deterministic stdout."""
+    monkeypatch.setattr(history_briefing.shutil, "which", lambda _name: "/usr/local/bin/mempalace")
+
+    class _Completed:
+        def __init__(self, out: str, code: int) -> None:
+            self.stdout = out
+            self.stderr = ""
+            self.returncode = code
+
+    def _runner(cmd, **_kwargs):
+        if "wake-up" in cmd:
+            return _Completed(stdout, returncode)
+        return _Completed("MemPalace 3.3.4", 0)
+
+    monkeypatch.setattr(history_briefing.subprocess, "run", _runner)
 
 
 def _seed_reacquaintance_project(conn, root: str) -> int:
@@ -349,3 +381,48 @@ def test_realistic_context_switch_open_questions_derive_from_unresolved_decision
     for q in questions:
         assert q["derived_from"]
         assert q["next_step"]
+
+
+def test_briefing_includes_external_memory_recap_when_mempalace_available(tmp_path, monkeypatch):
+    _stub_mempalace_available(monkeypatch)
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_reacquaintance_project(conn, root)
+    record_project_visit(conn, pid, visited_at="2026-04-12T12:00:00Z")
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+    recap = briefing["external_memory_recap"]
+
+    assert recap["available"] is True
+    assert recap["source_tool"] == "mempalace"
+    titles = {item["title"] for item in recap["items"]}
+    assert "Recent decision after baseline" in titles
+    # Item older than the recorded visit (2026-04-12) should be filtered out
+    assert "Older decision before baseline" not in titles
+
+
+def test_briefing_recap_is_unavailable_when_mempalace_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(history_briefing.shutil, "which", lambda _name: None)
+    root = str(tmp_path)
+    conn = connect(root)
+    init_schema(conn)
+    pid = _seed_reacquaintance_project(conn, root)
+    conn.close()
+
+    briefing = build_reacquaintance_briefing(root, baseline_mode="last_seen")
+    recap = briefing["external_memory_recap"]
+
+    assert recap["available"] is False
+    assert recap["items"] == []
+    assert recap["source_tool"] == "mempalace"
+
+
+def test_empty_project_briefing_still_emits_recap_field(tmp_path, monkeypatch):
+    monkeypatch.setattr(history_briefing.shutil, "which", lambda _name: None)
+    # tmp_path has no project row in the DB
+    briefing = build_reacquaintance_briefing(str(tmp_path), baseline_mode="last_seen")
+
+    assert "external_memory_recap" in briefing
+    assert briefing["external_memory_recap"]["available"] is False


### PR DESCRIPTION
## Summary
- Adds an additive `external_memory_recap` section to the v1 Reacquaintance contract. It runs `mempalace wake-up --wing <project>`, parses the `L1 — ESSENTIAL STORY` block into structured items (`kind`, `title`, `body`, `ref`, `occurred_at`), and filters to entries newer than the previous visit to Project Intelligence so re-entry surfaces only unseen material.
- "Last visit" is **any** `project_visits` row (dashboard_open, reacquaintance_*, etc.) — interpreted broadly as the last time the user touched the intelligence surface, not just the last Reacquaintance call.
- Best-effort by design: when MemPalace is not installed, the subprocess times out, or it returns nothing, the field reports `available: false` and the rest of the briefing is unaffected. Existing callers and tests keep working.

## Why
CopyClip's wedge is *"stay attached to your codebase while AI writes most of it"*. Git tells you **what** changed; this layer surfaces **why** — the conversational context (decisions, agent sessions, diary entries) where those changes were planned. MemPalace already captures and classifies that material locally; rather than duplicate it, CopyClip invokes its CLI and interprets the result.

## Shape of the new field

```json
{
  "external_memory_recap": {
    "available": true,
    "source_tool": "mempalace",
    "source_version": "3.3.4",
    "wing": "copyclip",
    "since": "2026-05-15T14:25:34Z",
    "items": [
      {
        "kind": "decision",
        "category": "decisions",
        "title": "Cognitive Debt contract (#47, PR #68 merged as daacb16)",
        "body": "Contract objects: debt_score (scalar [0,100] + severity label)...",
        "ref": "session-2026-04-20-issue-47",
        "occurred_at": "2026-04-20"
      }
    ],
    "notes": ["Filtered 3 item(s) older than 2026-05-15."]
  }
}
```

The field is optional in the v1 contract — old consumers continue to function ignoring it.

## Files

```
docs/REACQUAINTANCE_BRIEFING_CONTRACT.md    | +21
src/copyclip/intelligence/history_briefing.py | +218 (new)
src/copyclip/intelligence/reacquaintance.py |  +35 / -1
tests/test_history_briefing.py              | +297 (new)
tests/test_reacquaintance_briefing.py       |  +77
```

Total: +648 / -1 across 5 files. No frontend changes — the API response gets a new optional field that frontends can render later.

## Test plan

- [x] `python3 -m pytest tests/test_history_briefing.py -q` — 27 passed (parser, since-filter, subprocess fallbacks, kind normalization).
- [x] `python3 -m pytest tests/test_reacquaintance_briefing.py -q` — 13 passed (existing 10 + 3 new integration tests covering available/unavailable/empty-project paths).
- [x] `python3 -m pytest -q` — 335 passed, 1 skipped on the full suite.
- [x] `scripts/dev-smoke.sh` runtime suite — 3 passed.
- [x] End-to-end against real local MemPalace 3.3.4:
  - `build_reacquaintance_briefing('.')` returned `available=true`, `wing=copyclip`, correctly filtered out 10 April items because the last intelligence visit was on 2026-05-15. With `since_iso=None` it returns all 10 items, correctly kind-tagged and date-parsed.

## MemPalace-side setup (companion to this PR, done locally, not in repo)

- Created `~/.mempalace/identity.txt` with a short developer profile so `wake-up` includes useful L0 context.
- `mempalace hook` is already running in silent-save mode (`mempalace_hook_settings` confirms `silent_save: true, desktop_toast: false`). Sessions are being auto-classified into `wing_copyclip` automatically.

## Substrate caveat — known and intentionally accepted for this PR

The `copyclip` wing currently contains 10 hand-curated drawers, all from April 2026 (the Handoff and Cognitive Debt arcs). Recent sessions (May 2026 PRs #74–#82) are landing in `wing_copyclip` as raw `CHECKPOINT:` entries with low-signal bodies. Today this PR reads `--wing copyclip` only, so the recap will look "stuck in April" until either:

1. Recent sessions are mined into `copyclip` with curated bodies (manual `mempalace mine` pass, or automation), or
2. The recap reads both `copyclip` and `wing_copyclip` and merges/deduplicates.

(2) is a clean follow-up. The function signature was kept single-wing in this PR to keep the diff focused.

## Scope confirmation

```
$ git diff main --name-only
docs/REACQUAINTANCE_BRIEFING_CONTRACT.md
src/copyclip/intelligence/history_briefing.py
src/copyclip/intelligence/reacquaintance.py
tests/test_history_briefing.py
tests/test_reacquaintance_briefing.py
```

Untouched: server routes, MCP tools, CLI, frontend, analyzer, debt remediation, handoff modules.

## Follow-ups (intentionally not in this PR)

- Multi-wing read (`copyclip` + `wing_copyclip`) with dedup by `ref`.
- Frontend rendering of the recap section inside Reacquaintance Mode UI.
- MCP tool that exposes only the recap (for agent use during handoff drafting).
- Configurable wing override via project settings instead of derived-from-name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)