### PR TITLE
fix: normalize relpaths to POSIX in _iter_repo_files (#111)

### DIFF
--- a/src/copyclip/intelligence/analyzer.py
+++ b/src/copyclip/intelligence/analyzer.py
@@ -196,7 +196,13 @@ def _iter_repo_files(root: str) -> Iterable[Tuple[Path, str]]:
         dirs[:] = [d for d in dirs if d not in ignored_dirs]
         for f in files:
             p = Path(base) / f
-            rel = str(p.relative_to(root))
+            # Always emit POSIX-form separators: every downstream consumer
+            # (`_module_from_relpath`, `_is_test_path`, `cognitive_debt`
+            # markers, the stored `files.path` / `symbols.file_path`
+            # columns, frontend `normalizePath`) assumes `/`. Without this
+            # normalization, Windows `\\` separators collapse the entire
+            # project into a single module='root' (see #111).
+            rel = p.relative_to(root).as_posix()
             yield p, rel
 
 

--- a/tests/test_intelligence_analyzer.py
+++ b/tests/test_intelligence_analyzer.py
@@ -5,6 +5,8 @@ from copyclip.intelligence.analyzer import (
     _complexity_score,
     _is_dependency_impacted,
     _is_test_path,
+    _iter_repo_files,
+    _module_from_relpath,
 )
 from copyclip.intelligence.tree_sitter_parser import (
     CallRef,
@@ -20,6 +22,32 @@ def test_is_test_path_variants():
     assert _is_test_path("src/foo/bar.spec.ts")
     assert _is_test_path("src/foo/bar.test.js")
     assert not _is_test_path("src/foo/bar.ts")
+
+
+def test_iter_repo_files_yields_posix_relpaths(tmp_path):
+    """Regression for #111: every downstream consumer of `rel` assumes POSIX
+    separators. On Windows, `str(Path.relative_to(root))` returns backslashes,
+    which broke `_module_from_relpath`, `_is_test_path`, and the stored
+    `files.path` / `symbols.file_path` columns. `_iter_repo_files` is the
+    single point of normalization, so this test pins the contract there."""
+    (tmp_path / "src" / "copyclip" / "intelligence").mkdir(parents=True)
+    (tmp_path / "src" / "copyclip" / "intelligence" / "server.py").write_text("# x", encoding="utf-8")
+    (tmp_path / "src" / "copyclip" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "tests" / "intelligence").mkdir(parents=True)
+    (tmp_path / "tests" / "intelligence" / "test_server.py").write_text("# y", encoding="utf-8")
+
+    rels = [rel for _p, rel in _iter_repo_files(str(tmp_path))]
+
+    assert rels, "fixture must produce at least one file"
+    for rel in rels:
+        assert "\\" not in rel, f"relpath leaked a backslash: {rel!r}"
+
+    # Sanity: downstream consumers now see real module structure rather than
+    # collapsing to 'root'. Pre-fix, `_module_from_relpath` on a backslash
+    # relpath returned 'root' for every file.
+    by_basename = {rel.rsplit("/", 1)[-1]: rel for rel in rels}
+    assert _module_from_relpath(by_basename["server.py"]) != "root"
+    assert _is_test_path(by_basename["test_server.py"])
 
 
 def test_complexity_score_detects_control_flow():


### PR DESCRIPTION
## Summary

Closes #111. On Windows, every analyzed file collapsed into a single `module='root'` because `_iter_repo_files` returned backslash-separated relpaths and every downstream consumer assumes POSIX `/`.

`_iter_repo_files` now emits `p.relative_to(root).as_posix()`. Single point of normalization at the source. Every downstream consumer (`_module_from_relpath`, `_is_test_path`, `cognitive_debt` test-path markers, the stored `files.path` / `symbols.file_path` columns, the frontend's `normalizePath`) was already correct for POSIX input, so the chain reconnects in one change.

## Why this matters

The bug invalidated module-level analysis on Windows:

- Architecture graph degenerates to a single `root` Module containing every symbol.
- Cognitive debt's `_module_has_tests` always misses (test markers like `/tests/` never match backslash-separated stored paths).
- `_is_test_path` misclassifies test files as production files.
- The Atlas3D codebase map shows no Module nodes worth expanding, so the playground connector from #103 never has a target to activate — which is why #110's manual verification was blocked.

## Migration

Existing Windows DBs hold paths with backslashes. On the next `copyclip analyze`:

- `prev_state.get(rel)` lookups miss for those entries (keys are backslash-form, lookups are forward-slash form).
- The affected files are treated as "changed" and re-analyzed.
- After that one analyze, the DB is fully migrated.

No user action required beyond running analyze once. POSIX users are unaffected — `Path.as_posix()` returns the same string as `str(Path)` there.

## Test plan

- [x] `python -m pytest tests/test_intelligence_analyzer.py tests/test_playground.py tests/test_ast_extractor_enhancements.py tests/test_cognitive_debt_api.py` → 68 passed in 6.41s, no regression.
- [x] New regression test `test_iter_repo_files_yields_posix_relpaths` creates a real tempdir with nested files, asserts no `rel` contains `\`, and exercises two of the previously-broken downstreams (`_module_from_relpath` no longer returns `'root'` for a real path; `_is_test_path` correctly classifies a test file under `tests/`).
- [ ] Post-merge: full backend suite via `scripts/dev-smoke.sh` once the changes settle.

## Related

- Closes #111.
- Unblocks #110 (Atlas3D Function/Method/Class emission) — verification was stuck because the Windows analyzer left no Module nodes in the architecture graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)