### PR TITLE
fix(cuaderno): retry no longer 400s on real providers; turns never silently lost

### DIFF
--- a/src/copyclip/intelligence/cuaderno/ask_stream.py
+++ b/src/copyclip/intelligence/cuaderno/ask_stream.py
@@ -8,12 +8,15 @@ from .persistence import save_question
 from .schema import Block, Frame, FRAME_STATUS_PARTIAL, frame_from_dict
 
 
-def _persist_partial(conn, session_id: str, question: str, emitted: list[dict]) -> None:
-    pframe = Frame(
-        question=question,
-        blocks=[Block.from_dict(b) for b in emitted],
-        status=FRAME_STATUS_PARTIAL,
-    )
+def _persist_partial(conn, session_id: str, question: str, emitted: list[dict],
+                     message: Optional[str] = None) -> None:
+    blocks = [Block.from_dict(b) for b in emitted]
+    if not blocks:
+        # No surviving blocks (e.g. an error after a retry's reset cleared the
+        # buffer). Persist a marker so the turn is never silently lost.
+        reason = message or "the stream ended early"
+        blocks = [Block.paragraph(f"This turn was interrupted ({reason}). Re-ask to retry.")]
+    pframe = Frame(question=question, blocks=blocks, status=FRAME_STATUS_PARTIAL)
     save_question(conn, session_id, question, pframe)
 
 
@@ -66,9 +69,13 @@ def iter_ask_events(
                 persisted = True
                 yield {"type": "frame", "position": position, "frame": ev["frame"]}
             elif ev["type"] == "error":
-                if ev.get("partial") and emitted:
-                    _persist_partial(conn, session_id, question, emitted)
-                    persisted = True
+                # Always persist the turn so it is never silently lost — a stream
+                # error is a `partial` per the status taxonomy. Surviving blocks
+                # ride as the partial body; with none (e.g. an error after a
+                # retry's reset cleared the buffer) a marker block keeps the
+                # question in the conversation.
+                _persist_partial(conn, session_id, question, emitted, message=ev.get("message"))
+                persisted = True
                 yield ev
     finally:
         # Client disconnect (GeneratorExit) or abnormal stop: persist partial once.

--- a/src/copyclip/intelligence/cuaderno/compositor.py
+++ b/src/copyclip/intelligence/cuaderno/compositor.py
@@ -122,6 +122,30 @@ def _args_summary(name: str, args: dict[str, Any]) -> str:
     return ""
 
 
+def _ack_terminal_tools(turn_content: list[dict[str, Any]],
+                        emit_status: dict[str, Optional[str]]) -> list[dict[str, Any]]:
+    """tool_result acks for every tool_use in a TERMINAL assistant turn.
+
+    A retry re-invokes the model, and both the Anthropic and OpenAI APIs require
+    every assistant tool_use/tool_call to be answered by a tool_result before the
+    next turn (OpenAI: 'insufficient tool messages following tool_calls'). The
+    normal round acks inline (and dispatches read tools); the terminal round
+    skipped acking because it used to always return — until grounding /
+    responsiveness retries began re-calling the model from here."""
+    results: list[dict[str, Any]] = []
+    for blk in turn_content:
+        if blk.get("type") != "tool_use":
+            continue
+        tuid = blk["id"]
+        if blk.get("name") == "emit_block":
+            reason = emit_status.get(tuid)
+            results.append(_ack(tuid, {"ok": True}) if reason is None
+                           else _ack(tuid, {"error": "invalid_block", "detail": reason}, is_error=True))
+        else:
+            results.append(_ack(tuid, {"ok": True}))
+    return results
+
+
 def iter_compose_events(
     *,
     client: Any,
@@ -222,6 +246,11 @@ def iter_compose_events(
                     # more normal round. Fires at most once.
                     grounding_retry_used = True
                     emitted.clear()
+                    # Answer the terminal turn's tool_use blocks before re-calling
+                    # the model — a dangling tool_call 400s on real APIs.
+                    acks = _ack_terminal_tools(turn_content, emit_status)
+                    if acks:
+                        messages.append({"role": "user", "content": acks})
                     _inject_directive(messages, _retry_directive(verdict))
                     yield {"type": "reset"}
                     continue
@@ -236,6 +265,9 @@ def iter_compose_events(
                             and can_retry):
                         responsiveness_retry_used = True
                         emitted.clear()
+                        acks = _ack_terminal_tools(turn_content, emit_status)
+                        if acks:
+                            messages.append({"role": "user", "content": acks})
                         _inject_directive(
                             messages, jv.retry_directive or RESPONSIVENESS_RETRY_FALLBACK)
                         yield {"type": "reset"}

--- a/tests/test_cuaderno_retry_recovery.py
+++ b/tests/test_cuaderno_retry_recovery.py
@@ -71,3 +71,32 @@ def test_grounding_retry_produces_api_valid_messages(tmp_path):
     retry_messages = client.message_snapshots[1]
     oai, _ = _to_openai_request(None, None, retry_messages)
     _assert_openai_tool_calls_answered(oai)
+
+
+def test_turn_persisted_when_retry_restream_errors(tmp_path, monkeypatch):
+    """The turn must never be silently lost. When a retry's re-stream errors with
+    no surviving blocks (the buffer was cleared on reset), the question must still
+    be persisted — previously nothing was saved and the conversation lost it."""
+    from copyclip.intelligence.cuaderno import ask_stream
+
+    saved = []
+
+    def _spy(conn, session_id, question, frame):
+        saved.append((session_id, question, frame))
+        return len(saved)
+
+    monkeypatch.setattr(ask_stream, "save_question", _spy)
+
+    # One ungrounded turn -> grounding retry -> reset; the retry re-stream then
+    # fails (StubStream is out of turns -> RuntimeError, standing in for the 400).
+    client = StubStream([_ungrounded_turn("b1", "f1", "ungrounded")])
+    events = list(ask_stream.iter_ask_events(
+        client=client, question="how does X work?", project_root=str(tmp_path),
+        project_id=1, conn=None, session_id="s1", max_tool_rounds=8))
+
+    assert any(e["type"] == "error" for e in events), "expected a terminal error"
+    assert len(saved) == 1, f"turn must be persisted once, got {len(saved)}"
+    _, question, frame = saved[0]
+    assert question == "how does X work?"
+    assert frame.status == "partial"
+    assert frame.blocks, "a persisted partial must carry at least a marker block"

--- a/tests/test_cuaderno_retry_recovery.py
+++ b/tests/test_cuaderno_retry_recovery.py
@@ -1,0 +1,73 @@
+"""Regression tests for the retry path that 400'd on real providers.
+
+Bug: a grounding/responsiveness retry re-invokes the model, but the terminal
+assistant turn's `tool_use` blocks (emit_block/finish) were left unanswered —
+illegal for both the OpenAI ("insufficient tool messages following tool_calls")
+and Anthropic APIs. And on the error that followed, the turn was not persisted,
+so the question + answer were silently lost.
+"""
+
+import copy
+
+from copyclip.intelligence.cuaderno.compositor import iter_compose_events
+from copyclip.intelligence.cuaderno.openai_client import _to_openai_request
+from tests.test_cuaderno_compositor import StubStream, _tool_stop, _content, _msg_stop
+
+
+class RecordingStub(StubStream):
+    """StubStream that snapshots (deep-copies) the messages list AS SENT on each
+    call. The base StubStream stores the live reference, which the compositor
+    mutates in place — so a post-hoc read shows the final state, not what each
+    call actually transmitted. We need the per-call snapshot to verify the retry
+    call's messages were API-valid."""
+
+    def __init__(self, turns):
+        super().__init__(turns)
+        self.message_snapshots = []
+
+    def messages_stream(self, **kwargs):
+        self.message_snapshots.append(copy.deepcopy(kwargs.get("messages")))
+        yield from super().messages_stream(**kwargs)
+
+
+def _assert_openai_tool_calls_answered(oai_messages):
+    """OpenAI's hard requirement: an assistant message with tool_calls must be
+    immediately followed by one role:tool message per tool_call_id — the exact
+    rule the 400 'insufficient tool messages following tool_calls' enforces."""
+    for i, m in enumerate(oai_messages):
+        if m.get("role") == "assistant" and m.get("tool_calls"):
+            ids = [tc["id"] for tc in m["tool_calls"]]
+            window = oai_messages[i + 1 : i + 1 + len(ids)]
+            answered = {t.get("tool_call_id") for t in window if t.get("role") == "tool"}
+            missing = set(ids) - answered
+            assert not missing, (
+                f"assistant tool_calls {ids} not answered (missing {missing}); "
+                f"would 400 on OpenAI. Following: {oai_messages[i + 1 : i + 2 + len(ids)]}")
+
+
+def _ungrounded_turn(bid, fid, text):
+    # Emits one paragraph (no content-bearing reads) + finish -> the cheap layer
+    # seals 'ungrounded' for a code question, firing a grounding retry.
+    return [
+        _tool_stop(bid, "emit_block", {"kind": "paragraph", "text": text}),
+        _tool_stop(fid, "finish", {}),
+        _msg_stop("tool_use", [
+            _content(bid, "emit_block", {"kind": "paragraph", "text": text}),
+            _content(fid, "finish", {}),
+        ]),
+    ]
+
+
+def test_grounding_retry_produces_api_valid_messages(tmp_path):
+    client = RecordingStub([_ungrounded_turn("b1", "f1", "first ungrounded"),
+                            _ungrounded_turn("b2", "f2", "second")])
+    list(iter_compose_events(
+        client=client, question="how does the compositor work?",
+        project_root=str(tmp_path), project_id=1, conn=None, max_tool_rounds=8))
+    # A grounding retry must have fired -> at least 2 model calls.
+    assert len(client.message_snapshots) >= 2, "expected a retry (2 model calls)"
+    # The messages AS SENT on the retry call must translate to a valid OpenAI
+    # sequence (every assistant tool_call answered by a tool message).
+    retry_messages = client.message_snapshots[1]
+    oai, _ = _to_openai_request(None, None, retry_messages)
+    _assert_openai_tool_calls_answered(oai)


### PR DESCRIPTION
## Summary

Two related fixes for a crash a user hit on `copyclip start` against an OpenAI-compatible provider (DeepSeek/OpenAI), which lost the response and the conversation turn.

**Root cause (the 400).** The grounding/responsiveness retry (added in #125/#126) re-invokes the model, but the terminal assistant turn's `emit_block`/`finish` tool_use blocks were left unanswered. Both the OpenAI API ("An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'") and Anthropic reject a dangling tool_call, so **every retry 400'd on a real provider** — and the bench loop, which drives the same compositor with retries, would hit it too. It was never caught because the compositor tests use a StubStream that ignores message structure, and the live retry path was untested.

**Root cause (lost turn).** On the terminal error that followed, `iter_ask_events` persisted only when partial blocks survived. The retry's `reset` had cleared the buffer, so the error persisted nothing — the question and answer vanished from the conversation.

## Fixes

- `_ack_terminal_tools` appends a tool_result for every tool_use in the terminal turn before the retry's reset+continue, so the re-call is a valid message sequence on any provider.
- On a stream error, the turn is now always persisted as a partial (the status taxonomy's own definition of a stream error); with no surviving blocks, a marker block keeps the question in the conversation.

## Test Plan

- [x] New regression tests (`tests/test_cuaderno_retry_recovery.py`): a grounding retry's messages, captured as sent, translate to a valid OpenAI sequence (every tool_call answered); a retry whose re-stream errors still persists the turn as partial.
- [x] Full repo suite green: 605 passed, 3 skipped (the 3 skips are key-gated live tests).
- [x] No regression in compositor / ask_stream / persistence / adapter suites.
- [ ] Live: re-run `copyclip start` on a project with an OpenAI-compatible provider and provoke a retry (an ungrounded answer) — should self-correct instead of 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stream interruption handling: incomplete turns are now properly marked with a status indicator when streams are interrupted.
  * Enhanced retry recovery: tool calls are now properly acknowledged during retry scenarios, preventing unqueued tool calls from causing downstream issues.

* **Tests**
  * Added regression tests validating retry and recovery behavior, ensuring API-compliant message sequencing and proper persistence of partial turns during errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->