### PR TITLE
test: live emit_block e2e (key-gated) + Windows teardown fix

### DIFF
--- a/tests/test_cuaderno_live_e2e.py
+++ b/tests/test_cuaderno_live_e2e.py
@@ -1,0 +1,208 @@
+"""Live end-to-end validation of the emit_block protocol against a REAL LLM.
+
+This is the automated form of the manual T15 check: does the chosen provider
+(DeepSeek by default) actually drive the agentic emit_block/finish protocol —
+reading evidence, then emitting distinct, valid, *cited* blocks — over the real
+SSE endpoint?
+
+It is gated, not mocked. It hits a paid API, so it only runs when you have
+opted in by setting the provider's key. With no key it skips cleanly, so a
+normal `pytest` run (and CI without secrets) never touches the network.
+
+Run it:
+
+    # DeepSeek (default)
+    $env:DEEPSEEK_API_KEY = "sk-..."          # PowerShell
+    pytest tests/test_cuaderno_live_e2e.py -v -s
+
+    # Another provider
+    $env:CUADERNO_LIVE_PROVIDER = "anthropic"
+    $env:ANTHROPIC_API_KEY = "sk-ant-..."
+    pytest tests/test_cuaderno_live_e2e.py -v -s
+
+What it asserts (the wedge — anti-invention):
+  * the stream is real SSE and opens with a `meta` event;
+  * NO terminal `error` event — i.e. the model could drive emit_block;
+  * the model used a read tool (evidence phase ran);
+  * at least one `block` event arrived (answer came via emit_block, not free text);
+  * the terminal `frame` is at position 1 and every block is a known, renderable kind;
+  * at least one block carries a citation — the model grounded its answer in the file.
+"""
+
+import json
+import os
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+from urllib import request
+
+import pytest
+
+from copyclip.intelligence.db import connect, init_schema, init_cuaderno_schema
+from copyclip.intelligence.server import run_server
+from copyclip.intelligence.cuaderno.provider import DEFAULT_MODELS
+from copyclip.intelligence.cuaderno.schema import validate_block_dict
+from copyclip.llm.provider_config import PROVIDERS
+
+
+LIVE_PROVIDER = os.environ.get("CUADERNO_LIVE_PROVIDER", "deepseek").strip().lower()
+_KEY_ENV = PROVIDERS[LIVE_PROVIDER].api_key_env if LIVE_PROVIDER in PROVIDERS else None
+_HAS_KEY = bool(_KEY_ENV and (os.environ.get(_KEY_ENV) or "").strip())
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_KEY,
+    reason=(
+        f"live e2e: set {_KEY_ENV or 'the provider key'} "
+        f"(provider={LIVE_PROVIDER}) to run the real emit_block validation"
+    ),
+)
+
+
+# A small, self-contained project the model must READ to answer correctly.
+APP_PY = '''\
+def greet(name):
+    """Return a friendly greeting for the given name."""
+    return f"Hello, {name}! Welcome to CopyClip."
+
+
+def farewell(name):
+    """Return a parting message."""
+    return f"Goodbye, {name}."
+'''
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _wait_port(port, timeout_s=3.0):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError("server did not start")
+
+
+def _post_sse(url, body, timeout=120):
+    """POST and parse a text/event-stream response into a list of event dicts.
+
+    Stops after the terminal event (frame or error) so the keep-alive
+    connection doesn't hang. Live model + tool rounds can take a while, hence
+    the generous timeout.
+    """
+    data = json.dumps(body).encode("utf-8")
+    req = request.Request(url, method="POST", data=data,
+                          headers={"Content-Type": "application/json"})
+    with request.urlopen(req, timeout=timeout) as r:
+        status = r.status
+        ctype = r.headers.get("Content-Type", "")
+        events = []
+        for line in r:
+            line = line.decode("utf-8").rstrip("\n").rstrip("\r")
+            if line.startswith("data:"):
+                ev = json.loads(line[len("data:"):].strip())
+                events.append(ev)
+                if ev.get("type") in ("frame", "error"):
+                    break
+    return status, ctype, events
+
+
+def _has_citation(block: dict) -> bool:
+    """True if the block grounds the answer in a source (the anti-invention bar)."""
+    kind = block.get("kind")
+    if kind in ("citation", "citation_stack"):
+        return True
+    if "citation" in block or "citations" in block:
+        return True
+    # citation_stack stores its refs under "items"; a lone citation may too.
+    if kind == "citation_stack" and block.get("items"):
+        return True
+    return False
+
+
+def test_live_emit_block_protocol_over_sse():
+    td = tempfile.mkdtemp(prefix="cuaderno-live-")
+    root = str(Path(td).absolute())
+    (Path(td) / "README.md").write_text("# CopyClip\nA personal code-comprehension tool.\n",
+                                         encoding="utf-8")
+    (Path(td) / "app.py").write_text(APP_PY, encoding="utf-8")
+
+    conn = connect(root)
+    init_schema(conn)
+    init_cuaderno_schema(conn)
+    conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root, "live-e2e"))
+    conn.execute("INSERT OR REPLACE INTO config(key,value) VALUES('cuaderno_provider',?)",
+                 (LIVE_PROVIDER,))
+    conn.commit()
+    conn.close()
+
+    port = _free_port()
+    th = threading.Thread(target=run_server, args=(root, port), daemon=True)
+    th.start()
+    _wait_port(port)
+
+    question = (
+        "What does the function `greet` in app.py do, and on which line is it "
+        "defined? Cite the file and lines."
+    )
+    status, ctype, events = _post_sse(
+        f"http://127.0.0.1:{port}/api/cuaderno/ask",
+        {"question": question},
+    )
+
+    model = DEFAULT_MODELS.get(LIVE_PROVIDER, "?")
+    print(f"\n[live e2e] provider={LIVE_PROVIDER} model={model} events={len(events)}")
+    for e in events:
+        if e["type"] == "tool":
+            print(f"  tool  {e['name']}({e.get('args','')}) -> {e['state']} {e.get('ms')}ms")
+        elif e["type"] == "block":
+            print(f"  block {e['block'].get('kind')}")
+        elif e["type"] == "error":
+            print(f"  ERROR {e.get('message')}")
+
+    # --- transport ---
+    assert status == 200
+    assert "text/event-stream" in ctype
+    assert events and events[0]["type"] == "meta" and "session_id" in events[0]
+
+    # --- the protocol did not collapse ---
+    err = next((e for e in events if e["type"] == "error"), None)
+    assert err is None, (
+        f"{LIVE_PROVIDER} could not drive emit_block; terminal error: "
+        f"{err and err.get('message')}"
+    )
+
+    # --- evidence phase ran (model read the file before answering) ---
+    tool_events = [e for e in events if e["type"] == "tool"]
+    assert any(e.get("state") == "done" for e in tool_events), (
+        "no successful read tool — model answered without consulting the project"
+    )
+
+    # --- answer arrived as emit_block stream, not free text ---
+    block_events = [e for e in events if e["type"] == "block"]
+    assert block_events, "no block events — provider did not use emit_block"
+
+    # --- terminal frame: position 1, every block renderable ---
+    frame_ev = next((e for e in events if e["type"] == "frame"), None)
+    assert frame_ev is not None, "no terminal frame event"
+    assert frame_ev["position"] == 1
+    blocks = frame_ev["frame"]["blocks"]
+    assert blocks, "frame carried zero blocks"
+    for b in blocks:
+        reason = validate_block_dict(b)
+        assert reason is None, f"unrenderable block in frame: {reason} ({b!r})"
+
+    # --- the wedge: the answer is grounded in a citation ---
+    assert any(_has_citation(b) for b in blocks), (
+        "no citation in the answer — anti-invention bar not met. Blocks: "
+        + ", ".join(b.get("kind", "?") for b in blocks)
+    )

--- a/tests/test_intelligence_server_api.py
+++ b/tests/test_intelligence_server_api.py
@@ -99,7 +99,7 @@ def _post_json(url: str, payload: dict):
 
 
 def test_decisions_pagination_and_meta():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -127,7 +127,7 @@ def test_decisions_pagination_and_meta():
 
 
 def test_decision_history_endpoint():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -153,7 +153,7 @@ def test_decision_history_endpoint():
 
 
 def test_events_endpoint_starts_with_connected_event():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -172,7 +172,7 @@ def test_events_endpoint_starts_with_connected_event():
 
 
 def test_health_endpoint_contract():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -196,7 +196,7 @@ def test_health_endpoint_survives_sustained_requests():
     # Each handler invocation opens a SQLite conn; if we leak them, the
     # server eventually exhausts fds. Documents the intent that every
     # do_* handler closes its conn on every return path.
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -220,7 +220,7 @@ def test_health_endpoint_survives_sustained_requests():
 
 
 def test_ask_endpoint_returns_evidence_first_contract():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -265,7 +265,7 @@ def test_ask_endpoint_returns_evidence_first_contract():
 
 
 def test_ask_endpoint_returns_structured_insufficient_evidence_response():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -299,7 +299,7 @@ def test_ask_endpoint_returns_structured_insufficient_evidence_response():
 
 
 def test_ask_endpoint_surfaces_contradictory_signals_instead_of_false_certainty():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -349,7 +349,7 @@ def test_ask_endpoint_surfaces_contradictory_signals_instead_of_false_certainty(
 
 
 def test_ask_endpoint_requires_decision_and_drift_risk_to_overlap_on_same_file():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -392,7 +392,7 @@ def test_ask_endpoint_requires_decision_and_drift_risk_to_overlap_on_same_file()
 
 
 def test_ask_endpoint_does_not_ground_vague_question_from_generic_project_noise():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -423,7 +423,7 @@ def test_ask_endpoint_does_not_ground_vague_question_from_generic_project_noise(
 
 
 def test_ask_endpoint_does_not_ground_common_word_match_in_decision_text():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -448,7 +448,7 @@ def test_ask_endpoint_does_not_ground_common_word_match_in_decision_text():
 
 
 def test_ask_endpoint_does_not_ground_common_word_file_path_match():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -473,7 +473,7 @@ def test_ask_endpoint_does_not_ground_common_word_file_path_match():
 
 
 def test_context_bundle_endpoint_returns_manifest():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -502,7 +502,7 @@ def test_context_bundle_endpoint_returns_manifest():
 
 
 def test_analyze_cancel_without_running_job_returns_404():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -525,7 +525,7 @@ def test_analyze_cancel_without_running_job_returns_404():
 
 
 def test_risk_trends_endpoint_works_with_snapshot_breakdown():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -549,7 +549,7 @@ def test_risk_trends_endpoint_works_with_snapshot_breakdown():
 
 
 def test_quality_gate_blocks_resolve_without_evidence():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -577,7 +577,7 @@ def test_quality_gate_blocks_resolve_without_evidence():
 
 
 def test_quality_gate_allows_resolve_with_ref_or_note():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -606,7 +606,7 @@ def test_quality_gate_allows_resolve_with_ref_or_note():
 
 
 def test_pulls_endpoint_pagination():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -633,7 +633,7 @@ def test_pulls_endpoint_pagination():
 
 
 def test_alert_rules_and_cooldown_evaluation():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -664,7 +664,7 @@ def test_alert_rules_and_cooldown_evaluation():
 
 
 def test_weekly_export_endpoint_returns_markdown_and_summary():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -690,7 +690,7 @@ def test_weekly_export_endpoint_returns_markdown_and_summary():
 
 
 def test_settings_alias_get_and_post():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -713,7 +713,7 @@ def test_settings_alias_get_and_post():
 
 
 def test_alert_rule_patch_and_delete():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)
@@ -748,7 +748,7 @@ def test_alert_rule_patch_and_delete():
 
 
 def test_alert_scheduler_state_get_and_set():
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         root = Path(td)
         root_path = str(root.absolute())
         conn = connect(root_path)


### PR DESCRIPTION
## What

Two test-only changes, no product code touched.

### 1. Live emit_block e2e (`tests/test_cuaderno_live_e2e.py`)
Automates the manual T15 check. A real SSE round-trip validating that the chosen provider drives the agentic `emit_block`/`finish` protocol end-to-end: reads evidence, then emits distinct, valid, **cited** blocks.

- **Key-gated**: skips cleanly unless the provider's key env is set (`DEEPSEEK_API_KEY` by default; `CUADERNO_LIVE_PROVIDER` selects another). Normal runs and CI never touch the network.
- Asserts the anti-invention bar: no terminal error, evidence phase ran, answer arrived via `emit_block` (not free text), terminal frame at position 1 with renderable blocks, ≥1 citation.

Validated live against DeepSeek (`deepseek-chat`): it drives the protocol cleanly — `read_file` → `lead`/`citation`/`paragraph`/`followups`, no round-2 error. The per-provider whole-Frame fallback is not needed for DeepSeek.

### 2. Windows temp-dir teardown race (`tests/test_intelligence_server_api.py`)
The daemon `ThreadingHTTPServer` spawns a thread per request that closes its sqlite connection in a `finally`, after the response is sent. On Windows the test exits the `TemporaryDirectory` context and `rmtree` runs before that close, so `intelligence.db` is still open → `WinError 32` fails teardown (the API assertions had already passed).

Adds `ignore_cleanup_errors=True` to the 23 remaining `TemporaryDirectory` call sites, matching the convention already present at the one site that had been patched.

## Test
Full suite: **475 passed, 2 skipped, 0 failed** (was 32 failed before this branch — 9 were a missing `pytest-asyncio`, now installed; 23 were this teardown race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end testing for real-time streaming protocol with LLM provider integration, validating session management, execution, and content delivery.
  * Improved API integration test stability with enhanced cleanup handling for temporary resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sssamuelll/copyclip/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->