### PR TITLE
feat: Atlas3D emits Function/Method/Class nodes via lazy symbol fetch (#104)

### DIFF
--- a/frontend/src/pages/Atlas3DPage.tsx
+++ b/frontend/src/pages/Atlas3DPage.tsx
@@ -53,6 +53,7 @@ const DEFAULT_NODE_COLORS: Record<string, string> = {
   Directory: '#f59e0b',
   File: '#42a5f5',
   Class: '#66bb6a',
+  Method: '#9ccc65',
   Interface: '#26a69a',
   Trait: '#81c784',
   Function: '#ffca28',
@@ -118,6 +119,14 @@ type FlowchartCanvasProps = {
   isDark: boolean
   selectedId: number | null
   onSelectNode: (id: number | null) => void
+  // Modules whose symbol children have not been fetched yet (state ≠ 'loaded').
+  // The expand affordance still renders for these so the user can trigger the
+  // lazy fetch; the label shows `+` (unknown count) instead of `+N`.
+  pendingModuleIds: ReadonlySet<number>
+  // Fired the first time a pending Module is expanded. The page wires this
+  // to a fetch against /api/module/symbols and merges the response into the
+  // data on the next render.
+  onModuleExpand: (moduleNodeId: number, modulePath: string) => void
 }
 
 type FlowEdgeInfo = {
@@ -367,7 +376,7 @@ function buildFlowData(tree: TreeNode | null, archNodes: ArchNode[], archEdges: 
 }
 
 const FlowchartCanvas = forwardRef<FlowHandle, FlowchartCanvasProps>(function FlowchartCanvas(
-  { data, width, height, nodeColors, edgeColors, isDark, selectedId, onSelectNode },
+  { data, width, height, nodeColors, edgeColors, isDark, selectedId, onSelectNode, pendingModuleIds, onModuleExpand },
   ref,
 ) {
   const svgRef = useRef<SVGSVGElement>(null)
@@ -703,15 +712,35 @@ const FlowchartCanvas = forwardRef<FlowHandle, FlowchartCanvasProps>(function Fl
 
   const toggleExpand = useCallback((id: number, event: React.MouseEvent) => {
     event.stopPropagation()
+    // Compute fetch intent BEFORE the updater — setExpanded's updater must
+    // stay pure because React strict mode invokes it twice in development,
+    // and calling onModuleExpand inside would fire the request twice.
+    const wasExpanded = expanded.has(id)
+    const node = nodeMap.get(id)
+    const willTriggerFetch =
+      !wasExpanded && node != null && node.type === 'Module' && pendingModuleIds.has(id)
     setExpanded((current) => {
       const next = new Set(current)
       if (next.has(id)) next.delete(id)
       else next.add(id)
       return next
     })
-  }, [])
+    if (willTriggerFetch && node) {
+      // The button stays as `+` (via the totalChildren === 0 branch below)
+      // until the response merges children into `data`; no spinner — by design
+      // the canvas keeps motion budget for the graph itself, not the node chrome.
+      onModuleExpand(id, node.path)
+    }
+  }, [expanded, nodeMap, pendingModuleIds, onModuleExpand])
 
-  const hasChildren = useCallback((id: number) => (childMap.get(id) || []).some((childId) => nodeMap.has(childId)), [childMap, nodeMap])
+  // Pending Modules still show the expand affordance even though childMap has
+  // no entries for them yet — that's how the user discovers there's something
+  // to fetch.
+  const hasChildren = useCallback(
+    (id: number) =>
+      pendingModuleIds.has(id) || (childMap.get(id) || []).some((childId) => nodeMap.has(childId)),
+    [childMap, nodeMap, pendingModuleIds],
+  )
   const childCount = useCallback((id: number) => (childMap.get(id) || []).filter((childId) => nodeMap.has(childId)).length, [childMap, nodeMap])
 
   return (
@@ -909,7 +938,11 @@ const FlowchartCanvas = forwardRef<FlowHandle, FlowchartCanvasProps>(function Fl
                     fill={color}
                     style={{ pointerEvents: 'none' }}
                   >
-                    {expandedNode ? '−' : `+${totalChildren}`}
+                    {expandedNode
+                      ? '−'
+                      : pendingModuleIds.has(id) && totalChildren === 0
+                        ? '+'
+                        : `+${totalChildren}`}
                   </text>
                 </g>
               )}
@@ -960,6 +993,19 @@ export function Atlas3DPage() {
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null)
   const [viewport, setViewport] = useState({ width: 1200, height: 760 })
   const flowRef = useRef<FlowHandle | null>(null)
+  // Per-module symbol cache for the lazy Module → Function/Method/Class expand.
+  // `idle` = fetch in flight, `loaded` = response merged (possibly with zero
+  // symbols). Absence = never requested → pending → shows `+` affordance.
+  const [moduleSymbolStates, setModuleSymbolStates] = useState<Map<number, 'idle' | 'loaded'>>(
+    () => new Map(),
+  )
+  const [moduleSymbolChildren, setModuleSymbolChildren] = useState<Map<number, FlowNode[]>>(
+    () => new Map(),
+  )
+  // Monotonically decreasing counter that hands out unique IDs for fetched
+  // symbol nodes. Negatives never collide with `buildFlowData`'s positive
+  // `nextId` allocation, so the merged FlowData can use plain numeric IDs.
+  const symbolIdCounterRef = useRef(-1)
 
   useEffect(() => {
     let cancelled = false
@@ -1013,14 +1059,107 @@ export function Atlas3DPage() {
     return { nodes: keepNodes, links: keepEdges }
   }, [baseData, searchQuery, visibleNodeTypes])
 
+  // Reset the symbol cache whenever a fresh graph arrives (re-analyze, project
+  // switch). The fetched Function/Method/Class IDs would otherwise dangle.
+  useEffect(() => {
+    setModuleSymbolStates(new Map())
+    setModuleSymbolChildren(new Map())
+    symbolIdCounterRef.current = -1
+  }, [baseData])
+
+  const fetchModuleSymbols = useCallback(
+    async (moduleNodeId: number, modulePath: string) => {
+      if (moduleSymbolStates.has(moduleNodeId)) return
+      const dotted = modulePath.startsWith('module:')
+        ? modulePath.slice('module:'.length)
+        : modulePath
+      if (!dotted) return
+      setModuleSymbolStates((prev) => {
+        const next = new Map(prev)
+        next.set(moduleNodeId, 'idle')
+        return next
+      })
+      try {
+        const response = await api.moduleSymbols(dotted)
+        const symbolNodes: FlowNode[] = []
+        for (const symbol of response.symbols) {
+          const kindCap =
+            symbol.kind.charAt(0).toUpperCase() + symbol.kind.slice(1)
+          if (kindCap !== 'Function' && kindCap !== 'Method' && kindCap !== 'Class') continue
+          symbolNodes.push({
+            id: symbolIdCounterRef.current,
+            name: symbol.name,
+            type: kindCap as FlowNodeType,
+            path: `${symbol.file_path}:${symbol.line_start}`,
+          })
+          symbolIdCounterRef.current -= 1
+        }
+        setModuleSymbolChildren((prev) => {
+          const next = new Map(prev)
+          next.set(moduleNodeId, symbolNodes)
+          return next
+        })
+        setModuleSymbolStates((prev) => {
+          const next = new Map(prev)
+          next.set(moduleNodeId, 'loaded')
+          return next
+        })
+      } catch (err) {
+        // Silent retry per the UX brief: no spinner, no error glyph. Drop the
+        // pending state so the next click re-attempts the fetch.
+        console.error('[atlas] module symbol fetch failed', dotted, err)
+        setModuleSymbolStates((prev) => {
+          const next = new Map(prev)
+          next.delete(moduleNodeId)
+          return next
+        })
+      }
+    },
+    [moduleSymbolStates],
+  )
+
+  const mergedData = useMemo<FlowData>(() => {
+    if (moduleSymbolChildren.size === 0) return filteredData
+    const newNodes = [...filteredData.nodes]
+    const newLinks = [...filteredData.links]
+    const parentIdsInData = new Set(filteredData.nodes.map((node) => node.id))
+    const query = searchQuery.trim().toLowerCase()
+    for (const [moduleId, symbolNodes] of moduleSymbolChildren) {
+      if (!parentIdsInData.has(moduleId)) continue
+      for (const symbolNode of symbolNodes) {
+        if (!visibleNodeTypes.has(symbolNode.type)) continue
+        if (
+          query &&
+          !symbolNode.name.toLowerCase().includes(query) &&
+          !symbolNode.path.toLowerCase().includes(query)
+        ) {
+          continue
+        }
+        newNodes.push(symbolNode)
+        newLinks.push({ source: moduleId, target: symbolNode.id, type: 'CONTAINS' })
+      }
+    }
+    return { nodes: newNodes, links: newLinks }
+  }, [filteredData, moduleSymbolChildren, visibleNodeTypes, searchQuery])
+
+  const pendingModuleIds = useMemo(() => {
+    const ids = new Set<number>()
+    for (const node of mergedData.nodes) {
+      if (node.type === 'Module' && moduleSymbolStates.get(node.id) !== 'loaded') {
+        ids.add(node.id)
+      }
+    }
+    return ids
+  }, [mergedData.nodes, moduleSymbolStates])
+
   useEffect(() => {
     if (selectedNodeId == null) return
-    if (!filteredData.nodes.some((node) => node.id === selectedNodeId)) setSelectedNodeId(null)
-  }, [filteredData.nodes, selectedNodeId])
+    if (!mergedData.nodes.some((node) => node.id === selectedNodeId)) setSelectedNodeId(null)
+  }, [mergedData.nodes, selectedNodeId])
 
   const selectedNode = useMemo(
-    () => filteredData.nodes.find((node) => node.id === selectedNodeId) || null,
-    [filteredData.nodes, selectedNodeId],
+    () => mergedData.nodes.find((node) => node.id === selectedNodeId) || null,
+    [mergedData.nodes, selectedNodeId],
   )
 
   const playground = usePlayground()
@@ -1119,7 +1258,7 @@ export function Atlas3DPage() {
         ) : (
           <FlowchartCanvas
             ref={flowRef}
-            data={filteredData}
+            data={mergedData}
             width={viewport.width}
             height={viewport.height}
             nodeColors={DEFAULT_NODE_COLORS}
@@ -1127,6 +1266,8 @@ export function Atlas3DPage() {
             isDark={isDark}
             selectedId={selectedNodeId}
             onSelectNode={setSelectedNodeId}
+            pendingModuleIds={pendingModuleIds}
+            onModuleExpand={fetchModuleSymbols}
           />
         )}
 


### PR DESCRIPTION
## Summary
Closes the v1 loop of the Anchored Playground epic (#86) by emitting symbol-level nodes (`Function` / `Method` / `Class`) in Atlas3D so the "▶ Playground" button can activate.

Until now the connector wired in #103 was filtering selections to `{Function, Method, Class}`, but `buildFlowData` only produced structural nodes (`Repository` / `Directory` / `File` / `Module` / `Other`), so the button stayed permanently disabled in the live UI. This PR closes the data-layer gap.

## Approach

**Lazy fetch by Module:**
- Per-module cache (`moduleSymbolStates` + `moduleSymbolChildren`) keyed by Module FlowNode id; resets on `baseData` change (re-analyze / project switch).
- `fetchModuleSymbols(id, modulePath)` strips the `module:` prefix, calls the existing `api.moduleSymbols(dotted)` endpoint, filters to `kind ∈ {function, method, class}` per issue scope, and emits FlowNodes with `path = "<file_path>:<line_start>"` (exactly what `buildLaunchableRef` already parses).
- Symbol nodes get monotonically-decreasing negative IDs so they can't collide with `buildFlowData`'s positive allocation.
- On fetch error: silent retry (state dropped, next click re-attempts). No spinner, no error glyph — the canvas keeps its motion budget for the graph itself.

**Expand UX (Iris Tane verdict):**
Reuses the existing `[+N]` affordance on each node — *not* a new gesture. Single unified rule across all node kinds:

> "+N if the count is known; just `+` if not."

| Module state | Children | Button label |
|---|---|---|
| Pending (no fetch yet) | — | `+` |
| Expanded, fetch in flight | — | `−` |
| Loaded, N > 0 children | N | `+N` (or `−` when expanded) |
| Loaded, 0 children | 0 | (no button — empty promise) |

Rejected: double-click as a separate gesture (invisible, breaks consistency); toolbar "Show symbols" pill (separates control from object). See the consultation in the PR conversation for the full reasoning.

**React strict mode safety:** `toggleExpand` was restructured so the fetch side effect fires *outside* the `setExpanded` updater. Strict mode invokes updaters twice in development; calling the fetch inside would have double-fired the request.

**Misc:** `Method` is added to `DEFAULT_NODE_COLORS` (`#9ccc65`, between Class green and Function yellow) so Method nodes don't fall back to the generic gray. The legend / filter panel picks it up automatically.

## Test plan

Verified:
- [x] `npm --prefix frontend run build` — TypeScript + Vite build green (50 modules, 728ms).
- [x] Static review of the state machine across four observable cases (pending+collapsed, pending+expanded, loaded+0, loaded+N).
- [x] Issue acceptance criterion #3 (graph load time < 2× baseline with 200+ symbols) — symbols are lazy, so initial load is identical to baseline.

Pending live verification (no headless UI tests committed in repo yet — see #105 / #106):
- [ ] Module nodes show `+` (not `+0`) before first expand.
- [ ] Clicking `+` on a Module fires exactly one `/api/module/symbols` request and renders the symbol children once it returns.
- [ ] Selecting a `Function` / `Method` / `Class` node activates the "▶ Playground" pill in the toolbar.
- [ ] Clicking the pill opens the playground with breadcrumb `Atlas → <file>:<line> → <name>()`.
- [ ] Search query / type-filter still respected over the expanded symbol set.
- [ ] No regression on existing Directory/File/Module collapse/expand behavior.

## Related

- Closes #104.
- Refs #86 (Anchored Playground epic).
- Builds on #98, #99, #102, #103 (v1 backend, subprocess manager, frontend panel, Atlas connector).
- Unblocks the v2 connector follow-ups (#91-#96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)