### PR TITLE
fix(atlas3d): preserve expand state on lazy fetch + Python-only playground gate

### DIFF
--- a/frontend/src/pages/Atlas3DPage.tsx
+++ b/frontend/src/pages/Atlas3DPage.tsx
@@ -1158,6 +1158,21 @@ export function Atlas3DPage() {
     return ids
   }, [mergedData.nodes, moduleSymbolStates])
 
+  // Force a fresh `FlowchartCanvas` mount whenever the *structural* inputs
+  // change (project re-analyze, search query, or visible-type filter). This
+  // resets internal canvas state — expanded set, pan/zoom, hover — so the
+  // new tree's roots get the auto-expand-on-load treatment again. Crucially,
+  // it does NOT depend on `moduleSymbolChildren` or `mergedData`, so a lazy
+  // symbol fetch (which only appends children to an existing Module) does
+  // not trigger a remount and the user's expand stays intact.
+  const canvasResetKey = useMemo(
+    () =>
+      `${baseData.nodes.length}|${searchQuery}|${Array.from(visibleNodeTypes)
+        .sort()
+        .join(',')}`,
+    [baseData.nodes.length, searchQuery, visibleNodeTypes],
+  )
+
   useEffect(() => {
     if (selectedNodeId == null) return
     if (!mergedData.nodes.some((node) => node.id === selectedNodeId)) setSelectedNodeId(null)
@@ -1279,6 +1294,7 @@ export function Atlas3DPage() {
         ) : (
           <FlowchartCanvas
             ref={flowRef}
+            key={canvasResetKey}
             data={mergedData}
             width={viewport.width}
             height={viewport.height}

--- a/frontend/src/pages/Atlas3DPage.tsx
+++ b/frontend/src/pages/Atlas3DPage.tsx
@@ -438,13 +438,19 @@ const FlowchartCanvas = forwardRef<FlowHandle, FlowchartCanvasProps>(function Fl
     return next
   }, [roots, childMap])
 
+  // One-shot initialization: when data first becomes non-empty, seed
+  // `expanded` with the auto-expand-on-load policy. Subsequent data growth
+  // (e.g. lazy symbol fetch from #110's Module → Function/Method/Class
+  // expansion) must NOT re-fire this effect — otherwise the Module the
+  // user just clicked gets re-collapsed the moment its symbols arrive,
+  // and the view jumps back to the autoFit baseline.
+  const hasInitializedExpand = useRef(false)
   useEffect(() => {
+    if (hasInitializedExpand.current) return
+    if (data.nodes.length === 0) return
     setExpanded(initialExpanded)
-    setSelectedEdge(null)
-    setHoverEdge(null)
-    setHoverNode(null)
-    autoFitDone.current = false
-  }, [initialExpanded, data.nodes.length, data.links.length])
+    hasInitializedExpand.current = true
+  }, [data.nodes.length, initialExpanded])
 
   const orphanIds = useMemo(
     () => new Set(roots.filter((id) => !(childMap.get(id) || []).some((childId) => nodeMap.has(childId)))),
@@ -1166,8 +1172,21 @@ export function Atlas3DPage() {
   // Carry the narrowed node (or null) explicitly so TS sees a non-null
   // FlowNode in every branch that consumes it — avoids the
   // `selectedNode!.name` non-null assertions that the previous shape needed.
+  //
+  // Python-only gate: Marimo (the playground engine) runs Python in v1. A
+  // selection from a .ts/.tsx/.js file would reach `/api/playground/launch`
+  // with a module like 'frontend/src/pages', fail the importable-module
+  // check in resolve_function_ref (playground.py:310), and surface as a
+  // misleading "function_not_found" dialog. We gate at the source so the
+  // pill stays inert and the tooltip explains why.
+  const isPythonSymbolPath = (path: string) => {
+    const colon = path.indexOf(':')
+    const filePath = colon > 0 ? path.slice(0, colon) : path
+    return filePath.toLowerCase().endsWith('.py')
+  }
+  const isLaunchableType = selectedNode != null && LAUNCHABLE_NODE_TYPES.has(selectedNode.type)
   const launchableSelection =
-    selectedNode != null && LAUNCHABLE_NODE_TYPES.has(selectedNode.type)
+    isLaunchableType && selectedNode != null && isPythonSymbolPath(selectedNode.path)
       ? selectedNode
       : null
   const launchPlayground = useCallback(() => {
@@ -1214,7 +1233,9 @@ export function Atlas3DPage() {
             title={
               launchableSelection
                 ? `Run ${launchableSelection.name}() in a Marimo playground`
-                : 'Select a function, method, or class to open in the playground'
+                : isLaunchableType
+                  ? 'Playground is Python-only in v1 — select a function from a .py file'
+                  : 'Select a function, method, or class to open in the playground'
             }
             style={{
               borderColor: launchableSelection ? 'var(--accent-cyan)' : undefined,


### PR DESCRIPTION
## Summary

Two regressions surfaced during the manual smoke of #110. Single PR fixes both in `frontend/src/pages/Atlas3DPage.tsx`.

## 1) Expand state collapses the moment symbols arrive

**Symptom:** Click `+` on a Module → the Module visibly expands → fetch resolves → the Module collapses back and the view snaps to the auto-fit baseline.

**Cause:** `FlowchartCanvas` had a reset effect with `data.nodes.length` and `data.links.length` in its deps. Before #110 this was harmless — `data` was set once on mount and never grew. After #110, the merged data grows as a Module's lazy `/api/module/symbols` fetch resolves, which triggers the effect, which reverts `expanded` to the initial roots-only set and clears `autoFitDone`. This is the "se reinicia a root en medio del camino" behaviour reported during verification.

**Fix:** Replace with a one-shot ref-guarded initializer that fires once the first time `data` becomes non-empty, then never again. Auto-expand-roots policy is preserved for first load; no resets on lazy growth.

## 2) Misleading "function_not_found" dialog on non-Python symbols

**Symptom:** Click a TS/JS function in the codebase map → Playground pill activates → click pill → dialog says "Function not found in the index — re-run analyze to refresh". Re-analyzing doesn't help.

**Cause:** `resolve_function_ref` (`playground.py:310`) rejects any symbol whose derived module name isn't a dotted sequence of Python identifiers. TS/TSX/JS symbols end up with module strings like `frontend/src/pages` — slashes fail `_is_identifier`, so the call returns `FunctionNotFoundError` with the wrong diagnostic.

**Fix:** Per spec §"Stack lock-in", the playground is Python-only in v1. Gate the launchable-selection at the frontend on `file_path.endsWith('.py')`. The tooltip on a launchable-kind / non-Python selection now explicitly explains the constraint ("Playground is Python-only in v1 — select a function from a .py file") instead of silently reaching a backend that can't help.

## Test plan

- [x] `npm --prefix frontend run build` — TS + Vite green (50 modules, 722ms, 301.45 kB).
- [ ] Manual (post-merge, with #112 + fresh analyze):
  - Click `+` on the `frontend/src/pages` Module. Symbols appear as children. The Module **stays expanded**. The view does **not** snap back to fit-all.
  - Click a `.py` symbol (e.g. from `copyclip/intelligence`). Pill activates cyan, opens the playground with correct breadcrumb.
  - Click a `.ts` symbol. Pill stays inert; tooltip reads "Playground is Python-only in v1 — select a function from a .py file" (no misleading "function_not_found" dialog).

## Regression note

No frontend test framework committed yet (#105 still open), so regression (1) is captured by the manual smoke above rather than a unit test. Prime target for a Vitest case when #105 lands: assert that appending nodes to `data` does not clear the `expanded` Set.

## Related

- Follows up #110.
- Unblocks browser verification deferred in #110's test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)