### PR TITLE
docs: ghost-cleanup + REJECTED.md brake mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Pick up any project after a week away, after 30 agent PRs, or after a context switch — CopyClip tells you exactly what changed, why it matters, and what you should read first.
 
-Built for solo developers and small teams who work alongside AI agents and need to stay in control of code they didn't write line by line.
+Built first for the author's own daily use, working alongside AI agents on long-lived personal codebases. Lives publicly so others with the same pain can read it, fork it, or learn from how the architecture is shaped — but the author optimizes for his own workflow first, team adoption is not currently in scope.
 
 - Project memory anchored to architectural decisions, not just commits.
 - Surfaces unfamiliar code — what AI wrote that you haven't reviewed.

--- a/docs/REJECTED.md
+++ b/docs/REJECTED.md
@@ -1,0 +1,93 @@
+# CopyClip — Rejected Ideas
+
+## Why this file exists
+
+Personal tools fail by infinite refinement of a tool that has stopped being used, not by
+lack of features. Without external pressure (users, deadlines, market signal), the only
+defense against scope creep is an explicit brake: a written record of technically-good
+ideas that the author chose **not** to build, and why.
+
+This file is the brake.
+
+A rejected idea is not a permanent verdict — circumstances may change, the criterion may
+evolve, the underlying need may resurface in a form that passes the tests. But it must
+be re-justified explicitly. Default behavior on a rejected idea is: stays rejected.
+
+## The rejection criterion
+
+The primary test every CopyClip feature must pass:
+
+> **Does this technique *support* the asymmetry — original author returning to a changed
+> codebase — or does it *dissolve* it?**
+
+If it supports the asymmetry, build it (subject to other priorities).
+If it dissolves the asymmetry, reject it — even if it would be technically interesting,
+even if competitors have it, even if it looks like an obvious win.
+
+### Secondary tests
+
+A feature SHOULD also pass each of these before being built:
+
+- **Friction test.** Can I name a specific recent friction this feature would have
+  resolved, with a date? If no, reject — it is being motivated by the hypothetical
+  audience, not by my actual pain.
+- **Mediation test.** Does this add a new agent layer between me and my code? If yes,
+  almost certainly reject — additional agentic intermediation increases cognitive load
+  even when it appears to reduce it.
+- **Horizon test.** Does the implementation cost match a personal-tool horizon (days
+  to weeks of effort, not months)? If no, defer indefinitely.
+
+Failing any one of these is grounds for rejection or significant reframing.
+
+## Rejected ideas
+
+### Semantic Refactor Agent (active-suggestion version) — 2026-05-26
+
+**What it was.** A specialized AI agent that would suggest architectural cleanups based on
+detected intent drift. Originally listed in `src/copyclip/roadmap.md` under the long-term
+capability goals section.
+
+**Why rejected.** Fails the primary test. The feature would have added a third authorship
+category — *"this is code an agent suggested that CopyClip's drift detector triggered"* —
+on top of the existing human-vs-agent split that the entire CopyClip architecture exists
+to protect. Introducing agentic intermediation, however well-informed by registered
+decisions, increases the cognitive load that CopyClip exists to reduce. It would have
+claimed to solve the drift problem while quietly making the authorship surface less
+legible to its human user.
+
+Also fails the mediation test (adds a new agent layer between author and code).
+
+**What survives.** The drift-detection capability is preserved as **Intent Drift Surface**
+— a passive layer that flags regions which have drifted from registered architectural
+decisions, surfacing them for the author's inspection. The reformulated version does NOT
+propose refactors and does NOT trigger agentic action. Refactor decisions stay with the
+author.
+
+**Cost of the rejection.** Loses the ergonomic appeal of *"the tool tells me what to do
+about the drift it found."* The author must read the drift surface and decide on response
+themselves. This is an acceptable cost — the cognitive load of deciding is precisely
+the load the architecture is designed to preserve under the author's ownership.
+
+**Triggered by.** Verdict from the `aurelius-voronov` meta-architect agent during the
+post-competitor strategic review (2026-05-26 arc, triggered by the surfacing of
+Lum1104/Understand-Anything).
+
+---
+
+## Template for future rejections
+
+Copy-paste this block for each new rejection:
+
+```
+### [Feature name] — YYYY-MM-DD
+
+**What it was.** [Concrete description, where it was proposed]
+
+**Why rejected.** Fails the [primary / friction / mediation / horizon] test because [...].
+
+**What survives (if anything).** [Reformulated version, or "nothing"]
+
+**Cost of the rejection.** [What ergonomic / capability gain is being given up]
+
+**Triggered by.** [What surfaced the question — friction, review, observation]
+```

--- a/src/copyclip/roadmap.md
+++ b/src/copyclip/roadmap.md
@@ -1,4 +1,4 @@
-# 🚀 CopyClip → Strategic Roadmap
+# 🚀 CopyClip → Capability Roadmap
 
 > Note: runtime/package version is currently `v0.4.0`. The milestones below describe product capability progress, not a strict semver changelog.
 
@@ -21,13 +21,13 @@
 
 ---
 
-## 🏆 1.0 Milestones: The "Intent Engine"
+## 🛠️ Long-term capability goals (no launch date)
 - [ ] **VSCode Extension:** Integrated intent-aware handoffs directly in the IDE.
-- [ ] **Semantic Refactor Agent:** Specialized agent that suggests architectural cleanups based on intent drift.
-- [ ] **Multi-Repo Project Memory:** Connect multiple repositories into a single "Corporate Brain" Codebase Map.
+- [ ] **Intent Drift Surface:** Passive detection layer that flags code regions which have drifted from registered architectural decisions. Surfaces the drift to the author for inspection; does NOT propose refactors or trigger agentic action. Refactor decisions stay with the author.
+- [ ] **Multi-Repo Project Memory:** If the author ever needs to navigate multiple repos as a single cognitive surface, connect them. Currently single-repo only.
 - [ ] **Exportable Constraints:** Generate `.copyclip/constraints.json` for external LLM system prompts.
 
 ---
 
 # 🎯 Vision
-Evolve CopyClip into the **Project Mind**—a sentinel that prevents developers from losing ownership of their projects as AI agents generate more code.
+A personal cognitive sentinel for the author — the tool that lets him stay attached to his own codebases as AI agents write more of the code. If others with the same pain eventually find it useful, that's downstream of the author's own daily use working.


### PR DESCRIPTION
## Summary
- Removes ghost-audience language from `README.md` and `src/copyclip/roadmap.md` after the project recommitted to personal-use scope on 2026-05-26
- Reformulates the roadmap's "Semantic Refactor Agent" as "Intent Drift Surface" (passive detection, no agentic suggestion) per the asymmetry test
- Adds `docs/REJECTED.md` as the explicit brake mechanism for personal-tool scope discipline

## Why
Following the closure of the protocol-pivot arc (PR #107, closed without merge) and Samuel's explicit commitment to use CopyClip as a personal tool, Aurelius-voronov's third-pass review identified specific language in README and roadmap that still performed audience-facing claims, and named the absence of an explicit brake against scope creep as the primary failure mode of personal tools.

This PR is the operational cleanup that flows from the recommitment.

## Changes
- `README.md` line 7: from *"Built for solo developers and small teams who work alongside AI agents..."* to honest staging language naming the author as primary user with public visibility for transparency/forkability (not team adoption).
- `src/copyclip/roadmap.md`:
  - Title: *"Strategic Roadmap"* → *"Capability Roadmap"*
  - *"1.0 Milestones: The Intent Engine"* → *"Long-term capability goals (no launch date)"*
  - *"Multi-Repo Project Memory: Connect multiple repositories into a single 'Corporate Brain' Codebase Map"* → honest single-repo-now framing with conditional future expansion
  - Vision section: from *"developers"* plural and *"Project Mind"* aspirational naming to *"a personal cognitive sentinel for the author"* with explicit downstream condition for others
  - *"Semantic Refactor Agent: Specialized agent that suggests architectural cleanups based on intent drift"* → *"Intent Drift Surface: Passive detection layer that flags code regions which have drifted from registered architectural decisions. Surfaces the drift to the author for inspection; does NOT propose refactors or trigger agentic action."*
- `docs/REJECTED.md`: new file with rejection criterion (asymmetry test as primary, friction/mediation/horizon as secondary), first concrete rejection (Semantic Refactor Agent active-suggestion version with full rationale), template for future entries.

## Test plan
- [ ] `README.md` renders cleanly in GitHub markdown viewer; no broken references or formatting issues
- [ ] `src/copyclip/roadmap.md` renders cleanly; section structure intact
- [ ] `docs/REJECTED.md` renders cleanly; rejection entry is dated, complete, and includes all required fields
- [ ] No code changes — confirmed via diff that only `.md` files in `docs/` and `README.md` plus `src/copyclip/roadmap.md` are touched; no test or build impact expected

## Related
- Closes the cleanup arc that followed PR #107 (closed without merge)
- Memory updated at `~/.claude/projects/.../memory/project_copyclip-personal-tool.md` to reflect the new state

🤖 Generated with [Claude Code](https://claude.com/claude-code)