### PR TITLE
test: bound substring asserts in test_playground (#100)

### DIFF
--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -221,8 +221,8 @@ def test_generate_notebook_uses_first_input_only(tmp_path):
     content = Path(nb).read_text(encoding="utf-8")
     ast.parse(content)
     assert "sample = 7" in content
-    assert "99" not in content
-    assert "1000" not in content
+    assert "sample = 99" not in content
+    assert "sample = 1000" not in content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Bounds the negative assertions in `test_generate_notebook_uses_first_input_only` to the `sample = N` shape that the positive assertion already uses.

## Why
The test asserted `"99" not in content` and `"1000" not in content`, but `content` embeds `repr(project_root)` from the auto-loaded cell. When pytest's invocation directory name contained the substring `"99"` (e.g. `pytest-99`, `pytest-199`, `pytest-299`, ...) or `"1000"`, the assertion failed even though the test logic was correct. The fix narrows the negative match to the exact shape of the generated sample line, so the project-root path can no longer collide with it.

Originated in PR #98; observed during PR #99 work at `pytest-of-Samuel/pytest-199/`.

## Test plan
- [x] `python -m pytest tests/test_playground.py -q` → 48 passed.
- [x] Sanity-check the change is exactly 2 lines (`"99"` → `"sample = 99"`, `"1000"` → `"sample = 1000"`).

Closes #100