### PR TITLE
feat: marimo subprocess manager for playground (#86)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "tree-sitter-css",
   "tree-sitter-cpp",
   "tree-sitter-rust",
+  "psutil>=5.9",
 ]
 
 [project.optional-dependencies]

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ asyncio_mode = auto
 testpaths = tests
 markers =
     asyncio: marks tests that use asyncio
+    integration: spawns real subprocesses (slower; can be skipped with -m "not integration")

--- a/src/copyclip/intelligence/marimo_runner.py
+++ b/src/copyclip/intelligence/marimo_runner.py
@@ -1,0 +1,325 @@
+"""Marimo subprocess manager for the Anchored Playground (issue #88).
+
+Implements the ``MarimoRunner`` Protocol defined in ``playground.py``:
+
+* Spawn a fresh ``python -m marimo edit`` subprocess per launch on a
+  127.0.0.1-only port picked via the bind-to-0 trick.
+* Healthcheck the editor URL until it responds (or the subprocess dies),
+  surfacing ``MarimoNotInstalledError`` / ``MarimoSpawnError`` with a
+  stderr tail.
+* Terminate cross-platform with ``Popen.terminate()`` then ``kill()`` —
+  ``os.kill(SIGTERM)`` is POSIX-only and silently breaks on Windows.
+* Sweep orphaned ``copyclip-playground-*`` directories from previous
+  CopyClip crashes on startup (psutil ``cmdline`` scan — open_files
+  needs admin on Windows).
+
+Trust-by-design per the spec: the editor uses ``--no-token`` because
+the iframe is loaded by the same CopyClip dashboard that spawned the
+subprocess, both on 127.0.0.1. No sandboxing — the subprocess inherits
+``sys.executable``'s venv.
+"""
+
+from __future__ import annotations
+
+import collections
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import dataclass, field
+from typing import Literal
+
+import psutil
+
+from .playground import (
+    MarimoNotInstalledError,
+    MarimoSpawnError,
+    NoFreePortError,
+)
+
+MAX_CONCURRENT_PLAYGROUNDS = 5
+HEALTHCHECK_TIMEOUT_S = 10.0
+HEALTHCHECK_POLL_S = 0.1
+TERMINATE_GRACE_S = 2.0
+TEMP_DIR_PREFIX = "copyclip-playground-"
+_STDERR_TAIL_BYTES = 500
+_STDERR_BUFFER_BYTES = 8192
+
+# Marker substrings that prove the subprocess died because marimo itself
+# wasn't importable — distinct from a generic spawn failure.
+_MARIMO_NOT_INSTALLED_MARKERS = (
+    "No module named 'marimo'",
+    "No module named marimo",
+)
+
+
+class _StderrCollector:
+    """Background drain for the subprocess stderr pipe.
+
+    Without this, marimo's startup chatter (typically 1–4 KB) eventually
+    fills the OS pipe buffer (~64 KB POSIX, ~4 KB Windows) and blocks the
+    child on its next stderr write. The thread reads with ``read1`` so it
+    never waits for the buffer to fill before flushing — short reads land
+    in our deque immediately. The deque caps at ``_STDERR_BUFFER_BYTES``;
+    older bytes are evicted, which is what ``tail(n)`` wants anyway.
+    """
+
+    def __init__(self, stream) -> None:
+        self._buf: collections.deque = collections.deque(maxlen=_STDERR_BUFFER_BYTES)
+        self._lock = threading.Lock()
+        self._stream = stream
+        self._thread = threading.Thread(
+            target=self._drain, name="copyclip-marimo-stderr", daemon=True
+        )
+        self._thread.start()
+
+    def _drain(self) -> None:
+        try:
+            while True:
+                chunk = self._stream.read1(4096)
+                if not chunk:
+                    return  # EOF: subprocess closed stderr
+                with self._lock:
+                    self._buf.extend(chunk)
+        except Exception:
+            return
+
+    def tail(self, n: int = _STDERR_TAIL_BYTES) -> str:
+        with self._lock:
+            data = bytes(self._buf)
+        return data[-n:].decode("utf-8", errors="replace")
+
+    def join(self, timeout: float = 0.5) -> None:
+        self._thread.join(timeout=timeout)
+
+
+@dataclass
+class _RunningInstance:
+    playground_id: str
+    port: int
+    process: subprocess.Popen
+    temp_dir: str
+    stderr_collector: _StderrCollector = field(repr=False)
+
+
+class MarimoRunner:
+    """Spawn-on-demand Marimo subprocess manager. Thread-safe."""
+
+    def __init__(self) -> None:
+        self._instances: dict[str, _RunningInstance] = {}
+        self._lock = threading.Lock()
+        self._sweep_orphans_on_startup()
+
+    # ------------------------------------------------------------------
+    # Public API (MarimoRunner Protocol + kill_all)
+    # ------------------------------------------------------------------
+
+    def launch(self, notebook_path: str) -> tuple[str, str]:
+        with self._lock:
+            if len(self._instances) >= MAX_CONCURRENT_PLAYGROUNDS:
+                raise NoFreePortError(
+                    f"max {MAX_CONCURRENT_PLAYGROUNDS} playgrounds already running; "
+                    "close one before opening another"
+                )
+
+        port = self._allocate_port()
+        cmd = [
+            sys.executable,
+            "-m",
+            "marimo",
+            "edit",
+            notebook_path,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--headless",
+            "--no-token",
+        ]
+        try:
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            # sys.executable went away; treat as marimo-unavailable.
+            raise MarimoNotInstalledError(
+                f"python interpreter not found at {sys.executable!r}: {exc}"
+            ) from exc
+
+        collector = _StderrCollector(process.stderr)
+        try:
+            self._wait_for_healthy(process, port, collector)
+        except BaseException:
+            self._best_effort_kill(process)
+            raise
+
+        playground_id = uuid.uuid4().hex
+        temp_dir = os.path.dirname(os.path.abspath(notebook_path))
+        instance = _RunningInstance(
+            playground_id=playground_id,
+            port=port,
+            process=process,
+            temp_dir=temp_dir,
+            stderr_collector=collector,
+        )
+        with self._lock:
+            self._instances[playground_id] = instance
+        return playground_id, f"http://127.0.0.1:{port}/"
+
+    def kill(self, playground_id: str) -> bool:
+        with self._lock:
+            instance = self._instances.pop(playground_id, None)
+        if instance is None:
+            return False
+        self._best_effort_kill(instance.process)
+        shutil.rmtree(instance.temp_dir, ignore_errors=True)
+        return True
+
+    def status(
+        self, playground_id: str
+    ) -> Literal["running", "exited", "missing"]:
+        with self._lock:
+            instance = self._instances.get(playground_id)
+        if instance is None:
+            return "missing"
+        return "running" if instance.process.poll() is None else "exited"
+
+    def kill_all(self) -> None:
+        with self._lock:
+            instances = list(self._instances.values())
+            self._instances.clear()
+        for inst in instances:
+            try:
+                self._best_effort_kill(inst.process)
+            except Exception:
+                pass
+            shutil.rmtree(inst.temp_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _allocate_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+
+    def _probe_url(self, url: str) -> bool:
+        """Return True iff the URL responds with any HTTP status.
+
+        Even 4xx counts as healthy — what we care about is that the
+        subprocess bound the port and the HTTP layer is up.
+        """
+        try:
+            with urllib.request.urlopen(url, timeout=0.5) as r:
+                return 200 <= r.status < 500
+        except urllib.error.HTTPError as e:
+            return 200 <= e.code < 500
+        except Exception:
+            return False
+
+    def _wait_for_healthy(
+        self,
+        process: subprocess.Popen,
+        port: int,
+        collector: _StderrCollector,
+    ) -> None:
+        url = f"http://127.0.0.1:{port}/"
+        start = time.monotonic()
+        while time.monotonic() - start < HEALTHCHECK_TIMEOUT_S:
+            rc = process.poll()
+            if rc is not None:
+                # subprocess died before the editor came up
+                collector.join(timeout=0.5)
+                stderr_tail = collector.tail()
+                if any(m in stderr_tail for m in _MARIMO_NOT_INSTALLED_MARKERS):
+                    raise MarimoNotInstalledError(
+                        "marimo is not installed in the active python "
+                        f"({sys.executable}); install with: "
+                        "pip install 'copyclip[playground]'"
+                    )
+                raise MarimoSpawnError(
+                    f"marimo exited before becoming healthy (rc={rc}); "
+                    f"stderr_tail: {stderr_tail!r}"
+                )
+            if self._probe_url(url):
+                return
+            time.sleep(HEALTHCHECK_POLL_S)
+        # timeout: kill, then drain stderr for diagnostics
+        self._best_effort_kill(process)
+        collector.join(timeout=0.5)
+        raise MarimoSpawnError(
+            f"marimo failed to respond within {HEALTHCHECK_TIMEOUT_S}s on port {port}; "
+            f"stderr_tail: {collector.tail()!r}"
+        )
+
+    def _best_effort_kill(self, process: subprocess.Popen) -> None:
+        if process.poll() is not None:
+            return
+        try:
+            process.terminate()
+        except Exception:
+            pass
+        try:
+            process.wait(timeout=TERMINATE_GRACE_S)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            process.kill()
+        except Exception:
+            pass
+        try:
+            process.wait(timeout=TERMINATE_GRACE_S)
+        except Exception:
+            pass
+
+    def _sweep_orphans_on_startup(self) -> None:
+        tmp = tempfile.gettempdir()
+        try:
+            entries = os.listdir(tmp)
+        except OSError:
+            return
+        for name in entries:
+            if not name.startswith(TEMP_DIR_PREFIX):
+                continue
+            path = os.path.join(tmp, name)
+            if not os.path.isdir(path):
+                continue
+            if self._dir_has_live_owner(path):
+                continue
+            shutil.rmtree(path, ignore_errors=True)
+
+    def _dir_has_live_owner(self, path: str) -> bool:
+        """Detect whether any live process holds ``path``.
+
+        Implementation note: we scan ``cmdline`` rather than ``open_files``
+        because ``open_files`` requires elevated privileges on Windows and
+        is slow on Linux. The marimo subprocess is always spawned with the
+        notebook path (which lives inside ``path``) in its argv, so a
+        substring match is sufficient and cheap.
+        """
+        target = os.path.normcase(path)
+        for proc in psutil.process_iter(["pid", "cmdline"]):
+            try:
+                cmdline = proc.info.get("cmdline") or []
+                for arg in cmdline:
+                    if arg and target in os.path.normcase(arg):
+                        return True
+            except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+                continue
+        return False
+
+
+def create_runner() -> MarimoRunner:
+    """Factory consumed by ``server.py``'s fallback wiring."""
+    return MarimoRunner()

--- a/src/copyclip/intelligence/marimo_runner.py
+++ b/src/copyclip/intelligence/marimo_runner.py
@@ -106,6 +106,8 @@ class _RunningInstance:
     port: int
     process: subprocess.Popen
     temp_dir: str
+    # repr-suppressed: the collector owns a thread + deque whose repr is noise
+    # in tracebacks and adds nothing diagnosable about the instance itself.
     stderr_collector: _StderrCollector = field(repr=False)
 
 
@@ -114,6 +116,10 @@ class MarimoRunner:
 
     def __init__(self) -> None:
         self._instances: dict[str, _RunningInstance] = {}
+        # Slot reservations held during the slow spawn+healthcheck window so
+        # parallel launch() calls can't both pass the cap check while neither
+        # has registered yet. See launch() for the swap-under-lock.
+        self._reservations: set[str] = set()
         self._lock = threading.Lock()
         self._sweep_orphans_on_startup()
 
@@ -122,58 +128,81 @@ class MarimoRunner:
     # ------------------------------------------------------------------
 
     def launch(self, notebook_path: str) -> tuple[str, str]:
+        # Reserve a slot under the lock so two concurrent launches can't both
+        # see len == cap-1 and both register (ThreadingHTTPServer dispatches
+        # each request in its own thread, so this race is reachable).
+        slot_id = uuid.uuid4().hex
         with self._lock:
-            if len(self._instances) >= MAX_CONCURRENT_PLAYGROUNDS:
+            if (
+                len(self._instances) + len(self._reservations)
+                >= MAX_CONCURRENT_PLAYGROUNDS
+            ):
                 raise NoFreePortError(
                     f"max {MAX_CONCURRENT_PLAYGROUNDS} playgrounds already running; "
                     "close one before opening another"
                 )
+            self._reservations.add(slot_id)
 
-        port = self._allocate_port()
-        cmd = [
-            sys.executable,
-            "-m",
-            "marimo",
-            "edit",
-            notebook_path,
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(port),
-            "--headless",
-            "--no-token",
-        ]
         try:
-            process = subprocess.Popen(
-                cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
+            port = self._allocate_port()
+            cmd = [
+                sys.executable,
+                "-m",
+                "marimo",
+                "edit",
+                notebook_path,
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--headless",
+                "--no-token",
+            ]
+            try:
+                process = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                )
+            except FileNotFoundError as exc:
+                # sys.executable went away; treat as marimo-unavailable.
+                raise MarimoNotInstalledError(
+                    f"python interpreter not found at {sys.executable!r}: {exc}"
+                ) from exc
+
+            collector = _StderrCollector(process.stderr)
+            try:
+                self._wait_for_healthy(process, port, collector)
+            except BaseException:
+                # BaseException (not Exception) so Ctrl-C during a slow boot
+                # still kills the spawned subprocess before propagating —
+                # otherwise the marimo child would outlive its parent. The
+                # tempdir holding playground.py is cleaned by the caller
+                # (launch_playground() in playground.py) on any runner.launch
+                # failure, so we don't rmtree here.
+                self._best_effort_kill(process)
+                raise
+
+            playground_id = uuid.uuid4().hex
+            temp_dir = os.path.dirname(os.path.abspath(notebook_path))
+            instance = _RunningInstance(
+                playground_id=playground_id,
+                port=port,
+                process=process,
+                temp_dir=temp_dir,
+                stderr_collector=collector,
             )
-        except FileNotFoundError as exc:
-            # sys.executable went away; treat as marimo-unavailable.
-            raise MarimoNotInstalledError(
-                f"python interpreter not found at {sys.executable!r}: {exc}"
-            ) from exc
-
-        collector = _StderrCollector(process.stderr)
-        try:
-            self._wait_for_healthy(process, port, collector)
+            # Atomic swap: drop reservation and register instance under one
+            # lock, so the cap accounting (instances + reservations) never
+            # drops below the actual subprocess count.
+            with self._lock:
+                self._reservations.discard(slot_id)
+                self._instances[playground_id] = instance
+            return playground_id, f"http://127.0.0.1:{port}/"
         except BaseException:
-            self._best_effort_kill(process)
+            with self._lock:
+                self._reservations.discard(slot_id)
             raise
-
-        playground_id = uuid.uuid4().hex
-        temp_dir = os.path.dirname(os.path.abspath(notebook_path))
-        instance = _RunningInstance(
-            playground_id=playground_id,
-            port=port,
-            process=process,
-            temp_dir=temp_dir,
-            stderr_collector=collector,
-        )
-        with self._lock:
-            self._instances[playground_id] = instance
-        return playground_id, f"http://127.0.0.1:{port}/"
 
     def kill(self, playground_id: str) -> bool:
         with self._lock:
@@ -197,11 +226,19 @@ class MarimoRunner:
         with self._lock:
             instances = list(self._instances.values())
             self._instances.clear()
+            self._reservations.clear()
         for inst in instances:
             try:
                 self._best_effort_kill(inst.process)
-            except Exception:
-                pass
+            except Exception as exc:
+                # Best-effort: keep going so other instances still get cleaned.
+                # Surface the failure to stderr so a hung _best_effort_kill
+                # leaves a trail instead of vanishing silently.
+                print(
+                    f"WARN: kill_all could not terminate playground "
+                    f"{inst.playground_id} (pid {inst.process.pid}): {exc!r}",
+                    file=sys.stderr,
+                )
             shutil.rmtree(inst.temp_dir, ignore_errors=True)
 
     # ------------------------------------------------------------------
@@ -214,10 +251,14 @@ class MarimoRunner:
             return s.getsockname()[1]
 
     def _probe_url(self, url: str) -> bool:
-        """Return True iff the URL responds with any HTTP status.
+        """Return True iff the URL responds with a non-server-error HTTP status.
 
-        Even 4xx counts as healthy — what we care about is that the
-        subprocess bound the port and the HTTP layer is up.
+        Counts 4xx as healthy on purpose: marimo's editor may redirect or
+        gate the root URL depending on version (200 today, 302 → editor
+        path tomorrow, 404 if a flag changes the default route), but any
+        HTTP response under 500 proves the subprocess bound the port and
+        the HTTP stack is up. 5xx implies marimo is alive but broken —
+        treat as not-yet-healthy so the loop keeps polling until timeout.
         """
         try:
             with urllib.request.urlopen(url, timeout=0.5) as r:
@@ -306,7 +347,14 @@ class MarimoRunner:
         because ``open_files`` requires elevated privileges on Windows and
         is slow on Linux. The marimo subprocess is always spawned with the
         notebook path (which lives inside ``path``) in its argv, so a
-        substring match is sufficient and cheap.
+        substring match over each argument is sufficient and cheap.
+
+        Caveat: substring matching can false-positive — an unrelated tool
+        with the orphan's path in its argv (an editor session, a grep, a
+        `ps -ef | grep ...` invocation) would suppress the sweep. The cost
+        is one extra session of leaked disk; the next sweep cleans it. We
+        accept that vs. paying the price of an exact-arg + python+marimo
+        cmdline shape check in v1.
         """
         target = os.path.normcase(path)
         for proc in psutil.process_iter(["pid", "cmdline"]):

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -2445,4 +2445,12 @@ def run_server(
         except Exception:
             pass
         server.server_close()
+        # Kill any live Marimo playground subprocesses spawned during this
+        # session. Falls through silently for the Stub runner (no method).
+        kill_all = getattr(playground_runner, "kill_all", None)
+        if callable(kill_all):
+            try:
+                kill_all()
+            except Exception:
+                pass
         print(f"{_c('OK', '32')} Bye.")

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -2451,6 +2451,11 @@ def run_server(
         if callable(kill_all):
             try:
                 kill_all()
-            except Exception:
-                pass
+            except Exception as exc:
+                # Don't crash on the way out; do leave a breadcrumb so a
+                # hung subprocess cleanup is debuggable instead of silently
+                # lost.
+                print(
+                    f"{_c('WARN', '33')} playground_runner.kill_all() failed: {exc!r}"
+                )
         print(f"{_c('OK', '32')} Bye.")

--- a/tests/test_marimo_runner.py
+++ b/tests/test_marimo_runner.py
@@ -347,6 +347,74 @@ def test_concurrency_cap_enforced(monkeypatch, tmp_path):
     r.kill_all()
 
 
+def test_concurrency_cap_enforced_under_parallel_launches(monkeypatch, tmp_path):
+    """The reservation-slot pattern must hold the cap when launches race.
+
+    Without it, ``launch()`` released the lock between the cap check and
+    instance registration, so N concurrent launches could all pass the
+    guard while none had registered yet. This test gates ``Popen`` on a
+    barrier so every thread reaches it under the slot reservation, then
+    releases them simultaneously.
+    """
+    import threading as _t
+
+    spawn_gate = _t.Event()
+    procs: list[_FakeProcess] = []
+    procs_lock = _t.Lock()
+
+    def gated_popen(*args, **kwargs):
+        spawn_gate.wait(timeout=5.0)
+        p = _FakeProcess()
+        with procs_lock:
+            procs.append(p)
+        return p
+
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.subprocess.Popen", gated_popen
+    )
+    r = MarimoRunner()
+    monkeypatch.setattr(r, "_probe_url", lambda url: True)
+
+    n_threads = MAX_CONCURRENT_PLAYGROUNDS + 2
+    results: list[str] = []
+    results_lock = _t.Lock()
+
+    def attempt(idx: int) -> None:
+        nb = _make_notebook(tmp_path, f"race{idx}")
+        try:
+            r.launch(nb)
+            with results_lock:
+                results.append("ok")
+        except NoFreePortError:
+            with results_lock:
+                results.append("rejected")
+
+    threads = [
+        _t.Thread(target=attempt, args=(i,)) for i in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    # Give every thread time to acquire its slot reservation before any
+    # spawn proceeds. Without this beat, the first thread might complete
+    # before later threads run their cap check.
+    time.sleep(0.1)
+    spawn_gate.set()
+    for t in threads:
+        t.join(timeout=10.0)
+        assert not t.is_alive(), "race-test thread did not finish"
+
+    assert results.count("ok") == MAX_CONCURRENT_PLAYGROUNDS, (
+        f"got {results.count('ok')} successful launches; "
+        f"expected exactly {MAX_CONCURRENT_PLAYGROUNDS}"
+    )
+    assert results.count("rejected") == n_threads - MAX_CONCURRENT_PLAYGROUNDS
+    assert len(r._instances) == MAX_CONCURRENT_PLAYGROUNDS
+    # Reservations must drain after the launches settle, so a follow-up
+    # kill+launch can still admit a new slot.
+    assert r._reservations == set()
+    r.kill_all()
+
+
 # ---------------------------------------------------------------------------
 # Unit tests: orphan sweep on startup
 # ---------------------------------------------------------------------------

--- a/tests/test_marimo_runner.py
+++ b/tests/test_marimo_runner.py
@@ -1,0 +1,541 @@
+"""Tests for the Marimo subprocess manager (issue #88).
+
+Two tiers:
+
+* Unit tests monkey-patch ``subprocess.Popen`` and the URL probe to
+  exercise the lifecycle without paying the cost of a real Marimo boot.
+  These cover concurrency cap, orphan sweep, error mapping, and
+  cleanup semantics.
+
+* Integration tests (``@pytest.mark.integration``) spawn a real
+  ``python -m marimo edit`` subprocess on Windows/POSIX. Each uses a
+  fixture that registers ``runner.kill_all()`` as a finalizer so a
+  failing test never leaks subprocesses across the suite. Skipped
+  automatically when marimo isn't importable.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import psutil
+import pytest
+
+from copyclip.intelligence.marimo_runner import (
+    MAX_CONCURRENT_PLAYGROUNDS,
+    MarimoRunner,
+    _RunningInstance,
+    _StderrCollector,
+    create_runner,
+)
+from copyclip.intelligence.playground import (
+    MarimoNotInstalledError,
+    MarimoSpawnError,
+    NoFreePortError,
+)
+
+
+_MINIMAL_NOTEBOOK = (
+    "import marimo\n"
+    "app = marimo.App()\n\n"
+    "@app.cell\n"
+    "def __():\n"
+    "    return\n\n"
+    "if __name__ == '__main__':\n"
+    "    app.run()\n"
+)
+
+
+def _has_marimo() -> bool:
+    try:
+        import marimo  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# FakeProcess for unit tests (no real subprocess)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcess:
+    """Mimics the slice of ``subprocess.Popen`` that ``MarimoRunner`` uses."""
+
+    def __init__(
+        self,
+        stderr_data: bytes = b"",
+        poll_initial: int | None = None,
+    ) -> None:
+        self._poll_value = poll_initial
+        self.returncode = poll_initial if poll_initial is not None else 0
+        self.stderr = io.BytesIO(stderr_data)
+        self.stdout = None
+        self.pid = 0
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self._poll_value
+
+    def terminate(self) -> None:
+        self.terminated = True
+        if self._poll_value is None:
+            self._poll_value = -15
+            self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        if self._poll_value is None:
+            self._poll_value = -9
+            self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self._poll_value is None:
+            self._poll_value = 0
+            self.returncode = 0
+        return self._poll_value
+
+
+def _make_notebook(tmp_path: Path, name: str) -> str:
+    nb_dir = tmp_path / f"copyclip-playground-{name}"
+    nb_dir.mkdir()
+    nb = nb_dir / "playground.py"
+    nb.write_text(_MINIMAL_NOTEBOOK, encoding="utf-8")
+    return str(nb)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner(request):
+    """A MarimoRunner with kill_all registered as a finalizer.
+
+    Guarantees no orphan subprocesses leak even if a test asserts and
+    aborts before its own cleanup.
+    """
+    r = MarimoRunner()
+    request.addfinalizer(r.kill_all)
+    return r
+
+
+@pytest.fixture
+def minimal_notebook(tmp_path):
+    return _make_notebook(tmp_path, "integration")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: API basics
+# ---------------------------------------------------------------------------
+
+
+def test_status_returns_missing_for_unknown_id():
+    assert MarimoRunner().status("nonexistent-id") == "missing"
+
+
+def test_kill_returns_false_for_unknown_id():
+    assert MarimoRunner().kill("nonexistent-id") is False
+
+
+def test_create_runner_returns_marimo_runner():
+    assert isinstance(create_runner(), MarimoRunner)
+
+
+def test_allocate_port_returns_valid_port():
+    port = MarimoRunner()._allocate_port()
+    assert 1024 <= port < 65536
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: launch / kill happy path (mocked subprocess)
+# ---------------------------------------------------------------------------
+
+
+def _patch_healthy_spawn(monkeypatch, fake_proc=None):
+    """Wire Popen and _probe_url so launch() succeeds without real marimo."""
+    proc = fake_proc or _FakeProcess()
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.subprocess.Popen",
+        lambda *a, **k: proc,
+    )
+    return proc
+
+
+def test_launch_returns_id_and_iframe_url(monkeypatch, tmp_path):
+    _patch_healthy_spawn(monkeypatch)
+    r = MarimoRunner()
+    monkeypatch.setattr(r, "_probe_url", lambda url: True)
+    nb = _make_notebook(tmp_path, "launch")
+
+    pid, url = r.launch(nb)
+
+    assert pid and len(pid) >= 16
+    assert url.startswith("http://127.0.0.1:")
+    assert url.endswith("/")
+    assert r.status(pid) == "running"
+    r.kill_all()
+
+
+def test_launch_picks_a_port_via_bind_zero(monkeypatch, tmp_path):
+    _patch_healthy_spawn(monkeypatch)
+    r = MarimoRunner()
+    monkeypatch.setattr(r, "_probe_url", lambda url: True)
+    nb = _make_notebook(tmp_path, "port")
+    _, url = r.launch(nb)
+
+    # The URL has a non-zero port that we can parse back.
+    port_str = url.rstrip("/").rsplit(":", 1)[-1]
+    port = int(port_str)
+    assert 1024 <= port < 65536
+    r.kill_all()
+
+
+def test_kill_removes_instance_and_temp_dir(monkeypatch, tmp_path):
+    fake_proc = _FakeProcess()
+    _patch_healthy_spawn(monkeypatch, fake_proc)
+    r = MarimoRunner()
+    monkeypatch.setattr(r, "_probe_url", lambda url: True)
+    nb = _make_notebook(tmp_path, "kill")
+    nb_dir = os.path.dirname(nb)
+
+    pid, _ = r.launch(nb)
+    assert os.path.isdir(nb_dir)
+
+    assert r.kill(pid) is True
+    assert fake_proc.terminated
+    assert r.status(pid) == "missing"
+    assert not os.path.exists(nb_dir)
+
+
+def test_kill_all_clears_every_instance(monkeypatch, tmp_path):
+    procs: list[_FakeProcess] = []
+
+    def fake_popen(*args, **kwargs):
+        p = _FakeProcess()
+        procs.append(p)
+        return p
+
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.subprocess.Popen", fake_popen
+    )
+    r = MarimoRunner()
+    monkeypatch.setattr(r, "_probe_url", lambda url: True)
+
+    nb_dirs = []
+    for i in range(3):
+        nb = _make_notebook(tmp_path, f"all{i}")
+        r.launch(nb)
+        nb_dirs.append(os.path.dirname(nb))
+
+    assert len(r._instances) == 3
+    r.kill_all()
+    assert r._instances == {}
+    for p in procs:
+        assert p.terminated or p.killed
+    for d in nb_dirs:
+        assert not os.path.exists(d)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: error mapping
+# ---------------------------------------------------------------------------
+
+
+def test_launch_raises_marimo_not_installed_when_stderr_says_so(
+    monkeypatch, tmp_path
+):
+    dead = _FakeProcess(
+        stderr_data=b"/usr/bin/python3: No module named marimo\n",
+        poll_initial=1,
+    )
+    _patch_healthy_spawn(monkeypatch, dead)
+    r = MarimoRunner()
+    nb = _make_notebook(tmp_path, "missing")
+
+    with pytest.raises(MarimoNotInstalledError):
+        r.launch(nb)
+
+
+def test_launch_raises_marimo_spawn_failed_on_early_exit(monkeypatch, tmp_path):
+    dead = _FakeProcess(
+        stderr_data=b"unrelated traceback: ValueError: boom\n", poll_initial=2
+    )
+    _patch_healthy_spawn(monkeypatch, dead)
+    r = MarimoRunner()
+    nb = _make_notebook(tmp_path, "early-exit")
+
+    with pytest.raises(MarimoSpawnError) as exc_info:
+        r.launch(nb)
+    # stderr tail should appear in the error for diagnostics
+    assert "boom" in str(exc_info.value) or "rc=2" in str(exc_info.value)
+
+
+def test_launch_raises_marimo_spawn_failed_on_timeout(monkeypatch, tmp_path):
+    """Subprocess stays alive but never serves HTTP — must raise after timeout."""
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.HEALTHCHECK_TIMEOUT_S", 0.3
+    )
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.HEALTHCHECK_POLL_S", 0.05
+    )
+    proc = _FakeProcess()  # poll() returns None — alive forever
+    _patch_healthy_spawn(monkeypatch, proc)
+    r = MarimoRunner()
+    monkeypatch.setattr(r, "_probe_url", lambda url: False)
+    nb = _make_notebook(tmp_path, "timeout")
+
+    with pytest.raises(MarimoSpawnError) as exc_info:
+        r.launch(nb)
+    assert "respond" in str(exc_info.value).lower()
+    assert proc.terminated  # launch must kill the hung subprocess before raising
+
+
+def test_launch_raises_marimo_not_installed_when_interpreter_missing(
+    monkeypatch, tmp_path
+):
+    def boom(*args, **kwargs):
+        raise FileNotFoundError("no such interpreter")
+
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.subprocess.Popen", boom
+    )
+    r = MarimoRunner()
+    nb = _make_notebook(tmp_path, "no-py")
+
+    with pytest.raises(MarimoNotInstalledError):
+        r.launch(nb)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: concurrency cap
+# ---------------------------------------------------------------------------
+
+
+def test_concurrency_cap_enforced(monkeypatch, tmp_path):
+    procs: list[_FakeProcess] = []
+
+    def fake_popen(*args, **kwargs):
+        p = _FakeProcess()
+        procs.append(p)
+        return p
+
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.subprocess.Popen", fake_popen
+    )
+    r = MarimoRunner()
+    monkeypatch.setattr(r, "_probe_url", lambda url: True)
+
+    for i in range(MAX_CONCURRENT_PLAYGROUNDS):
+        r.launch(_make_notebook(tmp_path, f"cap{i}"))
+
+    extra_nb = _make_notebook(tmp_path, "overflow")
+    with pytest.raises(NoFreePortError):
+        r.launch(extra_nb)
+    # cap rejection should not register a new instance or spawn anything new
+    assert len(r._instances) == MAX_CONCURRENT_PLAYGROUNDS
+    assert len(procs) == MAX_CONCURRENT_PLAYGROUNDS
+    r.kill_all()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: orphan sweep on startup
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_temp_dir_cleaned_on_startup(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.tempfile.gettempdir",
+        lambda: str(tmp_path),
+    )
+    orphan = tmp_path / "copyclip-playground-orphan"
+    orphan.mkdir()
+    (orphan / "playground.py").write_text("# leftover", encoding="utf-8")
+    assert orphan.exists()
+
+    MarimoRunner()
+
+    assert not orphan.exists()
+
+
+def test_orphan_sweep_ignores_unrelated_temp_dirs(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.tempfile.gettempdir",
+        lambda: str(tmp_path),
+    )
+    keep = tmp_path / "some-other-prefix-keepme"
+    keep.mkdir()
+
+    MarimoRunner()
+
+    assert keep.exists()
+
+
+def test_orphan_sweep_preserves_dirs_with_live_owner(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "copyclip.intelligence.marimo_runner.tempfile.gettempdir",
+        lambda: str(tmp_path),
+    )
+    live_dir = tmp_path / "copyclip-playground-live"
+    live_dir.mkdir()
+    marker_path = str(live_dir / "playground.py")
+    # Spawn a long-running python process whose cmdline contains
+    # the live_dir path verbatim (no shell escaping involved — argv
+    # is passed via CreateProcess/execve, so psutil sees it raw).
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(15)", marker_path]
+    )
+    try:
+        # Wait for the process to be visible in psutil's listing.
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            if any(
+                marker_path in (arg or "")
+                for p in psutil.process_iter(["cmdline"])
+                for arg in (p.info.get("cmdline") or [])
+            ):
+                break
+            time.sleep(0.05)
+
+        MarimoRunner()
+        assert live_dir.exists(), (
+            "live_dir should not be swept — its path is in a live process's cmdline"
+        )
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: stderr collector
+# ---------------------------------------------------------------------------
+
+
+def test_stderr_collector_captures_data_and_tails():
+    data = b"warning A\n" + b"warning B\n" * 50 + b"final line\n"
+    collector = _StderrCollector(io.BytesIO(data))
+    collector.join(timeout=1.0)
+    tail = collector.tail(40)
+    assert "final line" in tail
+    assert len(tail.encode("utf-8")) <= 40 or tail.endswith("final line\n")
+
+
+def test_stderr_collector_handles_empty_stream():
+    collector = _StderrCollector(io.BytesIO(b""))
+    collector.join(timeout=0.5)
+    assert collector.tail() == ""
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: real marimo subprocess
+# ---------------------------------------------------------------------------
+
+pytestmark_integration = pytest.mark.skipif(
+    not _has_marimo(), reason="marimo not installed; pip install copyclip[playground]"
+)
+
+
+@pytest.mark.integration
+@pytestmark_integration
+def test_integration_launch_starts_real_marimo(runner, minimal_notebook):
+    pid, url = runner.launch(minimal_notebook)
+    assert pid
+    assert url.startswith("http://127.0.0.1:")
+    assert runner.status(pid) == "running"
+
+    port = int(url.rstrip("/").rsplit(":", 1)[-1])
+    with socket.create_connection(("127.0.0.1", port), timeout=2.0):
+        pass  # something is listening
+
+
+@pytest.mark.integration
+@pytestmark_integration
+def test_integration_kill_terminates_within_2s(runner, minimal_notebook):
+    pid, _ = runner.launch(minimal_notebook)
+    with runner._lock:
+        sub_pid = runner._instances[pid].process.pid
+    assert psutil.pid_exists(sub_pid)
+
+    start = time.monotonic()
+    assert runner.kill(pid) is True
+    elapsed = time.monotonic() - start
+    # Spec budget is 2s grace + 0.5s slack for wait/cleanup
+    assert elapsed < 3.0, f"kill took {elapsed:.2f}s"
+
+    # Either gone outright, or a transient zombie on POSIX — never alive.
+    for _ in range(20):
+        if not psutil.pid_exists(sub_pid):
+            return
+        try:
+            status = psutil.Process(sub_pid).status()
+        except psutil.NoSuchProcess:
+            return
+        if status == psutil.STATUS_ZOMBIE:
+            return
+        time.sleep(0.05)
+    pytest.fail(f"subprocess pid {sub_pid} still alive after kill")
+
+
+@pytest.mark.integration
+@pytestmark_integration
+def test_integration_kill_removes_temp_dir(runner, minimal_notebook):
+    pid, _ = runner.launch(minimal_notebook)
+    with runner._lock:
+        temp_dir = runner._instances[pid].temp_dir
+    assert os.path.isdir(temp_dir)
+
+    runner.kill(pid)
+
+    assert not os.path.exists(temp_dir)
+
+
+@pytest.mark.integration
+@pytestmark_integration
+def test_integration_status_reports_running_then_exited(runner, minimal_notebook):
+    pid, _ = runner.launch(minimal_notebook)
+    assert runner.status(pid) == "running"
+
+    # Terminate the subprocess without going through runner.kill (which would
+    # remove the instance from the registry). After it dies, status flips
+    # from "running" to "exited" — the instance is still tracked.
+    with runner._lock:
+        proc = runner._instances[pid].process
+    proc.terminate()
+    try:
+        proc.wait(timeout=3.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=3.0)
+
+    assert runner.status(pid) == "exited"
+
+
+@pytest.mark.integration
+@pytestmark_integration
+def test_integration_kill_all_cleans_everything(runner, tmp_path):
+    nb1 = _make_notebook(tmp_path, "all1")
+    nb2 = _make_notebook(tmp_path, "all2")
+    pid1, _ = runner.launch(nb1)
+    pid2, _ = runner.launch(nb2)
+    assert runner.status(pid1) == "running"
+    assert runner.status(pid2) == "running"
+
+    runner.kill_all()
+
+    assert runner.status(pid1) == "missing"
+    assert runner.status(pid2) == "missing"
+    assert not os.path.exists(os.path.dirname(nb1))
+    assert not os.path.exists(os.path.dirname(nb2))


### PR DESCRIPTION
## Summary

Implements the `MarimoRunner` Protocol defined in `playground.py` (PR #98) so the Anchored Playground actually opens real Marimo notebooks — replaces the `StubMarimoRunner` fallback that was returning `marimo_spawn_failed` for every launch. Unblocks the #90 Atlas connector to embed live notebooks.

- Spawns one `python -m marimo edit` subprocess per launch on a 127.0.0.1-only port (bind-to-0).
- Healthchecks `http://127.0.0.1:{port}/` every 100ms up to 10s; surfaces `marimo_not_installed` / `marimo_spawn_failed` with the stderr tail for diagnostics.
- Cross-platform termination via `Popen.terminate()` → wait 2s → `kill()` (the original issue's `os.kill(SIGTERM)` doesn't work on Windows; this approach is what the spec settled on).
- Caps concurrency at 5, raises `NoFreePortError` past that.
- Sweeps orphan `copyclip-playground-*` tempdirs left by previous CopyClip crashes on startup (psutil `cmdline` scan — `open_files` needs admin on Windows).
- `kill_all()` wired into the server shutdown via `getattr` so the Stub fallback path still works.

Closes sub-issue #88 of epic #86.

## What's in this PR

- `src/copyclip/intelligence/marimo_runner.py` (new, ~290 LOC) — `MarimoRunner` class + `create_runner()` factory + `_StderrCollector` (background drain so a long-running marimo doesn't deadlock on a full stderr pipe buffer).
- `src/copyclip/intelligence/server.py` (+8 LOC) — `playground_runner.kill_all()` called in the shutdown `finally:` block.
- `pyproject.toml` — `psutil>=5.9` added as a hard dependency (used by the orphan-sweep cmdline scan).
- `pytest.ini` — registers the `integration` marker.
- `tests/test_marimo_runner.py` (new, ~410 LOC) — 18 unit tests + 5 integration tests gated on `@pytest.mark.integration` and `skipif(no marimo)`.

## DoD evidence

- [x] `python -m pytest tests/test_marimo_runner.py -q` — **23/23 green** (18 unit in 1.4s; 5 integration in ~8s with real marimo 0.23.7 on Win11).
- [x] `python -m pytest tests/test_playground.py -q` — **48/48 green** (PR #98 contract untouched).
- [x] `python -m pytest -q` — full suite shows the same 32 pre-existing failures from baseline (23 SQLite teardown flakes in `test_intelligence_server_api.py`; 9 missing-async-plugin flakes in `test_mcp_handoff.py` + `test_mcp_intent_oracle.py`). **No new regressions.**
- [x] Manual smoke `python -c "from copyclip.intelligence.marimo_runner import MarimoRunner; r=MarimoRunner(); print('ok')"` → `ok`.
- [x] Manual integration: started `python -m copyclip start --port 4321`, `GET /api/health` → `{"ok": true}`, `POST /api/playground/launch` → `function_not_found` 404 (the index for this checkout is empty — but confirms wiring goes through my runner, not the Stub, which would have returned `marimo_spawn_failed`).
- [x] `grep -n "marimo_runner" src/copyclip/intelligence/server.py` shows the existing fallback imports + the new `kill_all` shutdown hook.
- [x] `git diff main --name-only` lists exactly: `pyproject.toml`, `pytest.ini`, `src/copyclip/intelligence/marimo_runner.py`, `src/copyclip/intelligence/server.py`, `tests/test_marimo_runner.py`.

## Test plan

- [ ] `python -m pytest tests/test_marimo_runner.py -q` — confirm 23 green locally.
- [ ] `python -m pytest tests/test_marimo_runner.py -q -m "not integration"` — confirm the 18 fast tests stand alone (~1.4s) so CI without marimo installed can still gate.
- [ ] `python -m pytest tests/test_playground.py -q` — confirm 48/48 from PR #98 still pass.
- [ ] End-to-end: in a project with a populated symbol index, `POST /api/playground/launch` with a valid `function_ref` → should return `iframe_url` pointing at a freshly spawned `python -m marimo edit` on a unique 127.0.0.1 port; `tasklist | findstr python` shows the child; `DELETE /api/playground/{id}` makes it disappear.

## Notes / discrepancies from the original #88 issue text

These were resolved during the #98 spec review and locked in by the kickoff brief:

- `psutil` IS used (the original issue said "no" — superseded; we need it for cmdline-based orphan ownership detection because `open_files` requires elevated privileges on Windows).
- Termination uses `Popen.terminate()` / `kill()` rather than `os.kill(SIGTERM)` (the latter silently breaks on Windows).
- Concurrency cap of 5 (`MAX_CONCURRENT_PLAYGROUNDS`).
- Orphan cleanup on startup.
- Module exports both `MarimoRunner` (class) and `create_runner` (factory) — the fallback wiring in `server.py` accepts either.

## Pre-existing flake observed (not in scope)

`tests/test_playground.py::test_generate_notebook_uses_first_input_only` asserts that the strings `"99"` and `"1000"` do not appear in the generated notebook content — but the content embeds `repr(project_root)`, which for pytest-supplied `tmp_path` ends in `pytest-of-<user>/pytest-N/...`. When `N` contains `"99"` (`pytest-99`, `pytest-199`, `pytest-299`, …) or `"1000"`, the assertion fails. This existed before my changes and I left it alone — would be a 2-line fix to use absolute numeric matching but it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)