### PR TITLE
fix(cuaderno): graph_view answers "around X" and degrades to prose

### DIFF
--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -270,9 +270,17 @@ def get_module_graph(
 ) -> dict[str, Any]:
     """Module-level topology aggregated from symbol_edges — both endpoints live
     in the symbols.module namespace, so every node maps to a real file (citation)
-    and stdlib/external import targets never appear. Deterministic caps: modules
-    ranked by edge degree DESC then name ASC; edges pruned to surviving nodes,
-    then capped by weight DESC."""
+    and stdlib/external import targets never appear.
+
+    `scope` is a FOCUS, not an induced-subgraph filter: it selects the modules
+    matching the substring — by module name OR by a backing file path, so
+    'analyzer' resolves the module whose file is analyzer.py even when that module
+    is named after the parent directory — and returns them PLUS their direct
+    neighbors and the edges incident to the focus (an ego graph, radius 1). This
+    is what answers 'the graph around X'; an empty scope returns the whole
+    project. Deterministic caps: focus modules rank first (never pruned out for a
+    higher-degree neighbor), then degree DESC then name ASC; edges pruned to
+    surviving nodes, then capped by weight DESC."""
     rows = conn.execute(
         """
         SELECT s1.module, s2.module, COUNT(*) AS weight
@@ -292,15 +300,38 @@ def get_module_graph(
             (project_id,),
         ).fetchall()
     )
-    mods = set(files)
+    all_mods = set(files)
+
+    focus: set[str] = set()
     if scope:
-        mods = {m for m in mods if scope in m}
-    edges = [(f, t, w) for (f, t, w) in rows if f in mods and t in mods]
+        focus = {m for m in all_mods if scope in m}
+        # Resolve via backing file paths too: a file like analyzer.py lives in a
+        # module named after its parent directory, so a name-only match misses it.
+        for (m,) in conn.execute(
+            "SELECT DISTINCT module FROM symbols "
+            "WHERE project_id=? AND module IS NOT NULL AND file_path LIKE ?",
+            (project_id, f"%{scope}%"),
+        ):
+            if m in all_mods:
+                focus.add(m)
+        if not focus:
+            return {"modules": [], "edges": [], "truncated": False}
+        # Ego graph: edges incident to a focus module, plus the nodes they reach.
+        edges = [(f, t, w) for (f, t, w) in rows if f in focus or t in focus]
+        nodes = set(focus)
+        for f, t, w in edges:
+            nodes.add(f)
+            nodes.add(t)
+        nodes &= all_mods
+    else:
+        nodes = set(all_mods)
+        edges = [(f, t, w) for (f, t, w) in rows if f in nodes and t in nodes]
+
     degree: dict[str, int] = {}
     for f, t, w in edges:
         degree[f] = degree.get(f, 0) + 1
         degree[t] = degree.get(t, 0) + 1
-    ranked = sorted(mods, key=lambda m: (-degree.get(m, 0), m))
+    ranked = sorted(nodes, key=lambda m: (m not in focus, -degree.get(m, 0), m))
     truncated = len(ranked) > max_modules
     keep = set(ranked[:max_modules])
     pruned = [(f, t, w) for (f, t, w) in edges if f in keep and t in keep]

--- a/src/copyclip/intelligence/cuaderno/compositor.py
+++ b/src/copyclip/intelligence/cuaderno/compositor.py
@@ -5,7 +5,10 @@ import sqlite3
 import time
 from typing import Any, Iterator, Optional
 
-from .prompts import SYSTEM_PROMPT, GROUNDING_RETRY_DIRECTIVE, LANGUAGE_RETRY_DIRECTIVE, RESPONSIVENESS_RETRY_FALLBACK
+from .prompts import (
+    SYSTEM_PROMPT, GROUNDING_RETRY_DIRECTIVE, LANGUAGE_RETRY_DIRECTIVE,
+    RESPONSIVENESS_RETRY_FALLBACK, INVALID_BLOCK_RECOVERY, WIDGET_RECOVERY_DIRECTIVE,
+)
 from .read_ledger import ReadLedger
 from .quality import assess, cheap_verdict_dict, artifacts_cited
 from .judge import judge_verdict_dict
@@ -144,7 +147,8 @@ def _ack_terminal_tools(turn_content: list[dict[str, Any]],
         if blk.get("name") == "emit_block":
             reason = emit_status.get(tuid)
             results.append(_ack(tuid, {"ok": True}) if reason is None
-                           else _ack(tuid, {"error": "invalid_block", "detail": reason}, is_error=True))
+                           else _ack(tuid, {"error": "invalid_block", "detail": reason,
+                                            "recovery": INVALID_BLOCK_RECOVERY}, is_error=True))
         else:
             results.append(_ack(tuid, {"ok": True}))
     return results
@@ -307,7 +311,8 @@ def iter_compose_events(
                     tool_results.append(_ack(tuid, {"ok": True}))
                 else:
                     tool_results.append(
-                        _ack(tuid, {"error": "invalid_block", "detail": reason}, is_error=True))
+                        _ack(tuid, {"error": "invalid_block", "detail": reason,
+                                    "recovery": INVALID_BLOCK_RECOVERY}, is_error=True))
                 continue
             if name == "finish":
                 tool_results.append(_ack(tuid, {"ok": True}))
@@ -342,6 +347,17 @@ def iter_compose_events(
                        "state": "error", "ms": ms}
 
         messages.append({"role": "user", "content": tool_results})
+
+        # Widget-fixation backstop: if every emit_block this round was rejected,
+        # the round produced no answer block — the model is stuck on a widget it
+        # cannot ground. Offer the prose off-ramp so an ungroundable widget
+        # degrades to an honest answer instead of draining the budget into a
+        # blank frame. Not latched (it neither discards blocks nor costs a round),
+        # so each stuck round renews the offer; skip the closing round, whose
+        # directive already forces composition and which has no next turn to read.
+        if (not is_closing and emit_status
+                and all(reason is not None for reason in emit_status.values())):
+            _inject_directive(messages, WIDGET_RECOVERY_DIRECTIVE)
 
     # Budget exhausted → fallback frame (terminal; parity with the wrapper below).
     if emitted:

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -56,6 +56,24 @@ LANGUAGE_RETRY_DIRECTIVE = (
     "labels — keeping it anchored to the same evidence."
 )
 
+# Recovery instruction attached to every invalid_block ack, so a rejected widget
+# tells the model what to do instead of only why it failed.
+INVALID_BLOCK_RECOVERY = (
+    "Rebuild this widget using ONLY the exact node and edge names a graph tool "
+    "returned this turn, or drop the widget and answer in prose with citations."
+)
+
+# Injected after a round whose only emit was a rejected widget — the model is
+# stuck on something it cannot ground. The off-ramp keeps an ungroundable widget
+# from draining the whole turn into a blank frame.
+WIDGET_RECOVERY_DIRECTIVE = (
+    "A widget you emitted could not be grounded in this turn's evidence, so it "
+    "was dropped. Do not keep retrying the same widget. Either rebuild it from "
+    "the EXACT node and edge names a graph tool returned this turn, or drop the "
+    "widget and answer in prose — an honest prose answer is better than no "
+    "answer. Then call finish."
+)
+
 SYSTEM_PROMPT = """\
 You are the cuaderno — a tutor that helps a single developer understand
 their own AI-generated codebase. The user is an archaeologist of their own

--- a/src/copyclip/intelligence/cuaderno/tool_catalog.py
+++ b/src/copyclip/intelligence/cuaderno/tool_catalog.py
@@ -118,16 +118,23 @@ def build_tool_definitions() -> list[dict[str, Any]]:
         {
             "name": "get_module_graph",
             "description": (
-                "Module-level dependency topology (all relations: calls, inheritance) "
-                "across modules, with the file backing each module. Use it to build a "
-                "graph_view widget; emit only nodes/edges this tool returned."
+                "Module-level dependency topology (calls, inheritance) with the file "
+                "backing each module. Pass `scope` to focus on one area: it returns "
+                "the matching modules PLUS their direct neighbors and the edges "
+                "between them — this is how you answer 'the graph around X'. Use it "
+                "to build a graph_view widget; emit only the nodes/edges it returned."
             ),
             "input_schema": {
                 "type": "object",
                 "properties": {
                     "scope": {
                         "type": "string",
-                        "description": "substring filter on module names; empty = whole project",
+                        "description": (
+                            "focus substring, matched against module names AND file "
+                            "paths (so 'analyzer' finds analyzer.py even though its "
+                            "module is the parent dir); returns that neighborhood. "
+                            "Empty = whole project."
+                        ),
                     }
                 },
             },

--- a/tests/test_cuaderno_compositor.py
+++ b/tests/test_cuaderno_compositor.py
@@ -830,3 +830,133 @@ def test_graph_evidence_survives_across_rounds(tmp_path: Path):
     assert len(frame["frame"]["blocks"]) == 1, (
         "valid cross-round widget must appear in the sealed frame"
     )
+
+
+# ---------------------------------------------------------------------------
+# Widget-fixation backstop — an ungroundable widget must offer a prose off-ramp
+# instead of silently draining the round budget into a blank frame.
+# ---------------------------------------------------------------------------
+
+_GRAPH_RESULT = {
+    "modules": [
+        {"name": "pkg/a", "file_path": "src/pkg/a.py"},
+        {"name": "pkg/b", "file_path": "src/pkg/b.py"},
+    ],
+    "edges": [{"from": "pkg/a", "to": "pkg/b", "weight": 1}],
+    "truncated": False,
+}
+
+# A graph_view with a reversed edge (b->a) — not in the evidence, so it is
+# rejected at emit time and never becomes a block.
+_BAD_WIDGET = {
+    "kind": "widget",
+    "widget": {
+        "kind": "graph_view",
+        "nodes": [
+            {"id": "pkg/a", "label": "a", "citation": {"kind": "path", "path": "src/pkg/a.py"}},
+            {"id": "pkg/b", "label": "b", "citation": {"kind": "path", "path": "src/pkg/b.py"}},
+        ],
+        "edges": [{"from": "pkg/b", "to": "pkg/a"}],
+    },
+}
+
+
+def _graph_turn():
+    return [
+        _tool_stop("g1", "get_module_graph", {"scope": "pkg"}),
+        _msg_stop("tool_use", [_content("g1", "get_module_graph", {"scope": "pkg"})]),
+    ]
+
+
+def _bad_widget_turn(bid="w1"):
+    # Emits the ungroundable widget WITHOUT finish — stays in tool_use, so the
+    # round is non-terminal and the loop continues (the fixation pattern).
+    return [
+        _tool_stop(bid, "emit_block", _BAD_WIDGET),
+        _msg_stop("tool_use", [_content(bid, "emit_block", _BAD_WIDGET)]),
+    ]
+
+
+def test_invalid_block_ack_carries_recovery_instruction(tmp_path: Path):
+    """When a widget is rejected, its invalid_block ack must carry a `recovery`
+    instruction — not just the bare reason — so the model is told what to do."""
+    turns = [
+        _graph_turn(),
+        _bad_widget_turn(),
+        [  # the model recovers with prose
+            _tool_stop("l1", "emit_block", {"kind": "lead", "text": "ans"}),
+            _tool_stop("f", "finish", {}),
+            _msg_stop("tool_use", [
+                _content("l1", "emit_block", {"kind": "lead", "text": "ans"}),
+                _content("f", "finish", {}),
+            ]),
+        ],
+    ]
+    client = StubStream(turns)
+    with patch(
+        "copyclip.intelligence.cuaderno.compositor.dispatch_tool",
+        side_effect=lambda name, args, **kw: _GRAPH_RESULT,
+    ):
+        list(iter_compose_events(
+            client=client, question="q", project_root=str(tmp_path),
+            project_id=1, conn=None, max_tool_rounds=8,
+        ))
+    # Decode the error acks the model was sent and confirm the rejected widget's
+    # ack carries a recovery instruction, not just a bare reason.
+    error_acks = []
+    for m in client.calls[-1]["messages"]:
+        if m["role"] == "user" and isinstance(m["content"], list):
+            for blk in m["content"]:
+                if isinstance(blk, dict) and blk.get("type") == "tool_result" and blk.get("is_error"):
+                    error_acks.append(json.loads(blk["content"]))
+    invalid = [a for a in error_acks if a.get("error") == "invalid_block"]
+    assert invalid, "the rejected widget must produce an invalid_block ack"
+    assert all("recovery" in a for a in invalid), "invalid_block ack must carry a recovery instruction"
+
+
+def test_all_rejected_round_injects_prose_recovery_directive(tmp_path: Path):
+    """After a round whose only emit was a rejected widget, the compositor must
+    inject a directive telling the model it may answer in prose."""
+    turns = [
+        _graph_turn(),
+        _bad_widget_turn(),
+        [
+            _tool_stop("l1", "emit_block", {"kind": "lead", "text": "ans"}),
+            _tool_stop("f", "finish", {}),
+            _msg_stop("tool_use", [
+                _content("l1", "emit_block", {"kind": "lead", "text": "ans"}),
+                _content("f", "finish", {}),
+            ]),
+        ],
+    ]
+    client = StubStream(turns)
+    with patch(
+        "copyclip.intelligence.cuaderno.compositor.dispatch_tool",
+        side_effect=lambda name, args, **kw: _GRAPH_RESULT,
+    ):
+        list(iter_compose_events(
+            client=client, question="q", project_root=str(tmp_path),
+            project_id=1, conn=None, max_tool_rounds=8,
+        ))
+    serialized = json.dumps(client.calls[2]["messages"])
+    assert "answer in prose" in serialized, (
+        "a stuck-on-widget round must offer the prose off-ramp"
+    )
+
+
+def test_persistent_widget_fixation_keeps_offering_prose_offramp(tmp_path: Path):
+    """A model that fixates on an ungroundable widget every round must be offered
+    the prose off-ramp (at least once) rather than silently draining the budget."""
+    turns = [_graph_turn()] + [_bad_widget_turn(f"w{i}") for i in range(7)]  # 8 rounds
+    client = StubStream(turns)
+    with patch(
+        "copyclip.intelligence.cuaderno.compositor.dispatch_tool",
+        side_effect=lambda name, args, **kw: _GRAPH_RESULT,
+    ):
+        events = list(iter_compose_events(
+            client=client, question="q", project_root=str(tmp_path),
+            project_id=1, conn=None, max_tool_rounds=8,
+        ))
+    offers = json.dumps(client.calls).count("answer in prose")
+    assert offers >= 1, "the prose off-ramp must be offered to a fixating model"
+    assert any(e["type"] == "frame" for e in events), "a terminal frame must still be produced"

--- a/tests/test_cuaderno_module_graph.py
+++ b/tests/test_cuaderno_module_graph.py
@@ -71,10 +71,56 @@ def test_edges_join_modules_and_nodes_carry_files(seeded):
     assert g["truncated"] is False
 
 
-def test_scope_filters_by_substring(seeded):
+def test_scope_returns_neighborhood_not_isolated_node(seeded):
+    """A scoped graph is a NEIGHBORHOOD: the focus module PLUS its direct
+    neighbors and the edges incident to it — never an isolated, edge-less node.
+    (Regression: scope='X' used to return only X with zero edges, leaving the
+    model with no graph to render and no way to answer 'the graph around X'.)"""
     c, pid = seeded
     g = get_module_graph(c, pid, scope="pkg/b")
-    assert {m["name"] for m in g["modules"]} == {"pkg/b"}
+    names = {m["name"] for m in g["modules"]}
+    assert "pkg/b" in names                      # the focus
+    assert "pkg/a" in names                      # its neighbor (a -> b)
+    assert "pkg/c" not in names                  # not adjacent to b — excluded
+    assert ("pkg/a", "pkg/b") in {(e["from"], e["to"]) for e in g["edges"]}
+
+
+def test_scope_resolves_focus_via_file_path(seeded):
+    """The focus substring matches a module's BACKING FILE PATH, not only its
+    collapsed module name — so 'analyzer' finds the module whose file is
+    analyzer.py even though the module name is the parent directory."""
+    c, pid = seeded
+    core = _insert_symbol(c, pid, "run", "svc/core", "svc/special_analyzer.py")
+    dep = _insert_symbol(c, pid, "store", "svc/db", "svc/db.py")
+    _insert_edge(c, pid, core, dep)  # svc/core -> svc/db
+    g = get_module_graph(c, pid, scope="analyzer")
+    names = {m["name"] for m in g["modules"]}
+    assert "svc/core" in names                   # resolved by file path
+    assert "svc/db" in names                      # its neighbor
+
+
+def test_focus_node_survives_truncation():
+    """Under a tight module cap the FOCUS node is never pruned out in favor of a
+    higher-degree neighbor — the user asked about it specifically."""
+    c = sqlite3.connect(":memory:")
+    init_schema(c)
+    pid = _make_project(c)
+    a = _insert_symbol(c, pid, "fn_a", "pkg/a", "pkg/a.py")  # hub, degree 3
+    b = _insert_symbol(c, pid, "fn_b", "pkg/b", "pkg/b.py")
+    cc = _insert_symbol(c, pid, "fn_c", "pkg/c", "pkg/c.py")
+    d = _insert_symbol(c, pid, "fn_d", "pkg/d", "pkg/d.py")
+    _insert_edge(c, pid, a, b)
+    _insert_edge(c, pid, a, cc)
+    _insert_edge(c, pid, a, d)
+    g = get_module_graph(c, pid, scope="pkg/b", max_modules=1)
+    assert "pkg/b" in {m["name"] for m in g["modules"]}
+    assert g["truncated"] is True
+
+
+def test_scope_no_match_returns_empty(seeded):
+    c, pid = seeded
+    g = get_module_graph(c, pid, scope="does-not-exist")
+    assert g == {"modules": [], "edges": [], "truncated": False}
 
 
 def test_caps_are_deterministic_and_prune_edges(seeded):
@@ -138,7 +184,7 @@ def test_dispatch_get_module_graph_not_unknown_tool(seeded):
 
 
 def test_dispatch_get_module_graph_scope_arg(seeded):
-    """Dispatcher passes scope argument through correctly."""
+    """Dispatcher passes scope through; scope yields the focus neighborhood."""
     c, pid = seeded
     from copyclip.intelligence.cuaderno.tool_catalog import dispatch_tool
     out = dispatch_tool(
@@ -149,7 +195,7 @@ def test_dispatch_get_module_graph_scope_arg(seeded):
         conn=c,
     )
     names = {m["name"] for m in out["modules"]}
-    assert names == {"pkg/b"}
+    assert "pkg/b" in names and "pkg/a" in names
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A graph question — "show me the module graph around the analyzer" — burned all 8 tool-call rounds and returned the bare **"tool-call budget exhausted"** frame (no answer). Diagnosed with systematic debugging and an adversarial multi-agent workflow that refuted the naive single-cause story and confirmed a **two-layer** root cause against the live DB. Both layers are fixed; `scope` is the chosen scope (make "around X" work **and** guarantee degradation).

### Layer 1 — trigger: `get_module_graph` could not answer "around X"
`scope` was an induced-subgraph filter (both edge endpoints in scope), and module names collapse files into their parent directory, so `analyzer.py` is not its own node — it lives in `copyclip/intelligence`. `scope="analyzer"` resolved to **1 isolated node (a test file), 0 edges** → nothing to render.

- `scope` is now a **focus**: returns the matching modules **plus their direct neighbors and incident edges** (ego graph, radius 1).
- focus matches **module names AND backing file paths**, so `"analyzer"` resolves `analyzer.py` even though its module is the parent directory.
- focus modules **rank first** under the cap — a tight max never prunes out the very module the user asked about.

### Layer 2 — amplifier: an ungroundable widget had no off-ramp
The `graph_view` emit-time validator (exact-subset + per-node citation) rejected every emit; rejected emits ride an `invalid_block` ack **without terminating the turn**, and there was no recovery directive, so `emitted` stayed empty across all 8 rounds and the turn died blank. This is the failure **class**, not just the analyzer case — exactly counter to the cuaderno's evidence-first honesty backbone.

- every `invalid_block` ack now carries a **`recovery`** instruction (what to do, not just why it failed).
- after a round whose only emit was a rejected widget, inject a **prose off-ramp** ("an honest prose answer is better than no answer"). Not latched: each stuck round renews the offer; the closing round is skipped.

## Test Plan

- [x] **8 new/changed tests**, TDD red→green:
  - `get_module_graph`: neighborhood-not-isolated-node, file-path focus resolution, focus survives truncation, no-match empty, dispatcher scope arg.
  - compositor: `invalid_block` ack carries recovery, all-rejected round injects the prose off-ramp, persistent fixation keeps offering the off-ramp.
- [x] **Full suite: 652 passed, 3 skipped** (marimo integration). The lone `database is locked` warning is the known Windows-flaky analysis-thread family, unrelated to these files.
- [x] **Real-DB end-to-end**: `scope="analyzer"` went from *1 module / 0 edges* to *50 modules / 55 edges* with focus `copyclip/intelligence` and its cited neighbors.

## Flagged for later (not in scope)
The resolved neighborhood is test-heavy because the module model collapses files into their directory (`analyzer.py` is not its own node). Module-vs-file granularity is a deeper modeling concern — a Wave 4 candidate, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced module selection to match both names and file paths for more flexible graph scoping.
  * Added recovery mechanisms to gracefully handle cases when content cannot be properly generated, offering prose alternatives.

* **Improvements**
  * Improved ranking of module results to prioritize focused selections.
  * Expanded error recovery handling with clearer fallback instructions.

* **Tests**
  * Added comprehensive test coverage for recovery behaviors and updated scope semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->