### PR TITLE
fix(cuaderno): close the SSE stream so the composer unlocks after an answer

### DIFF
--- a/frontend/src/pages/CuadernoPage.tsx
+++ b/frontend/src/pages/CuadernoPage.tsx
@@ -69,6 +69,19 @@ export function CuadernoPage({ onOpenDashboard }: { onOpenDashboard?: () => void
     setToolCalls([])
 
     let capturedSession = sessionId
+    // `frame` and `error` are the only legitimate terminals, and they are
+    // authored by the compositor — not by the transport. We unlock the composer
+    // on whichever arrives (the answer being sealed), never on the socket
+    // closing. A stream that ends with neither is itself a failure, surfaced as
+    // an error; we must never silently unlock, which would record a question
+    // with no answer and no error.
+    let terminal: 'frame' | 'error' | null = null
+
+    const settleIdle = () => {
+      setIsLoading(false)
+      setPartialBlocks([])
+      setToolCalls([])
+    }
 
     askStream(question, sessionId ?? undefined, {
       signal: ac.signal,
@@ -95,6 +108,7 @@ export function CuadernoPage({ onOpenDashboard }: { onOpenDashboard?: () => void
             setPartialBlocks((prev) => [...prev, e.block])
             break
           case 'frame': {
+            terminal = 'frame'
             const newQ: CuadernoQuestion = {
               position: e.position,
               question,
@@ -105,23 +119,27 @@ export function CuadernoPage({ onOpenDashboard }: { onOpenDashboard?: () => void
             }
             setQuestions((prev) => [...prev, newQ])
             setActivePosition(e.position)
+            settleIdle()
             break
           }
           case 'error':
+            terminal = 'error'
             setError(e.partial ? `${e.message} (partial answer saved)` : e.message)
+            settleIdle()
             break
         }
       },
     })
-      .catch((err) => {
-        if (ac.signal.aborted) return
-        setError(String(err))
+      .then(() => {
+        // Transport closed cleanly but the compositor never authored a terminal.
+        if (ac.signal.aborted || terminal !== null) return
+        setError('the answer stream ended without completing — please try again')
+        settleIdle()
       })
-      .finally(() => {
-        if (ac.signal.aborted) return
-        setIsLoading(false)
-        setPartialBlocks([])
-        setToolCalls([])
+      .catch((err) => {
+        if (ac.signal.aborted || terminal !== null) return
+        setError(String(err))
+        settleIdle()
       })
   }
 

--- a/src/copyclip/intelligence/server_helpers.py
+++ b/src/copyclip/intelligence/server_helpers.py
@@ -69,7 +69,13 @@ def sse_response(handler, events) -> bool:
     handler.send_response(200)
     handler.send_header("Content-Type", "text/event-stream")
     handler.send_header("Cache-Control", "no-cache")
-    handler.send_header("Connection", "keep-alive")
+    # Finite stream: its body is delimited by the connection closing (there is no
+    # Content-Length, and the default HTTP/1.0 handler has no chunked framing).
+    # With keep-alive the socket stays open after the last event, so the browser's
+    # fetch reader never reaches `done` — the client treats the request as still
+    # in flight and the cuaderno composer stays disabled forever. Close it.
+    handler.send_header("Connection", "close")
+    handler.close_connection = True
     handler.end_headers()
     for ev in events:
         try:


### PR DESCRIPTION
Fixes the cuaderno **input staying locked** after a streamed answer finished — you couldn't ask anything else without reloading. The lock had a transport cause and an interaction-layer cause; this PR fixes both, so liveness is owned by the answer, not by the socket.

## Layer 1 — the SSE stream never closed (transport)

`sse_response` sent `Connection: keep-alive` with **no `Content-Length` and no chunked framing** (the default `BaseHTTPRequestHandler` speaks HTTP/1.0). The finite event stream's body was therefore never delimited: after the terminal `frame` event the socket stayed open, so the browser's `fetch` reader **never reached `done`**, `askStream` never resolved, and its `.finally` (the only place `setIsLoading(false)` ran) never ran.

Fix in `sse_response`: close the connection when the finite stream ends.

```python
handler.send_header("Connection", "close")
handler.close_connection = True
```

Verified by driving the **real** `sse_response` over HTTP with a browser-faithful `fetch` reader (no LLM): before, the reader never reached `done` (5s watchdog fired); after, `done` arrives in ~36ms.

## Layer 2 — liveness was defined by the transport, not the answer

Even with the stream closing, clearing `isLoading` only in `.finally` means the composer's liveness is bound to *the socket closing*, not to *the answer being authored*. That coupling is the actual category error: a transport fact (stream end) defining an interaction fact (input live).

Fix in `CuadernoPage.onAsk`: bind the unlock to the compositor-authored terminals. `frame` and `error` are now the **only** transitions back to idle, and they clear the loading state the moment they arrive. A stream that ends with **neither** (model hangs, compositor returns without a terminal) is surfaced as an error rather than a silent unlock — which would otherwise record a question with no answer and no error. Typechecks under `tsc -b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server stream connections now close explicitly after streaming completes to avoid lingering keep-alive connections.
  * Improved client streaming lifecycle: correctly detects terminal events, preserves partial answers on error, and avoids clearing loading/partial state prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->