### PR TITLE
fix(cuaderno): follow-ups no longer hide behind the composer until reload

### DIFF
--- a/frontend/src/styles/cuaderno.css
+++ b/frontend/src/styles/cuaderno.css
@@ -188,6 +188,11 @@
   position: absolute; inset: 0;
   display: flex;
   justify-content: center;
+  /* flex-start (not the default `stretch`): a stretched item is clamped to the
+     scroller's height, which silently swallows .cua-frame's padding-bottom and
+     lets the final block (follow-ups) hide behind the composer until reload.
+     flex-start lets .cua-frame size to its content so the clearance works. */
+  align-items: flex-start;
   overflow-y: auto;
 }
 .cua-frame {


### PR DESCRIPTION
## The bug

After a streamed answer finished, the **"go deeper" follow-ups** stayed hidden behind the input composer. Only a full reload of the conversation revealed them.

## Root cause

`.cua-frame-wrap` is `display:flex` with no explicit `align-items`, so it defaulted to **`stretch`**. A stretched flex item is clamped to the scroller's height, which **silently swallowed `.cua-frame`'s `padding-bottom:140px`** — the very clearance meant to keep content above the absolutely-positioned composer.

Measured: `.cua-frame` `offsetHeight` was pinned to the viewport (695px) even when its content was 1044px tall; the 140px padding contributed **0px** to the scrollable area. The follow-ups only cleared the composer by ~10px — incidentally, thanks to the `GotItMarkers` height below them. On completion the appended `GotItMarkers` grew `scrollHeight` by ~88px while `scrollTop` stayed parked at the old maximum, stranding the follow-ups behind the composer. A reload "fixed" it only because scrolling from scratch reached the true bottom.

## The fix

One line on `.cua-frame-wrap`:

```css
align-items: flex-start;
```

So `.cua-frame` sizes to its content and the `padding-bottom` clearance actually applies.

## Verification

Drove the real `<Cuaderno>` through the exact streamed-answer prop sequence in a browser (Playwright) and measured follow-ups vs composer (`>0` = hidden):

| state | before | after |
|---|---|---|
| during 'writing' (following the stream) | +78 hidden | **−62 visible** |
| at completion, no manual scroll (what the user sees) | +78 hidden | **−62 visible** |
| after manual scroll to the end | −10 visible | −150 visible |

Also confirmed visually: the three follow-up chips clear the composer with no reload. The empty state is unaffected (already top-aligned by design). Pure layout change — no scroll-management JS, so no risk of yanking the user's scroll position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a layout issue where content was being cut off or hidden until page reload. Content now displays correctly within the scroll container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->