### PR TITLE
feat: playground backend foundation (#86)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
   "pytest>=9.0",
   "pytest-asyncio>=1.0",
 ]
+playground = [
+  "marimo>=0.10",
+]
 
 [project.scripts]
 copyclip = "copyclip.__main__:main"

--- a/src/copyclip/intelligence/playground.py
+++ b/src/copyclip/intelligence/playground.py
@@ -1,0 +1,452 @@
+"""Anchored Playground bridge: contract, resolver, and Marimo notebook generator.
+
+The architectural contract lives in
+docs/superpowers/specs/2026-05-22-anchored-playground-design.md.
+
+This module owns the bridge between dashboard surfaces (Atlas3D, Reacquaintance,
+Debt Navigator, etc.) and Marimo subprocesses. It does NOT spawn or manage
+subprocesses — that responsibility belongs to marimo_runner.py (issue #88). The
+runner is consumed via the MarimoRunner Protocol below so this module can be
+tested in isolation with a mock.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+PLAYGROUND_SOURCES = frozenset(
+    {
+        "atlas",
+        "reacquaintance",
+        "debt_navigator",
+        "decisions",
+        "risks",
+        "timeline",
+        "context_builder",
+    }
+)
+
+LAUNCHABLE_SYMBOL_KINDS = frozenset({"function", "method", "class"})
+
+
+# ---------------------------------------------------------------------------
+# Wire shape (mirrors the TypeScript types in the design spec)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FunctionRef:
+    file: str
+    name: str
+    line: int | None = None
+    qualname: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: object) -> "FunctionRef":
+        if not isinstance(data, dict):
+            raise InvalidFunctionRefError("function_ref must be an object")
+        file = data.get("file")
+        name = data.get("name")
+        if not isinstance(file, str) or not file:
+            raise InvalidFunctionRefError("function_ref.file is required")
+        if not isinstance(name, str) or not name:
+            raise InvalidFunctionRefError("function_ref.name is required")
+        line = data.get("line")
+        if line is not None and not isinstance(line, int):
+            raise InvalidFunctionRefError(
+                "function_ref.line must be int when provided"
+            )
+        qualname = data.get("qualname")
+        if qualname is not None and not isinstance(qualname, str):
+            raise InvalidFunctionRefError(
+                "function_ref.qualname must be str when provided"
+            )
+        if _looks_absolute(file) or os.path.isabs(file):
+            raise InvalidFunctionRefError(
+                f"function_ref.file must be project-relative, got absolute path: {file!r}"
+            )
+        return cls(file=file, name=name, line=line, qualname=qualname)
+
+
+@dataclass(frozen=True)
+class PlaygroundLaunchRequest:
+    source: str
+    function_ref: FunctionRef
+    deps_hint: list[str] | None = None
+    suggested_inputs: list[object] | None = None
+    breadcrumb: str = ""
+
+    @classmethod
+    def from_dict(cls, data: object) -> "PlaygroundLaunchRequest":
+        if not isinstance(data, dict):
+            raise InvalidRequestError("request body must be an object")
+        source = data.get("source")
+        if source not in PLAYGROUND_SOURCES:
+            raise InvalidRequestError(
+                f"source must be one of {sorted(PLAYGROUND_SOURCES)}, got {source!r}"
+            )
+        ref = FunctionRef.from_dict(data.get("function_ref") or {})
+        deps_hint = data.get("deps_hint")
+        if deps_hint is not None and not isinstance(deps_hint, list):
+            raise InvalidRequestError("deps_hint must be a list when provided")
+        suggested = data.get("suggested_inputs")
+        if suggested is not None and not isinstance(suggested, list):
+            raise InvalidRequestError(
+                "suggested_inputs must be a list when provided"
+            )
+        breadcrumb = data.get("breadcrumb") or ""
+        if not isinstance(breadcrumb, str):
+            raise InvalidRequestError("breadcrumb must be a string")
+        return cls(
+            source=str(source),
+            function_ref=ref,
+            deps_hint=[str(x) for x in deps_hint] if deps_hint else None,
+            suggested_inputs=list(suggested) if suggested else None,
+            breadcrumb=breadcrumb,
+        )
+
+
+@dataclass(frozen=True)
+class PlaygroundLaunchResponse:
+    playground_id: str
+    iframe_url: str
+
+    def to_dict(self) -> dict:
+        return {
+            "playground_id": self.playground_id,
+            "iframe_url": self.iframe_url,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Runner Protocol — real implementation lands in marimo_runner.py (issue #88)
+# ---------------------------------------------------------------------------
+
+
+class MarimoRunner(Protocol):
+    def launch(self, notebook_path: str) -> tuple[str, str]:
+        """Return (playground_id, iframe_url) after a healthy spawn."""
+        ...
+
+    def kill(self, playground_id: str) -> bool:
+        ...
+
+    def status(self, playground_id: str) -> str:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Error classes — endpoints catch these and emit JSON with stable codes
+# ---------------------------------------------------------------------------
+
+
+class PlaygroundError(Exception):
+    error_code: str = "playground_error"
+    http_status: int = 500
+
+
+class InvalidRequestError(PlaygroundError):
+    error_code = "invalid_request"
+    http_status = 400
+
+
+class InvalidFunctionRefError(PlaygroundError):
+    error_code = "invalid_function_ref"
+    http_status = 400
+
+
+class FunctionNotFoundError(PlaygroundError):
+    error_code = "function_not_found"
+    http_status = 404
+
+
+class MarimoNotInstalledError(PlaygroundError):
+    error_code = "marimo_not_installed"
+    http_status = 503
+
+
+class MarimoSpawnError(PlaygroundError):
+    error_code = "marimo_spawn_failed"
+    http_status = 500
+
+
+class NoFreePortError(PlaygroundError):
+    error_code = "no_free_port"
+    http_status = 503
+
+
+# ---------------------------------------------------------------------------
+# Resolver: look up FunctionRef in the analyzer's symbol table
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResolvedFunction:
+    file: str
+    name: str
+    qualname: str
+    kind: str
+    module: str
+    line_start: int | None
+    parent_class: str | None
+
+
+def resolve_function_ref(
+    conn: sqlite3.Connection,
+    project_id: int,
+    ref: FunctionRef,
+) -> ResolvedFunction:
+    """Look up a FunctionRef in the symbols table. Raises FunctionNotFoundError on miss."""
+    qualname = ref.qualname or ref.name
+    parent_class: str | None = None
+    if "." in qualname:
+        head, tail = qualname.split(".", 1)
+        if head and tail and "." not in tail:
+            parent_class = head
+
+    if parent_class:
+        row = conn.execute(
+            """
+            SELECT name, kind, file_path, line_start, module
+            FROM symbols
+            WHERE project_id=? AND file_path=? AND name=?
+              AND kind IN ('method','function')
+            ORDER BY line_start
+            LIMIT 1
+            """,
+            (project_id, ref.file, ref.name),
+        ).fetchone()
+    else:
+        row = conn.execute(
+            """
+            SELECT name, kind, file_path, line_start, module
+            FROM symbols
+            WHERE project_id=? AND file_path=? AND name=?
+              AND kind IN ('function','method','class')
+            ORDER BY CASE kind
+                WHEN 'function' THEN 0
+                WHEN 'class' THEN 1
+                ELSE 2
+            END
+            LIMIT 1
+            """,
+            (project_id, ref.file, ref.name),
+        ).fetchone()
+
+    if not row:
+        raise FunctionNotFoundError(
+            f"no symbol {ref.name!r} found in {ref.file!r}"
+        )
+
+    db_name = row[0]
+    db_kind = row[1]
+    db_file = row[2]
+    db_line = row[3]
+    db_module = row[4] or _module_from_file(ref.file)
+
+    final_qualname = qualname if parent_class else db_name
+    return ResolvedFunction(
+        file=db_file,
+        name=db_name,
+        qualname=final_qualname,
+        kind=db_kind,
+        module=db_module,
+        line_start=db_line,
+        parent_class=parent_class,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Marimo notebook generator
+# ---------------------------------------------------------------------------
+
+
+_NOTEBOOK_TEMPLATE = '''import marimo
+
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    # CopyClip auto-loaded cell
+    # Source: {source}
+    # Breadcrumb: {breadcrumb}
+    import sys
+    sys.path.insert(0, {project_root!r})
+{imports_block}
+    return ({exported_symbols},)
+
+
+@app.cell
+def __({exported_symbols}):
+{sample_block}
+    return result, sample,
+
+
+@app.cell
+def __():
+    # Free cell: experiment freely
+    return
+
+
+if __name__ == "__main__":
+    app.run()
+'''
+
+
+def generate_marimo_notebook(
+    req: PlaygroundLaunchRequest,
+    project_root: str,
+    resolved: ResolvedFunction,
+    *,
+    temp_dir: str | None = None,
+) -> str:
+    """Write a runnable Marimo .py file to a temp dir and return its absolute path.
+
+    Cleanup of the temp dir is the runner's responsibility (see marimo_runner.py).
+    """
+    td = temp_dir or tempfile.mkdtemp(prefix="copyclip-playground-")
+    notebook_path = os.path.join(td, "playground.py")
+    imports_block, exported_symbols, call_expr = _build_symbol_resolution(resolved)
+    sample_block = _build_sample_block(req.suggested_inputs, call_expr)
+    content = _NOTEBOOK_TEMPLATE.format(
+        source=req.source,
+        breadcrumb=req.breadcrumb or "<unspecified>",
+        project_root=os.path.abspath(project_root),
+        imports_block=imports_block,
+        exported_symbols=exported_symbols,
+        sample_block=sample_block,
+    )
+    Path(notebook_path).write_text(content, encoding="utf-8")
+    return notebook_path
+
+
+def _build_symbol_resolution(resolved: ResolvedFunction) -> tuple[str, str, str]:
+    """Return (imports_block, exported_symbols, call_expr) per the spec's Symbol resolution rules.
+
+    Staticmethod / classmethod detection is deferred; we default methods to the
+    instance form ``Foo(...).method(sample)`` per the spec fallback.
+    """
+    mod = resolved.module
+    name = resolved.name
+    parent = resolved.parent_class
+
+    if parent and parent != name:
+        imports = f"    from {mod} import {parent}"
+        exported = parent
+        call_expr = f"{parent}(...).{name}(sample)"
+    else:
+        imports = f"    from {mod} import {name}"
+        exported = name
+        call_expr = f"{name}(sample)"
+
+    return imports, exported, call_expr
+
+
+def _build_sample_block(
+    suggested_inputs: list[object] | None, call_expr: str
+) -> str:
+    """Indented body of the second cell. v1: uses only the first suggested input."""
+    indent = "    "
+    if not suggested_inputs:
+        callable_repr = call_expr.split("(", 1)[0]
+        lines = [
+            f"{indent}# Suggested input",
+            f"{indent}# TODO: supply input",
+            f"{indent}sample = None",
+            f"{indent}result = None  # call {callable_repr}(sample) once sample is set",
+        ]
+    else:
+        first = suggested_inputs[0]
+        try:
+            sample_repr = repr(first)
+        except Exception:
+            sample_repr = "None"
+        lines = [
+            f"{indent}# Suggested input",
+            f"{indent}sample = {sample_repr}",
+            f"{indent}result = {call_expr}",
+            f"{indent}result",
+        ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator
+# ---------------------------------------------------------------------------
+
+
+def launch_playground(
+    req: PlaygroundLaunchRequest,
+    project_root: str,
+    conn: sqlite3.Connection,
+    pid: int,
+    runner: MarimoRunner,
+) -> PlaygroundLaunchResponse:
+    """Resolve, generate, launch. May raise PlaygroundError subclasses."""
+    resolved = resolve_function_ref(conn, pid, req.function_ref)
+    notebook_path = generate_marimo_notebook(req, project_root, resolved)
+    playground_id, iframe_url = runner.launch(notebook_path)
+    return PlaygroundLaunchResponse(
+        playground_id=playground_id,
+        iframe_url=iframe_url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _looks_absolute(path: str) -> bool:
+    """Detect absolute paths cross-platform.
+
+    os.path.isabs is platform-dependent and does not catch POSIX-style absolute
+    paths on Windows. We treat leading '/' or '\\' as absolute everywhere, plus
+    the Windows 'C:' drive prefix.
+    """
+    if not path:
+        return False
+    if path.startswith("/") or path.startswith("\\"):
+        return True
+    if len(path) >= 2 and path[1] == ":":
+        return True
+    return False
+
+
+def _module_from_file(file_path: str) -> str:
+    """'src/copyclip/foo.py' → 'copyclip.foo'. Strips leading 'src/' to match the project layout."""
+    norm = file_path.replace("\\", "/")
+    if norm.endswith(".py"):
+        norm = norm[:-3]
+    parts = [p for p in norm.split("/") if p]
+    if parts and parts[0] == "src":
+        parts = parts[1:]
+    return ".".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Temporary stub runner — remove the fallback import in server.py when
+# marimo_runner.py lands (issue #88). Keeps endpoint contract testable
+# end-to-end against stable JSON error codes in the meantime.
+# ---------------------------------------------------------------------------
+
+
+class StubMarimoRunner:
+    def launch(self, notebook_path: str) -> tuple[str, str]:
+        raise MarimoSpawnError(
+            "marimo subprocess manager not yet implemented (issue #88); "
+            f"notebook generated at {notebook_path}"
+        )
+
+    def kill(self, playground_id: str) -> bool:
+        return False
+
+    def status(self, playground_id: str) -> str:
+        return "missing"

--- a/src/copyclip/intelligence/playground.py
+++ b/src/copyclip/intelligence/playground.py
@@ -13,11 +13,13 @@ tested in isolation with a mock.
 from __future__ import annotations
 
 import os
+import re
+import shutil
 import sqlite3
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 
 PLAYGROUND_SOURCES = frozenset(
@@ -33,6 +35,36 @@ PLAYGROUND_SOURCES = frozenset(
 )
 
 LAUNCHABLE_SYMBOL_KINDS = frozenset({"function", "method", "class"})
+
+# User-supplied symbol fragments (name, qualname parts, parent class) are
+# substituted directly into the generated Marimo file as Python identifiers.
+# Without validation, `qualname="x;import os;y.method"` would slip into
+# `from {mod} import x;import os;y` and execute on spawn.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Cap to keep pathological breadcrumbs from blowing up the template / log files.
+_BREADCRUMB_MAX_LEN = 500
+
+
+def _is_identifier(value: str) -> bool:
+    return bool(_IDENTIFIER_RE.match(value))
+
+
+def _sanitize_for_comment(value: str) -> str:
+    """Make a string safe to embed in a single-line Python ``#`` comment.
+
+    Replaces any non-printable character (including line terminators ``\\n``,
+    ``\\r``, ``U+2028``, ``U+2029``) with a space, and truncates to
+    ``_BREADCRUMB_MAX_LEN``. Without this a breadcrumb of
+    ``"atlas\\n    import os; os.system('pwn')"`` would escape the comment
+    and execute on subprocess spawn.
+    """
+    if not value:
+        return ""
+    cleaned = "".join(c if (c == " " or c.isprintable()) else " " for c in value)
+    if len(cleaned) > _BREADCRUMB_MAX_LEN:
+        cleaned = cleaned[: _BREADCRUMB_MAX_LEN - 3] + "..."
+    return cleaned
 
 
 # ---------------------------------------------------------------------------
@@ -57,19 +89,37 @@ class FunctionRef:
             raise InvalidFunctionRefError("function_ref.file is required")
         if not isinstance(name, str) or not name:
             raise InvalidFunctionRefError("function_ref.name is required")
+        if not _is_identifier(name):
+            raise InvalidFunctionRefError(
+                f"function_ref.name must be a Python identifier, got {name!r}"
+            )
         line = data.get("line")
         if line is not None and not isinstance(line, int):
             raise InvalidFunctionRefError(
                 "function_ref.line must be int when provided"
             )
         qualname = data.get("qualname")
-        if qualname is not None and not isinstance(qualname, str):
-            raise InvalidFunctionRefError(
-                "function_ref.qualname must be str when provided"
-            )
+        if qualname is not None:
+            if not isinstance(qualname, str):
+                raise InvalidFunctionRefError(
+                    "function_ref.qualname must be str when provided"
+                )
+            qparts = qualname.split(".")
+            if len(qparts) > 2:
+                raise InvalidFunctionRefError(
+                    "nested class qualnames (e.g. Outer.Inner.method) are not supported in v1"
+                )
+            if not all(_is_identifier(p) for p in qparts):
+                raise InvalidFunctionRefError(
+                    f"function_ref.qualname segments must be Python identifiers, got {qualname!r}"
+                )
         if _looks_absolute(file) or os.path.isabs(file):
             raise InvalidFunctionRefError(
                 f"function_ref.file must be project-relative, got absolute path: {file!r}"
+            )
+        if ".." in file.replace("\\", "/").split("/"):
+            raise InvalidFunctionRefError(
+                f"function_ref.file must not contain '..' segments, got {file!r}"
             )
         return cls(file=file, name=name, line=line, qualname=qualname)
 
@@ -137,7 +187,9 @@ class MarimoRunner(Protocol):
     def kill(self, playground_id: str) -> bool:
         ...
 
-    def status(self, playground_id: str) -> str:
+    def status(
+        self, playground_id: str
+    ) -> Literal["running", "exited", "missing"]:
         ...
 
 
@@ -248,7 +300,18 @@ def resolve_function_ref(
     db_kind = row[1]
     db_file = row[2]
     db_line = row[3]
-    db_module = row[4] or _module_from_file(ref.file)
+    # Use db_file (canonical from analyzer) for the module fallback so a
+    # mis-cased input path can't poison the import statement.
+    db_module = row[4] or _module_from_file(db_file)
+
+    # The module string is embedded directly in `from {mod} import ...`.
+    # Reject anything that isn't a dotted sequence of identifiers — protects
+    # against files like `2legit.py` or `foo-bar.py` reaching the generator.
+    if not db_module or not all(_is_identifier(seg) for seg in db_module.split(".")):
+        raise FunctionNotFoundError(
+            f"file {ref.file!r} does not map to an importable Python module "
+            f"(derived module: {db_module!r})"
+        )
 
     final_qualname = qualname if parent_class else db_name
     return ResolvedFunction(
@@ -315,9 +378,14 @@ def generate_marimo_notebook(
     notebook_path = os.path.join(td, "playground.py")
     imports_block, exported_symbols, call_expr = _build_symbol_resolution(resolved)
     sample_block = _build_sample_block(req.suggested_inputs, call_expr)
+    # source is already validated against the PLAYGROUND_SOURCES whitelist, but
+    # we sanitize both fields anyway as defense in depth — these end up inside
+    # single-line ``#`` comments.
+    safe_source = _sanitize_for_comment(req.source)
+    safe_breadcrumb = _sanitize_for_comment(req.breadcrumb) or "<unspecified>"
     content = _NOTEBOOK_TEMPLATE.format(
-        source=req.source,
-        breadcrumb=req.breadcrumb or "<unspecified>",
+        source=safe_source,
+        breadcrumb=safe_breadcrumb,
         project_root=os.path.abspath(project_root),
         imports_block=imports_block,
         exported_symbols=exported_symbols,
@@ -389,10 +457,20 @@ def launch_playground(
     pid: int,
     runner: MarimoRunner,
 ) -> PlaygroundLaunchResponse:
-    """Resolve, generate, launch. May raise PlaygroundError subclasses."""
+    """Resolve, generate, launch. May raise PlaygroundError subclasses.
+
+    If the runner fails after the notebook has been written, the temp dir is
+    cleaned up best-effort so we don't leak per-request directories in the
+    common error path. Crash-cleanup of orphans across CopyClip restarts is
+    the runner's responsibility on startup (see spec, "Orphan cleanup").
+    """
     resolved = resolve_function_ref(conn, pid, req.function_ref)
     notebook_path = generate_marimo_notebook(req, project_root, resolved)
-    playground_id, iframe_url = runner.launch(notebook_path)
+    try:
+        playground_id, iframe_url = runner.launch(notebook_path)
+    except Exception:
+        shutil.rmtree(os.path.dirname(notebook_path), ignore_errors=True)
+        raise
     return PlaygroundLaunchResponse(
         playground_id=playground_id,
         iframe_url=iframe_url,
@@ -448,5 +526,7 @@ class StubMarimoRunner:
     def kill(self, playground_id: str) -> bool:
         return False
 
-    def status(self, playground_id: str) -> str:
+    def status(
+        self, playground_id: str
+    ) -> Literal["running", "exited", "missing"]:
         return "missing"

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -29,6 +29,13 @@ from .handoff import (
     update_handoff_packet,
 )
 from .db import connect, init_schema
+from .playground import (
+    MarimoNotInstalledError,
+    PlaygroundError,
+    PlaygroundLaunchRequest,
+    StubMarimoRunner,
+    launch_playground,
+)
 from .reacquaintance import build_reacquaintance_briefing, record_reacquaintance_visit
 from .server_context import ServerContext
 from .server_events import handle_events_get, publish_event as publish_event_impl
@@ -61,7 +68,12 @@ def _project_id(conn: sqlite3.Connection, root: str):
     return project_id(conn, root)
 
 
-def run_server(project_root: str, port: int = 4310) -> None:
+def run_server(
+    project_root: str,
+    port: int = 4310,
+    *,
+    playground_runner=None,
+) -> None:
     root = os.path.abspath(project_root)
 
     events = []
@@ -89,6 +101,18 @@ def run_server(project_root: str, port: int = 4310) -> None:
         cancel_lock=cancel_lock,
         cancel_events=cancel_events,
     )
+
+    # Playground subprocess runner. Tests inject a Mock via the keyword arg.
+    # Real implementation lands in src/copyclip/intelligence/marimo_runner.py
+    # (issue #88); until that merges we fall back to a stub that surfaces a
+    # stable JSON error so the endpoint contract and the frontend (#89) stay
+    # exercisable end-to-end.
+    if playground_runner is None:
+        try:
+            from .marimo_runner import MarimoRunner as _RealMarimoRunner  # type: ignore[attr-defined]
+            playground_runner = _RealMarimoRunner()
+        except ImportError:
+            playground_runner = StubMarimoRunner()
 
     def with_meta(payload: dict):
         return add_meta(root, payload)
@@ -352,6 +376,18 @@ def run_server(project_root: str, port: int = 4310) -> None:
             try:
                 init_schema(conn)
                 pid = project_id(conn, root)
+
+                if parsed.path.startswith("/api/playground/") and parsed.path.endswith("/status"):
+                    if not pid:
+                        self._json({"error": "run_analyze_first"}, 400)
+                        return
+                    playground_id = parsed.path[len("/api/playground/"):-len("/status")]
+                    if not playground_id or "/" in playground_id:
+                        self._json({"error": "missing_playground_id"}, 400)
+                        return
+                    status = playground_runner.status(playground_id)
+                    self._json({"status": status, "id": playground_id})
+                    return
 
                 if parsed.path == "/":
                     body = ctx.html.encode("utf-8")
@@ -1730,6 +1766,18 @@ def run_server(project_root: str, port: int = 4310) -> None:
                     self._json({"error": "run_analyze_first"}, 400)
                     return
 
+                if parsed.path.startswith("/api/playground/"):
+                    playground_id = parsed.path[len("/api/playground/"):]
+                    if not playground_id or "/" in playground_id:
+                        self._json({"error": "missing_playground_id"}, 400)
+                        return
+                    ok = playground_runner.kill(playground_id)
+                    if ok:
+                        self._json({"ok": True, "id": playground_id})
+                    else:
+                        self._json({"error": "playground_not_found", "id": playground_id}, 404)
+                    return
+
                 if parsed.path.startswith("/api/alerts/rules/"):
                     try:
                         rule_id = int(parsed.path.rsplit("/", 1)[-1])
@@ -1756,6 +1804,19 @@ def run_server(project_root: str, port: int = 4310) -> None:
                 pid = project_id(conn, root)
                 if not pid:
                     self._json({"error": "run_analyze_first"}, 400)
+                    return
+
+                if parsed.path == "/api/playground/launch":
+                    try:
+                        data = read_json_body(self)
+                        req = PlaygroundLaunchRequest.from_dict(data)
+                        response = launch_playground(req, root, conn, pid, playground_runner)
+                        self._json(response.to_dict())
+                    except PlaygroundError as e:
+                        payload = {"error": e.error_code, "message": str(e)}
+                        if isinstance(e, MarimoNotInstalledError):
+                            payload["install_hint"] = "pip install copyclip[playground]"
+                        self._json(payload, e.http_status)
                     return
 
                 if parsed.path == "/api/handoff-packets":

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -104,15 +104,21 @@ def run_server(
 
     # Playground subprocess runner. Tests inject a Mock via the keyword arg.
     # Real implementation lands in src/copyclip/intelligence/marimo_runner.py
-    # (issue #88); until that merges we fall back to a stub that surfaces a
-    # stable JSON error so the endpoint contract and the frontend (#89) stay
-    # exercisable end-to-end.
+    # (issue #88). Contract: that module MUST expose either a class named
+    # `MarimoRunner` instantiable with no args, OR a factory `create_runner()
+    # -> MarimoRunner`. Update this block accordingly when #88 merges. The
+    # StubMarimoRunner is the safety net so endpoint shape and the frontend
+    # (#89) stay exercisable end-to-end until then.
     if playground_runner is None:
         try:
-            from .marimo_runner import MarimoRunner as _RealMarimoRunner  # type: ignore[attr-defined]
-            playground_runner = _RealMarimoRunner()
+            from .marimo_runner import create_runner as _create_runner  # type: ignore[attr-defined]
+            playground_runner = _create_runner()
         except ImportError:
-            playground_runner = StubMarimoRunner()
+            try:
+                from .marimo_runner import MarimoRunner as _RealMarimoRunner  # type: ignore[attr-defined]
+                playground_runner = _RealMarimoRunner()
+            except ImportError:
+                playground_runner = StubMarimoRunner()
 
     def with_meta(payload: dict):
         return add_meta(root, payload)
@@ -1809,6 +1815,13 @@ def run_server(
                 if parsed.path == "/api/playground/launch":
                     try:
                         data = read_json_body(self)
+                    except (json.JSONDecodeError, ValueError) as e:
+                        self._json(
+                            {"error": "invalid_request", "message": f"malformed JSON body: {e}"},
+                            400,
+                        )
+                        return
+                    try:
                         req = PlaygroundLaunchRequest.from_dict(data)
                         response = launch_playground(req, root, conn, pid, playground_runner)
                         self._json(response.to_dict())

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -605,3 +605,212 @@ def test_status_endpoint_returns_runner_status_missing():
     status, body = _get_json(f"http://127.0.0.1:{port}/api/playground/unknown/status")
     assert status == 200
     assert body["status"] == "missing"
+
+
+# ---------------------------------------------------------------------------
+# Security & robustness regression tests
+# (post-review additions; see PR #98 review for context)
+# ---------------------------------------------------------------------------
+
+
+def test_function_ref_rejects_non_identifier_name():
+    with pytest.raises(InvalidFunctionRefError):
+        FunctionRef.from_dict({"file": "src/foo.py", "name": "bar; import os"})
+
+
+def test_function_ref_rejects_qualname_injection():
+    """qualname='x;import os;y.real_method' would otherwise inject `import os`
+    into the generated `from {mod} import x;import os;y` statement."""
+    with pytest.raises(InvalidFunctionRefError):
+        FunctionRef.from_dict(
+            {
+                "file": "src/foo.py",
+                "name": "real_method",
+                "qualname": "x;import os;y.real_method",
+            }
+        )
+
+
+def test_function_ref_rejects_nested_qualname():
+    with pytest.raises(InvalidFunctionRefError):
+        FunctionRef.from_dict(
+            {
+                "file": "src/foo.py",
+                "name": "method_name",
+                "qualname": "Outer.Inner.method_name",
+            }
+        )
+
+
+def test_function_ref_rejects_path_traversal():
+    with pytest.raises(InvalidFunctionRefError):
+        FunctionRef.from_dict({"file": "../../../etc/passwd.py", "name": "bar"})
+
+
+def test_function_ref_rejects_path_traversal_windows_separators():
+    with pytest.raises(InvalidFunctionRefError):
+        FunctionRef.from_dict({"file": "src\\..\\..\\etc.py", "name": "bar"})
+
+
+def test_generate_notebook_sanitizes_newline_in_breadcrumb(tmp_path):
+    """A breadcrumb with a newline must not escape the comment line and run
+    as code on subprocess spawn."""
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(file="src/copyclip/foo.py", name="bar"),
+        suggested_inputs=[1],
+        breadcrumb="atlas\n    import os; os.system('pwn')",
+    )
+    nb = generate_marimo_notebook(req, str(tmp_path), _make_resolved(), temp_dir=str(tmp_path))
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    # The whole payload must collapse to a single `# Breadcrumb:` comment line,
+    # and `os.system` must NOT appear on any non-comment line.
+    breadcrumb_lines = [
+        ln for ln in content.splitlines() if ln.lstrip().startswith("# Breadcrumb:")
+    ]
+    assert len(breadcrumb_lines) == 1
+    assert "os.system" in breadcrumb_lines[0]
+    for line in content.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        assert "os.system" not in stripped, f"os.system leaked into runnable line: {line!r}"
+
+
+def test_generate_notebook_sanitizes_unicode_line_separator(tmp_path):
+    """U+2028 (line separator) is also a line terminator in some contexts."""
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(file="src/copyclip/foo.py", name="bar"),
+        suggested_inputs=[1],
+        breadcrumb="atlas import os",
+    )
+    nb = generate_marimo_notebook(req, str(tmp_path), _make_resolved(), temp_dir=str(tmp_path))
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    assert " " not in content
+
+
+def test_generate_notebook_truncates_excessive_breadcrumb(tmp_path):
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(file="src/copyclip/foo.py", name="bar"),
+        suggested_inputs=[1],
+        breadcrumb="x" * 2000,
+    )
+    nb = generate_marimo_notebook(req, str(tmp_path), _make_resolved(), temp_dir=str(tmp_path))
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    # Long enough to verify the sanitiser engaged without hard-coding the cap.
+    assert content.count("x") < 1000
+    assert "..." in content
+
+
+def test_resolve_function_ref_rejects_non_importable_module():
+    """Files like 2legit.py or foo-bar.py would otherwise produce an import
+    statement that fails at runtime with a confusing marimo_spawn_failed."""
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_project(conn)
+    _seed_symbol(
+        conn, pid, name="bar", kind="function", file_path="src/foo-bar.py", module=None
+    )
+    with pytest.raises(FunctionNotFoundError) as exc:
+        resolve_function_ref(conn, pid, FunctionRef(file="src/foo-bar.py", name="bar"))
+    assert "importable" in str(exc.value).lower()
+
+
+def test_resolve_function_ref_uses_db_file_for_module_fallback():
+    """When the symbols.module column is NULL, the resolver derives the module
+    from the analyzer's canonical file path, not the user-supplied path."""
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_project(conn)
+    _seed_symbol(
+        conn, pid, name="bar", kind="function", file_path="src/copyclip/foo.py", module=None
+    )
+    resolved = resolve_function_ref(
+        conn, pid, FunctionRef(file="src/copyclip/foo.py", name="bar")
+    )
+    assert resolved.module == "copyclip.foo"
+
+
+def test_launch_playground_cleans_temp_dir_on_runner_failure(tmp_path):
+    """Failed runner.launch must not leak per-request temp dirs."""
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_project(conn)
+    _seed_symbol(conn, pid, name="bar", kind="function", file_path="src/foo.py", module="foo")
+
+    mock_runner = Mock()
+    mock_runner.launch.side_effect = MarimoSpawnError("boom")
+
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(file="src/foo.py", name="bar"),
+        suggested_inputs=[1],
+        breadcrumb="test",
+    )
+    with pytest.raises(MarimoSpawnError):
+        launch_playground(req, str(tmp_path), conn, pid, mock_runner)
+
+    notebook_path = mock_runner.launch.call_args[0][0]
+    assert not Path(notebook_path).exists(), "temp notebook should be cleaned up"
+    assert not Path(notebook_path).parent.exists(), "temp dir should be cleaned up"
+
+
+def test_launch_endpoint_rejects_malformed_json():
+    """A POST with a non-JSON body must surface as 400 invalid_request, not
+    bubble up as an HTTP 500."""
+    _, port = _start_server_with_runner(Mock())
+
+    body = b"not json at all {{{{"
+    req = request.Request(
+        f"http://127.0.0.1:{port}/api/playground/launch",
+        method="POST",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with request.urlopen(req, timeout=3) as r:
+            status, payload = r.status, json.loads(r.read().decode("utf-8"))
+    except HTTPError as exc:
+        body_text = exc.read().decode("utf-8")
+        status, payload = exc.code, json.loads(body_text) if body_text else {}
+    assert status == 400
+    assert payload["error"] == "invalid_request"
+
+
+def test_launch_endpoint_rejects_qualname_injection():
+    _, port = _start_server_with_runner(Mock())
+
+    status, body = _post_json(
+        f"http://127.0.0.1:{port}/api/playground/launch",
+        {
+            "source": "atlas",
+            "function_ref": {
+                "file": "src/copyclip/intelligence/reacquaintance.py",
+                "name": "build_reacquaintance_briefing",
+                "qualname": "x;import os;y.build_reacquaintance_briefing",
+            },
+            "breadcrumb": "test",
+        },
+    )
+    assert status == 400
+    assert body["error"] == "invalid_function_ref"
+
+
+def test_launch_endpoint_rejects_path_traversal():
+    _, port = _start_server_with_runner(Mock())
+
+    status, body = _post_json(
+        f"http://127.0.0.1:{port}/api/playground/launch",
+        {
+            "source": "atlas",
+            "function_ref": {"file": "../../../etc/passwd.py", "name": "bar"},
+            "breadcrumb": "test",
+        },
+    )
+    assert status == 400
+    assert body["error"] == "invalid_function_ref"

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -1,0 +1,607 @@
+"""Tests for the Anchored Playground backend foundation (issue #87).
+
+Covers:
+- Wire-shape parsing and validation (FunctionRef, PlaygroundLaunchRequest)
+- Module-from-file path conversion
+- Marimo notebook generation (valid Python, empty inputs, method qualname,
+  first-input-only semantics)
+- Resolver against a seeded sqlite symbols table
+- Orchestrator (launch_playground) with a Mock runner
+- StubMarimoRunner placeholder behaviour
+- HTTP endpoints (POST /launch, DELETE /{id}, GET /{id}/status) with an
+  injected Mock runner
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import socket
+import sqlite3
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import Mock
+from urllib import request
+from urllib.error import HTTPError
+
+import pytest
+
+from copyclip.intelligence.db import connect, init_schema
+from copyclip.intelligence.playground import (
+    FunctionNotFoundError,
+    FunctionRef,
+    InvalidFunctionRefError,
+    InvalidRequestError,
+    MarimoNotInstalledError,
+    MarimoSpawnError,
+    PlaygroundLaunchRequest,
+    PlaygroundLaunchResponse,
+    ResolvedFunction,
+    StubMarimoRunner,
+    _module_from_file,
+    generate_marimo_notebook,
+    launch_playground,
+    resolve_function_ref,
+)
+from copyclip.intelligence.server import run_server
+
+
+# ---------------------------------------------------------------------------
+# Wire-shape parsing
+# ---------------------------------------------------------------------------
+
+
+def test_function_ref_from_dict_minimal():
+    ref = FunctionRef.from_dict({"file": "src/foo.py", "name": "bar"})
+    assert ref.file == "src/foo.py"
+    assert ref.name == "bar"
+    assert ref.line is None
+    assert ref.qualname is None
+
+
+def test_function_ref_from_dict_full():
+    ref = FunctionRef.from_dict(
+        {"file": "src/foo.py", "name": "method_name", "line": 42, "qualname": "Foo.method_name"}
+    )
+    assert ref.line == 42
+    assert ref.qualname == "Foo.method_name"
+
+
+def test_function_ref_rejects_absolute_posix_path():
+    with pytest.raises(InvalidFunctionRefError):
+        FunctionRef.from_dict({"file": "/abs/foo.py", "name": "bar"})
+
+
+def test_function_ref_rejects_absolute_windows_path():
+    with pytest.raises(InvalidFunctionRefError):
+        FunctionRef.from_dict({"file": "C:/abs/foo.py", "name": "bar"})
+
+
+def test_function_ref_rejects_missing_file():
+    with pytest.raises(InvalidFunctionRefError):
+        FunctionRef.from_dict({"name": "bar"})
+
+
+def test_function_ref_rejects_missing_name():
+    with pytest.raises(InvalidFunctionRefError):
+        FunctionRef.from_dict({"file": "src/foo.py"})
+
+
+def test_request_from_dict_minimal():
+    req = PlaygroundLaunchRequest.from_dict(
+        {
+            "source": "atlas",
+            "function_ref": {"file": "src/foo.py", "name": "bar"},
+            "breadcrumb": "Atlas -> src/foo.py -> bar()",
+        }
+    )
+    assert req.source == "atlas"
+    assert req.function_ref.name == "bar"
+    assert req.breadcrumb == "Atlas -> src/foo.py -> bar()"
+
+
+def test_request_rejects_invalid_source():
+    with pytest.raises(InvalidRequestError):
+        PlaygroundLaunchRequest.from_dict(
+            {"source": "made_up", "function_ref": {"file": "src/foo.py", "name": "bar"}}
+        )
+
+
+def test_response_to_dict_no_expires_at():
+    res = PlaygroundLaunchResponse(playground_id="abc", iframe_url="http://127.0.0.1:5000/")
+    payload = res.to_dict()
+    assert payload == {"playground_id": "abc", "iframe_url": "http://127.0.0.1:5000/"}
+    assert "expires_at" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Module-from-file helper
+# ---------------------------------------------------------------------------
+
+
+def test_module_from_file_strips_src_prefix():
+    assert _module_from_file("src/copyclip/foo.py") == "copyclip.foo"
+    assert (
+        _module_from_file("src/copyclip/intelligence/reacquaintance.py")
+        == "copyclip.intelligence.reacquaintance"
+    )
+
+
+def test_module_from_file_handles_no_src_prefix():
+    assert _module_from_file("tests/test_foo.py") == "tests.test_foo"
+
+
+def test_module_from_file_normalises_windows_separators():
+    assert _module_from_file("src\\copyclip\\foo.py") == "copyclip.foo"
+
+
+# ---------------------------------------------------------------------------
+# Notebook generator
+# ---------------------------------------------------------------------------
+
+
+def _make_resolved(
+    *,
+    name: str = "bar",
+    module: str = "copyclip.foo",
+    parent: str | None = None,
+    kind: str = "function",
+    file: str = "src/copyclip/foo.py",
+) -> ResolvedFunction:
+    return ResolvedFunction(
+        file=file,
+        name=name,
+        qualname=f"{parent}.{name}" if parent else name,
+        kind=kind,
+        module=module,
+        line_start=10,
+        parent_class=parent,
+    )
+
+
+def test_generate_notebook_writes_valid_python(tmp_path):
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(file="src/copyclip/foo.py", name="bar"),
+        suggested_inputs=[42],
+        breadcrumb="test",
+    )
+    nb = generate_marimo_notebook(req, str(tmp_path), _make_resolved(), temp_dir=str(tmp_path))
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    assert "from copyclip.foo import bar" in content
+    assert "result = bar(sample)" in content
+    assert "sample = 42" in content
+
+
+def test_generate_notebook_handles_empty_inputs(tmp_path):
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(file="src/copyclip/foo.py", name="bar"),
+        breadcrumb="test",
+    )
+    nb = generate_marimo_notebook(req, str(tmp_path), _make_resolved(), temp_dir=str(tmp_path))
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    assert "# TODO: supply input" in content
+    assert "result = bar(sample)" not in content
+
+
+def test_generate_notebook_method_qualname(tmp_path):
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(
+            file="src/copyclip/foo.py", name="method_name", qualname="Foo.method_name"
+        ),
+        suggested_inputs=[1],
+        breadcrumb="test",
+    )
+    nb = generate_marimo_notebook(
+        req,
+        str(tmp_path),
+        _make_resolved(name="method_name", parent="Foo", kind="method"),
+        temp_dir=str(tmp_path),
+    )
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    assert "from copyclip.foo import Foo" in content
+    assert "Foo(...).method_name(sample)" in content
+
+
+def test_generate_notebook_uses_first_input_only(tmp_path):
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(file="src/copyclip/foo.py", name="bar"),
+        suggested_inputs=[7, 99, 1000],
+        breadcrumb="test",
+    )
+    nb = generate_marimo_notebook(req, str(tmp_path), _make_resolved(), temp_dir=str(tmp_path))
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    assert "sample = 7" in content
+    assert "99" not in content
+    assert "1000" not in content
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+def _seed_project(conn: sqlite3.Connection, root: str = "/proj") -> int:
+    conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root, "test"))
+    row = conn.execute("SELECT id FROM projects WHERE root_path=?", (root,)).fetchone()
+    return int(row[0])
+
+
+def _seed_symbol(
+    conn: sqlite3.Connection,
+    pid: int,
+    *,
+    name: str,
+    kind: str,
+    file_path: str,
+    module: str | None = None,
+    line_start: int = 10,
+) -> None:
+    conn.execute(
+        "INSERT INTO symbols(project_id,name,kind,file_path,line_start,line_end,parent_symbol_id,module) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        (pid, name, kind, file_path, line_start, line_start + 5, None, module),
+    )
+    conn.commit()
+
+
+def test_resolve_function_ref_finds_function():
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_project(conn)
+    _seed_symbol(conn, pid, name="bar", kind="function", file_path="src/foo.py", module="foo")
+    resolved = resolve_function_ref(conn, pid, FunctionRef(file="src/foo.py", name="bar"))
+    assert resolved.name == "bar"
+    assert resolved.kind == "function"
+    assert resolved.module == "foo"
+    assert resolved.parent_class is None
+
+
+def test_resolve_function_ref_method_with_qualname():
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_project(conn)
+    _seed_symbol(
+        conn, pid, name="method_name", kind="method", file_path="src/foo.py", module="foo"
+    )
+    resolved = resolve_function_ref(
+        conn,
+        pid,
+        FunctionRef(file="src/foo.py", name="method_name", qualname="Foo.method_name"),
+    )
+    assert resolved.parent_class == "Foo"
+    assert resolved.qualname == "Foo.method_name"
+
+
+def test_resolve_function_ref_raises_on_missing():
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_project(conn)
+    with pytest.raises(FunctionNotFoundError):
+        resolve_function_ref(conn, pid, FunctionRef(file="src/missing.py", name="nope"))
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def test_launch_playground_calls_runner_with_generated_path(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_project(conn)
+    _seed_symbol(conn, pid, name="bar", kind="function", file_path="src/foo.py", module="foo")
+
+    mock_runner = Mock()
+    mock_runner.launch.return_value = ("test-id-123", "http://127.0.0.1:5000/")
+
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(file="src/foo.py", name="bar"),
+        suggested_inputs=[1],
+        breadcrumb="test",
+    )
+    response = launch_playground(req, str(tmp_path), conn, pid, mock_runner)
+
+    assert response.playground_id == "test-id-123"
+    assert response.iframe_url == "http://127.0.0.1:5000/"
+    mock_runner.launch.assert_called_once()
+    notebook_path = mock_runner.launch.call_args[0][0]
+    assert Path(notebook_path).exists()
+    assert Path(notebook_path).name == "playground.py"
+
+
+def test_launch_playground_propagates_marimo_not_installed(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_project(conn)
+    _seed_symbol(conn, pid, name="bar", kind="function", file_path="src/foo.py", module="foo")
+
+    mock_runner = Mock()
+    mock_runner.launch.side_effect = MarimoNotInstalledError("marimo missing")
+
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(file="src/foo.py", name="bar"),
+        breadcrumb="test",
+    )
+    with pytest.raises(MarimoNotInstalledError):
+        launch_playground(req, str(tmp_path), conn, pid, mock_runner)
+
+
+# ---------------------------------------------------------------------------
+# StubMarimoRunner
+# ---------------------------------------------------------------------------
+
+
+def test_stub_runner_kill_returns_false():
+    assert StubMarimoRunner().kill("any-id") is False
+
+
+def test_stub_runner_status_returns_missing():
+    assert StubMarimoRunner().status("any-id") == "missing"
+
+
+def test_stub_runner_launch_raises_spawn_error(tmp_path):
+    nb = tmp_path / "playground.py"
+    nb.write_text("import marimo\napp = marimo.App()\n", encoding="utf-8")
+    with pytest.raises(MarimoSpawnError) as exc:
+        StubMarimoRunner().launch(str(nb))
+    assert "not yet implemented" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoints (Mock runner injected via run_server kwarg)
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_port(port: int, timeout_s: float = 3.0) -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError(f"server did not start on {port} in time")
+
+
+def _seed_playground_project(conn: sqlite3.Connection, root: str) -> int:
+    conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root, "test"))
+    pid = int(
+        conn.execute("SELECT id FROM projects WHERE root_path=?", (root,)).fetchone()[0]
+    )
+    conn.execute(
+        "INSERT INTO symbols(project_id,name,kind,file_path,line_start,line_end,parent_symbol_id,module) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        (
+            pid,
+            "build_reacquaintance_briefing",
+            "function",
+            "src/copyclip/intelligence/reacquaintance.py",
+            1,
+            10,
+            None,
+            "copyclip.intelligence.reacquaintance",
+        ),
+    )
+    conn.commit()
+    return pid
+
+
+def _post_json(url: str, payload: dict) -> tuple[int, dict]:
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        url, method="POST", data=data, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with request.urlopen(req, timeout=3) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8")
+        return exc.code, json.loads(body) if body else {}
+
+
+def _delete_json(url: str) -> tuple[int, dict]:
+    req = request.Request(url, method="DELETE")
+    try:
+        with request.urlopen(req, timeout=3) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8")
+        return exc.code, json.loads(body) if body else {}
+
+
+def _get_json(url: str) -> tuple[int, dict]:
+    try:
+        with request.urlopen(url, timeout=3) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8")
+        return exc.code, json.loads(body) if body else {}
+
+
+def _start_server_with_runner(runner) -> tuple[str, int]:
+    """Spin up a server bound to a fresh tempdir with the given runner injected.
+
+    Returns (root, port) — caller is responsible for nothing (thread is daemon).
+    """
+    td = tempfile.mkdtemp(prefix="copyclip-pg-test-")
+    root = str(Path(td).absolute())
+    conn = connect(root)
+    init_schema(conn)
+    _seed_playground_project(conn, root)
+    conn.close()
+
+    port = _free_port()
+    th = threading.Thread(
+        target=run_server,
+        kwargs={"project_root": root, "port": port, "playground_runner": runner},
+        daemon=True,
+    )
+    th.start()
+    _wait_port(port)
+    return root, port
+
+
+def test_launch_endpoint_returns_runner_response():
+    mock_runner = Mock()
+    mock_runner.launch.return_value = ("uuid-runner", "http://127.0.0.1:9999/")
+    _, port = _start_server_with_runner(mock_runner)
+
+    status, body = _post_json(
+        f"http://127.0.0.1:{port}/api/playground/launch",
+        {
+            "source": "atlas",
+            "function_ref": {
+                "file": "src/copyclip/intelligence/reacquaintance.py",
+                "name": "build_reacquaintance_briefing",
+            },
+            "breadcrumb": "test",
+        },
+    )
+    assert status == 200
+    assert body["playground_id"] == "uuid-runner"
+    assert body["iframe_url"] == "http://127.0.0.1:9999/"
+    assert "expires_at" not in body
+    mock_runner.launch.assert_called_once()
+
+
+def test_launch_endpoint_returns_marimo_not_installed():
+    mock_runner = Mock()
+    mock_runner.launch.side_effect = MarimoNotInstalledError("not installed")
+    _, port = _start_server_with_runner(mock_runner)
+
+    status, body = _post_json(
+        f"http://127.0.0.1:{port}/api/playground/launch",
+        {
+            "source": "atlas",
+            "function_ref": {
+                "file": "src/copyclip/intelligence/reacquaintance.py",
+                "name": "build_reacquaintance_briefing",
+            },
+            "breadcrumb": "test",
+        },
+    )
+    assert status == 503
+    assert body["error"] == "marimo_not_installed"
+    assert body["install_hint"] == "pip install copyclip[playground]"
+
+
+def test_launch_endpoint_rejects_absolute_path():
+    _, port = _start_server_with_runner(Mock())
+
+    status, body = _post_json(
+        f"http://127.0.0.1:{port}/api/playground/launch",
+        {
+            "source": "atlas",
+            "function_ref": {"file": "/abs/path/foo.py", "name": "bar"},
+            "breadcrumb": "test",
+        },
+    )
+    assert status == 400
+    assert body["error"] == "invalid_function_ref"
+
+
+def test_launch_endpoint_rejects_unknown_source():
+    _, port = _start_server_with_runner(Mock())
+
+    status, body = _post_json(
+        f"http://127.0.0.1:{port}/api/playground/launch",
+        {
+            "source": "made_up_surface",
+            "function_ref": {
+                "file": "src/copyclip/intelligence/reacquaintance.py",
+                "name": "build_reacquaintance_briefing",
+            },
+            "breadcrumb": "test",
+        },
+    )
+    assert status == 400
+    assert body["error"] == "invalid_request"
+
+
+def test_launch_endpoint_function_not_found():
+    _, port = _start_server_with_runner(Mock())
+
+    status, body = _post_json(
+        f"http://127.0.0.1:{port}/api/playground/launch",
+        {
+            "source": "atlas",
+            "function_ref": {
+                "file": "src/copyclip/intelligence/reacquaintance.py",
+                "name": "no_such_function_anywhere",
+            },
+            "breadcrumb": "test",
+        },
+    )
+    assert status == 404
+    assert body["error"] == "function_not_found"
+
+
+def test_delete_endpoint_calls_runner_kill():
+    mock_runner = Mock()
+    mock_runner.kill.return_value = True
+    _, port = _start_server_with_runner(mock_runner)
+
+    status, body = _delete_json(f"http://127.0.0.1:{port}/api/playground/some-uuid")
+    assert status == 200
+    assert body == {"ok": True, "id": "some-uuid"}
+    mock_runner.kill.assert_called_once_with("some-uuid")
+
+
+def test_delete_endpoint_returns_404_when_kill_returns_false():
+    mock_runner = Mock()
+    mock_runner.kill.return_value = False
+    _, port = _start_server_with_runner(mock_runner)
+
+    status, body = _delete_json(f"http://127.0.0.1:{port}/api/playground/missing-uuid")
+    assert status == 404
+    assert body["error"] == "playground_not_found"
+
+
+def test_status_endpoint_returns_runner_status_running():
+    mock_runner = Mock()
+    mock_runner.status.return_value = "running"
+    _, port = _start_server_with_runner(mock_runner)
+
+    status, body = _get_json(f"http://127.0.0.1:{port}/api/playground/abc/status")
+    assert status == 200
+    assert body == {"status": "running", "id": "abc"}
+
+
+def test_status_endpoint_returns_runner_status_exited():
+    mock_runner = Mock()
+    mock_runner.status.return_value = "exited"
+    _, port = _start_server_with_runner(mock_runner)
+
+    status, body = _get_json(f"http://127.0.0.1:{port}/api/playground/abc/status")
+    assert status == 200
+    assert body["status"] == "exited"
+
+
+def test_status_endpoint_returns_runner_status_missing():
+    mock_runner = Mock()
+    mock_runner.status.return_value = "missing"
+    _, port = _start_server_with_runner(mock_runner)
+
+    status, body = _get_json(f"http://127.0.0.1:{port}/api/playground/unknown/status")
+    assert status == 200
+    assert body["status"] == "missing"


### PR DESCRIPTION
## Summary

First PR of the **Anchored Playground** epic (#86). Lays the backend foundation: the bridge contract, the Marimo file generator, the three HTTP endpoints, and a temporary stub runner. Wire shape is exercisable end-to-end against a Mock from day one.

**Closes part of #86** — sub-issue #87. Unblocks #88 (subprocess manager) and #89 (frontend panel).

## What's in this PR

### `src/copyclip/intelligence/playground.py` (new, ~330 LOC)

- `FunctionRef`, `PlaygroundLaunchRequest`, `PlaygroundLaunchResponse` dataclasses (frozen) with strict `from_dict` validators and stable error codes.
- `MarimoRunner` Protocol consumed by the orchestrator (real impl lands in #88).
- Error class hierarchy: `PlaygroundError`, `InvalidFunctionRefError`, `InvalidRequestError`, `FunctionNotFoundError`, `MarimoNotInstalledError`, `MarimoSpawnError`, `NoFreePortError`.
- `resolve_function_ref` queries the analyzer's `symbols` table.
- `generate_marimo_notebook` writes a runnable `.py` per the spec's **Symbol resolution rules** table (plain function vs `Class.method` instance form).
- `StubMarimoRunner` placeholder used until #88 lands `marimo_runner.py`.

### `src/copyclip/intelligence/server.py`

- Three new routes wired into `do_POST` / `do_DELETE` / `do_GET`:
  - `POST /api/playground/launch`
  - `DELETE /api/playground/{id}`
  - `GET /api/playground/{id}/status`
- All inherit the existing `run_analyze_first` guard.
- `run_server` now accepts `playground_runner` kwarg so tests can inject a Mock against the real HTTP surface.

### `tests/test_playground.py` (new, 34 tests)

Contract roundtripping; absolute-path rejection (POSIX + Windows forms); module-from-file conversion; notebook generator (valid Python via `ast.parse`, empty inputs, method qualname, first-input-only semantics); resolver against seeded sqlite; orchestrator with `Mock` runner; `StubMarimoRunner` behaviour; HTTP endpoint integration tests (happy path plus `marimo_not_installed`, `function_not_found`, `invalid_function_ref`, `invalid_request`, DELETE 404, status `running`/`exited`/`missing`).

### `pyproject.toml`

`marimo>=0.10` added under `[project.optional-dependencies]` as a `playground` extra — install via `pip install copyclip[playground]`. Matches the merged spec (not a hard dep; the `marimo_not_installed` error path handles missing installs).

## Discrepancies with the original issue body (resolved during implementation)

The issue predated the spec review; spec wins:

- `marimo` → optional extra, not hard dep.
- `expires_at` removed from `PlaygroundLaunchResponse`.
- `function_ref.file` rejects absolute paths with `400 invalid_function_ref`.
- `run_analyze_first` guard inherited explicitly by all three endpoints.
- `iframe_url` normalised to `127.0.0.1` form.

## DoD evidence

- [x] `python -m pytest tests/test_playground.py -q` → **34 passed**
- [x] `python -m pytest -q` (full suite) → completed exit 0. 23 failures in `test_intelligence_server_api.py` are **pre-existing Windows-only teardown flakes** (`PermissionError` on `.copyclip/intelligence.db` cleanup); verified to reproduce on `main` with this branch's changes stashed.
- [x] `grep -n "playground" src/copyclip/intelligence/server.py` → POST/DELETE/GET wired at lines 380, 1769, 1809.
- [x] `python -c "from copyclip.intelligence.playground import PlaygroundLaunchRequest, launch_playground, StubMarimoRunner; print('ok')"` → ok.

## Scope (`git diff main --name-only`)

```
pyproject.toml
src/copyclip/intelligence/playground.py
src/copyclip/intelligence/server.py
tests/test_playground.py
```

Exactly the four files the issue called out.

## Test plan

- [x] Unit tests cover the contract / resolver / generator surfaces.
- [x] HTTP integration tests against the real `run_server` HTTP handler with an injected Mock runner.
- [x] Stub runner exercised so the endpoint chain works end-to-end without #88 merged.
- [ ] E2E with real Marimo waits on #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)