### PR TITLE
fix(cuaderno): file-granularity module graph — the node IS the file

### DIFF
--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -261,26 +261,42 @@ def git_diff(project_root: str, commit_sha: str, path: Optional[str] = None) -> 
     return {"diff": out}
 
 
-def get_module_graph(
-    conn: sqlite3.Connection,
-    project_id: int,
-    scope: str = "",
-    max_modules: int = 50,
-    max_edges: int = 80,
+def _rank_and_cap(
+    nodes: set[str],
+    edges: list[tuple[str, str, int]],
+    node_file: dict[str, str],
+    focus: set[str],
+    max_nodes: int,
+    max_edges: int,
 ) -> dict[str, Any]:
-    """Module-level topology aggregated from symbol_edges — both endpoints live
-    in the symbols.module namespace, so every node maps to a real file (citation)
-    and stdlib/external import targets never appear.
-
-    `scope` is a FOCUS, not an induced-subgraph filter: it selects the modules
-    matching the substring — by module name OR by a backing file path, so
-    'analyzer' resolves the module whose file is analyzer.py even when that module
-    is named after the parent directory — and returns them PLUS their direct
-    neighbors and the edges incident to the focus (an ego graph, radius 1). This
-    is what answers 'the graph around X'; an empty scope returns the whole
-    project. Deterministic caps: focus modules rank first (never pruned out for a
+    """Shared ego-graph finishing: focus nodes rank first (never pruned out for a
     higher-degree neighbor), then degree DESC then name ASC; edges pruned to
-    surviving nodes, then capped by weight DESC."""
+    surviving nodes, then capped by weight DESC. Each node carries its citation
+    file from node_file."""
+    degree: dict[str, int] = {}
+    for f, t, w in edges:
+        degree[f] = degree.get(f, 0) + 1
+        degree[t] = degree.get(t, 0) + 1
+    ranked = sorted(nodes, key=lambda m: (m not in focus, -degree.get(m, 0), m))
+    truncated = len(ranked) > max_nodes
+    keep = set(ranked[:max_nodes])
+    pruned = [(f, t, w) for (f, t, w) in edges if f in keep and t in keep]
+    pruned.sort(key=lambda e: (-e[2], e[0], e[1]))
+    if len(pruned) > max_edges:
+        truncated = True
+        pruned = pruned[:max_edges]
+    return {
+        "modules": [{"name": m, "file_path": node_file[m]} for m in sorted(keep)],
+        "edges": [{"from": f, "to": t, "weight": w} for (f, t, w) in pruned],
+        "truncated": truncated,
+    }
+
+
+def _directory_graph(
+    conn: sqlite3.Connection, project_id: int, max_nodes: int, max_edges: int
+) -> dict[str, Any]:
+    """Whole-project overview at DIRECTORY granularity: a node is a module
+    (a directory), the right altitude for 'show me the project'."""
     rows = conn.execute(
         """
         SELECT s1.module, s2.module, COUNT(*) AS weight
@@ -300,50 +316,70 @@ def get_module_graph(
             (project_id,),
         ).fetchall()
     )
-    all_mods = set(files)
+    nodes = set(files)
+    edges = [(f, t, w) for (f, t, w) in rows if f in nodes and t in nodes]
+    return _rank_and_cap(nodes, edges, files, set(), max_nodes, max_edges)
 
-    focus: set[str] = set()
-    if scope:
-        focus = {m for m in all_mods if scope in m}
-        # Resolve via backing file paths too: a file like analyzer.py lives in a
-        # module named after its parent directory, so a name-only match misses it.
-        for (m,) in conn.execute(
-            "SELECT DISTINCT module FROM symbols "
-            "WHERE project_id=? AND module IS NOT NULL AND file_path LIKE ?",
-            (project_id, f"%{scope}%"),
-        ):
-            if m in all_mods:
-                focus.add(m)
-        if not focus:
-            return {"modules": [], "edges": [], "truncated": False}
-        # Ego graph: edges incident to a focus module, plus the nodes they reach.
-        edges = [(f, t, w) for (f, t, w) in rows if f in focus or t in focus]
-        nodes = set(focus)
-        for f, t, w in edges:
-            nodes.add(f)
-            nodes.add(t)
-        nodes &= all_mods
-    else:
-        nodes = set(all_mods)
-        edges = [(f, t, w) for (f, t, w) in rows if f in nodes and t in nodes]
 
-    degree: dict[str, int] = {}
-    for f, t, w in edges:
-        degree[f] = degree.get(f, 0) + 1
-        degree[t] = degree.get(t, 0) + 1
-    ranked = sorted(nodes, key=lambda m: (m not in focus, -degree.get(m, 0), m))
-    truncated = len(ranked) > max_modules
-    keep = set(ranked[:max_modules])
-    pruned = [(f, t, w) for (f, t, w) in edges if f in keep and t in keep]
-    pruned.sort(key=lambda e: (-e[2], e[0], e[1]))
-    if len(pruned) > max_edges:
-        truncated = True
-        pruned = pruned[:max_edges]
-    return {
-        "modules": [{"name": m, "file_path": files[m]} for m in sorted(keep)],
-        "edges": [{"from": f, "to": t, "weight": w} for (f, t, w) in pruned],
-        "truncated": truncated,
+def _file_graph(
+    conn: sqlite3.Connection, project_id: int, scope: str, max_nodes: int, max_edges: int
+) -> dict[str, Any]:
+    """Focused ego graph at FILE granularity: a node is a file, cited as itself,
+    so the thing the user names ('the analyzer' = analyzer.py) is a node — not a
+    directory it dissolves into. The focus resolves by file path OR symbol name,
+    so 'around X' works whether X is a file or a function the user remembers."""
+    rows = conn.execute(
+        """
+        SELECT s1.file_path, s2.file_path, COUNT(*) AS weight
+        FROM symbol_edges e
+        JOIN symbols s1 ON e.from_symbol_id = s1.id
+        JOIN symbols s2 ON e.to_symbol_id = s2.id
+        WHERE e.project_id=? AND s1.file_path IS NOT NULL AND s2.file_path IS NOT NULL
+              AND s1.file_path != s2.file_path
+        GROUP BY s1.file_path, s2.file_path
+        """,
+        (project_id,),
+    ).fetchall()
+    focus = {
+        fp
+        for (fp,) in conn.execute(
+            "SELECT DISTINCT file_path FROM symbols "
+            "WHERE project_id=? AND file_path IS NOT NULL "
+            "AND (file_path LIKE ? OR name LIKE ?)",
+            (project_id, f"%{scope}%", f"%{scope}%"),
+        )
     }
+    if not focus:
+        return {"modules": [], "edges": [], "truncated": False}
+    edges = [(f, t, w) for (f, t, w) in rows if f in focus or t in focus]
+    nodes = set(focus)
+    for f, t, w in edges:
+        nodes.add(f)
+        nodes.add(t)
+    node_file = {n: n for n in nodes}  # a file node cites itself, never a sibling
+    return _rank_and_cap(nodes, edges, node_file, focus, max_nodes, max_edges)
+
+
+def get_module_graph(
+    conn: sqlite3.Connection,
+    project_id: int,
+    scope: str = "",
+    max_modules: int = 50,
+    max_edges: int = 80,
+) -> dict[str, Any]:
+    """Dependency topology aggregated from symbol_edges; nodes map to real files
+    (citations) and stdlib/external targets never appear.
+
+    Granularity follows intent: an empty `scope` returns the WHOLE PROJECT at
+    DIRECTORY granularity (a node is a module/folder — the right altitude for an
+    overview). A non-empty `scope` is a FOCUS that drops to FILE granularity — it
+    returns the file the user named (resolved by file path OR symbol name) as a
+    node cited as itself, PLUS its direct-import neighbors (an ego graph, radius
+    1). This is what makes 'the graph around analyzer.py' nameable: the file is a
+    node, not a directory it dissolves into."""
+    if scope:
+        return _file_graph(conn, project_id, scope, max_modules, max_edges)
+    return _directory_graph(conn, project_id, max_modules, max_edges)
 
 
 def find_tests(project_root: str, symbol_name: str) -> dict[str, Any]:

--- a/src/copyclip/intelligence/cuaderno/compositor.py
+++ b/src/copyclip/intelligence/cuaderno/compositor.py
@@ -8,6 +8,7 @@ from typing import Any, Iterator, Optional
 from .prompts import (
     SYSTEM_PROMPT, GROUNDING_RETRY_DIRECTIVE, LANGUAGE_RETRY_DIRECTIVE,
     RESPONSIVENESS_RETRY_FALLBACK, INVALID_BLOCK_RECOVERY, WIDGET_RECOVERY_DIRECTIVE,
+    WIDGET_RECOVERY_DIRECTIVE_VISUAL,
 )
 from .read_ledger import ReadLedger
 from .quality import assess, cheap_verdict_dict, artifacts_cited
@@ -45,6 +46,19 @@ def _inject_directive(messages: list[dict[str, Any]], text: str) -> None:
             messages.append({"role": "user", "content": [block]})
     else:
         messages.append({"role": "user", "content": [block]})
+
+
+# A question that explicitly asks to SEE a graph: for these, the prose off-ramp
+# is the wrong exit (prose earns off_target), so recovery pushes a widget rebuild.
+_VISUAL_REQUEST_TERMS = (
+    "show", "draw", "graph", "diagram", "visuali", "chart", "plot",
+    "muestra", "muéstra", "dibuj", "grafic", "grafo", "diagrama", "visualiz",
+)
+
+
+def _is_visual_request(question: str) -> bool:
+    q = question.lower()
+    return any(term in q for term in _VISUAL_REQUEST_TERMS)
 
 
 def _fallback_frame(question: str, reason: str) -> Frame:
@@ -357,7 +371,11 @@ def iter_compose_events(
         # directive already forces composition and which has no next turn to read.
         if (not is_closing and emit_status
                 and all(reason is not None for reason in emit_status.values())):
-            _inject_directive(messages, WIDGET_RECOVERY_DIRECTIVE)
+            _inject_directive(
+                messages,
+                WIDGET_RECOVERY_DIRECTIVE_VISUAL if _is_visual_request(question)
+                else WIDGET_RECOVERY_DIRECTIVE,
+            )
 
     # Budget exhausted → fallback frame (terminal; parity with the wrapper below).
     if emitted:

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -74,6 +74,17 @@ WIDGET_RECOVERY_DIRECTIVE = (
     "answer. Then call finish."
 )
 
+# For a question that explicitly asks to SHOW a graph, prose is off-target, not a
+# degraded answer. With file-granularity evidence the widget IS buildable, so
+# recovery means rebuild — never bail to prose unless the graph is truly empty.
+WIDGET_RECOVERY_DIRECTIVE_VISUAL = (
+    "The graph you emitted could not be grounded, so it was dropped. You asked to "
+    "SHOW a graph, so do not answer in prose — rebuild the graph_view using the "
+    "EXACT node and edge names a graph tool returned this turn (they are in the "
+    "evidence now). Only if a graph tool genuinely returned no nodes should you "
+    "say so briefly. Then call finish."
+)
+
 SYSTEM_PROMPT = """\
 You are the cuaderno — a tutor that helps a single developer understand
 their own AI-generated codebase. The user is an archaeologist of their own
@@ -162,8 +173,11 @@ not part of the format.
    "edges": [{"from": "<id>", "to": "<id>"}], "focus": "<id>"?, "truncated": <bool>}
    nodes/edges MUST come from this turn's get_module_graph or get_callers/get_callees results
    (no other tool's output qualifies); each node "id" and each edge "from"/"to" MUST be the
-   EXACT module or symbol name the tool returned — never a slug, index, or shortened label;
-   every node carries a citation ({kind:'path', path}); set truncated when the tool said so.
+   EXACT id the tool returned (a file path or a module name) — never a slug, index, or
+   shortened label; put any friendly short name in "label", not "id". A scoped
+   get_module_graph returns file ids; an empty scope returns module (directory) ids — do not
+   mix the two in one widget. Every node carries a citation ({kind:'path', path}); set
+   truncated when the tool said so.
 - {"kind": "playground", "function_ref": {"file": "...", "name": "...", "line": <int>?, "qualname": "..."?},
    "breadcrumb": "one-line description", "suggested_inputs": [...]?}
    a runnable example descriptor; function_ref must name a real symbol you located this turn;

--- a/src/copyclip/intelligence/cuaderno/tool_catalog.py
+++ b/src/copyclip/intelligence/cuaderno/tool_catalog.py
@@ -118,11 +118,13 @@ def build_tool_definitions() -> list[dict[str, Any]]:
         {
             "name": "get_module_graph",
             "description": (
-                "Module-level dependency topology (calls, inheritance) with the file "
-                "backing each module. Pass `scope` to focus on one area: it returns "
-                "the matching modules PLUS their direct neighbors and the edges "
-                "between them — this is how you answer 'the graph around X'. Use it "
-                "to build a graph_view widget; emit only the nodes/edges it returned."
+                "Dependency topology (calls, inheritance); every node maps to a real "
+                "file. Granularity follows your `scope`: pass a `scope` to FOCUS on a "
+                "file or symbol — you get that FILE as a node (cited as itself) plus "
+                "its direct-import neighbors, which is how you answer 'the graph "
+                "around X'. Leave `scope` empty for the whole-project overview at "
+                "directory granularity. Build a graph_view from it; emit only the "
+                "exact node/edge ids it returned."
             ),
             "input_schema": {
                 "type": "object",
@@ -130,10 +132,10 @@ def build_tool_definitions() -> list[dict[str, Any]]:
                     "scope": {
                         "type": "string",
                         "description": (
-                            "focus substring, matched against module names AND file "
-                            "paths (so 'analyzer' finds analyzer.py even though its "
-                            "module is the parent dir); returns that neighborhood. "
-                            "Empty = whole project."
+                            "focus substring naming a file or symbol, matched against "
+                            "file paths AND symbol names (so 'analyzer' finds "
+                            "analyzer.py). Returns that file's neighborhood at file "
+                            "granularity. Empty = whole project at directory granularity."
                         ),
                     }
                 },

--- a/tests/test_cuaderno_compositor.py
+++ b/tests/test_cuaderno_compositor.py
@@ -960,3 +960,43 @@ def test_persistent_widget_fixation_keeps_offering_prose_offramp(tmp_path: Path)
     offers = json.dumps(client.calls).count("answer in prose")
     assert offers >= 1, "the prose off-ramp must be offered to a fixating model"
     assert any(e["type"] == "frame" for e in events), "a terminal frame must still be produced"
+
+
+def test_visual_question_pushes_widget_rebuild_not_prose(tmp_path: Path):
+    """For a 'show me the graph' question, a rejected widget must NOT be told to
+    answer in prose (that earns off_target) — it must be pushed to rebuild the
+    graph_view, since file-granularity evidence makes the widget buildable now."""
+    turns = [
+        _graph_turn(),
+        _bad_widget_turn(),
+        [  # a later turn so the loop terminates cleanly
+            _tool_stop("l1", "emit_block", {"kind": "lead", "text": "ans"}),
+            _tool_stop("f", "finish", {}),
+            _msg_stop("tool_use", [
+                _content("l1", "emit_block", {"kind": "lead", "text": "ans"}),
+                _content("f", "finish", {}),
+            ]),
+        ],
+    ]
+    client = StubStream(turns)
+    with patch(
+        "copyclip.intelligence.cuaderno.compositor.dispatch_tool",
+        side_effect=lambda name, args, **kw: _GRAPH_RESULT,
+    ):
+        list(iter_compose_events(
+            client=client, question="show me the module graph around the analyzer",
+            project_root=str(tmp_path), project_id=1, conn=None, max_tool_rounds=8,
+        ))
+    # Isolate the injected DIRECTIVE (a user text block) from the ack recovery,
+    # which is JSON inside a tool_result.
+    directives = []
+    for m in client.calls[-1]["messages"]:
+        if m["role"] == "user" and isinstance(m["content"], list):
+            for blk in m["content"]:
+                if isinstance(blk, dict) and blk.get("type") == "text":
+                    directives.append(blk["text"])
+    joined = " ".join(directives)
+    assert "rebuild the graph_view" in joined, "a visual question must be pushed to rebuild the widget"
+    # The non-visual directive SELLS prose ("an honest prose answer is better than
+    # no answer"); the visual directive must not — that phrase is the distinguisher.
+    assert "better than no answer" not in joined, "a visual question must NOT sell the prose off-ramp"

--- a/tests/test_cuaderno_module_graph.py
+++ b/tests/test_cuaderno_module_graph.py
@@ -71,37 +71,68 @@ def test_edges_join_modules_and_nodes_carry_files(seeded):
     assert g["truncated"] is False
 
 
-def test_scope_returns_neighborhood_not_isolated_node(seeded):
-    """A scoped graph is a NEIGHBORHOOD: the focus module PLUS its direct
-    neighbors and the edges incident to it — never an isolated, edge-less node.
-    (Regression: scope='X' used to return only X with zero edges, leaving the
-    model with no graph to render and no way to answer 'the graph around X'.)"""
+def test_empty_scope_keeps_directory_granularity(seeded):
+    """The whole-project overview (empty scope) stays at DIRECTORY granularity —
+    nodes are module names, the right altitude for 'show me the project'."""
+    c, pid = seeded
+    g = get_module_graph(c, pid)
+    names = {m["name"] for m in g["modules"]}
+    assert {"pkg/a", "pkg/b", "pkg/c"} <= names      # modules, not file paths
+    assert not any(n.endswith(".py") for n in names)
+
+
+def test_scope_uses_file_granularity_neighborhood(seeded):
+    """A SCOPED query drops to FILE granularity: the node the user names is the
+    file itself, surrounded by its real-import neighbors. This is the identity
+    fix — 'the analyzer' becomes a node, not a directory it dissolves into."""
     c, pid = seeded
     g = get_module_graph(c, pid, scope="pkg/b")
     names = {m["name"] for m in g["modules"]}
-    assert "pkg/b" in names                      # the focus
-    assert "pkg/a" in names                      # its neighbor (a -> b)
-    assert "pkg/c" not in names                  # not adjacent to b — excluded
-    assert ("pkg/a", "pkg/b") in {(e["from"], e["to"]) for e in g["edges"]}
+    assert "pkg/b.py" in names                       # the focus, as a FILE node
+    assert "pkg/a.py" in names                       # its neighbor (a.py -> b.py)
+    assert "pkg/c.py" not in names                   # not adjacent — excluded
+    assert ("pkg/a.py", "pkg/b.py") in {(e["from"], e["to"]) for e in g["edges"]}
 
 
-def test_scope_resolves_focus_via_file_path(seeded):
-    """The focus substring matches a module's BACKING FILE PATH, not only its
-    collapsed module name — so 'analyzer' finds the module whose file is
-    analyzer.py even though the module name is the parent directory."""
+def test_file_node_cites_itself(seeded):
+    """A file node's citation is the file itself — never a sibling. (Regression:
+    the directory node copyclip/intelligence was cited as agents.py, so 'the
+    analyzer' node pointed at a different file.)"""
+    c, pid = seeded
+    g = get_module_graph(c, pid, scope="pkg/b")
+    assert g["modules"]
+    assert all(m["name"] == m["file_path"] for m in g["modules"])
+
+
+def test_scope_resolves_file_by_path(seeded):
+    """The focus substring matches a file PATH, so 'analyzer' finds analyzer.py
+    directly as its own node."""
     c, pid = seeded
     core = _insert_symbol(c, pid, "run", "svc/core", "svc/special_analyzer.py")
     dep = _insert_symbol(c, pid, "store", "svc/db", "svc/db.py")
-    _insert_edge(c, pid, core, dep)  # svc/core -> svc/db
+    _insert_edge(c, pid, core, dep)
     g = get_module_graph(c, pid, scope="analyzer")
     names = {m["name"] for m in g["modules"]}
-    assert "svc/core" in names                   # resolved by file path
-    assert "svc/db" in names                      # its neighbor
+    assert "svc/special_analyzer.py" in names        # the file itself is the node
+    assert "svc/db.py" in names                       # its neighbor
 
 
-def test_focus_node_survives_truncation():
-    """Under a tight module cap the FOCUS node is never pruned out in favor of a
-    higher-degree neighbor — the user asked about it specifically."""
+def test_scope_resolves_file_by_symbol_name(seeded):
+    """The focus substring also matches a SYMBOL name, resolving 'around <symbol>'
+    to the file that defines it — even when the name is not in the path."""
+    c, pid = seeded
+    ui = _insert_symbol(c, pid, "special_widget", "svc/ui", "svc/ui.py")
+    rend = _insert_symbol(c, pid, "draw", "svc/render", "svc/render.py")
+    _insert_edge(c, pid, ui, rend)
+    g = get_module_graph(c, pid, scope="special_widget")
+    names = {m["name"] for m in g["modules"]}
+    assert "svc/ui.py" in names                       # resolved by symbol name
+    assert "svc/render.py" in names                   # its neighbor
+
+
+def test_focus_file_survives_truncation():
+    """Under a tight cap the focus FILE node is never pruned for a higher-degree
+    neighbor."""
     c = sqlite3.connect(":memory:")
     init_schema(c)
     pid = _make_project(c)
@@ -113,7 +144,7 @@ def test_focus_node_survives_truncation():
     _insert_edge(c, pid, a, cc)
     _insert_edge(c, pid, a, d)
     g = get_module_graph(c, pid, scope="pkg/b", max_modules=1)
-    assert "pkg/b" in {m["name"] for m in g["modules"]}
+    assert "pkg/b.py" in {m["name"] for m in g["modules"]}
     assert g["truncated"] is True
 
 
@@ -184,7 +215,7 @@ def test_dispatch_get_module_graph_not_unknown_tool(seeded):
 
 
 def test_dispatch_get_module_graph_scope_arg(seeded):
-    """Dispatcher passes scope through; scope yields the focus neighborhood."""
+    """Dispatcher passes scope through; a scoped query yields the file neighborhood."""
     c, pid = seeded
     from copyclip.intelligence.cuaderno.tool_catalog import dispatch_tool
     out = dispatch_tool(
@@ -195,7 +226,7 @@ def test_dispatch_get_module_graph_scope_arg(seeded):
         conn=c,
     )
     names = {m["name"] for m in out["modules"]}
-    assert "pkg/b" in names and "pkg/a" in names
+    assert "pkg/b.py" in names and "pkg/a.py" in names
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

"show me the module graph around the analyzer" failed **three times, each in a new shape** — budget-exhausted (PR #135/#136), then vague prose, then off_target prose. Rather than patch a third symptom, the finding went to a **roster council** (Voronov · ontology, Serrano · spec, Richter · structure, Halberg · feasibility, Cassian · shipping, Axiom-0 · closer). The verdict was unanimous: one root cause beneath all three.

### Root cause — a category error in node identity
The graph names **directories**; the user names **files**. `_module_from_relpath` returns the parent directory (`"/".join(parts[:-1])`), so `analyzer.py` dissolves into the node `copyclip/intelligence` — cited, worse, as its alphabetic-MIN file `agents.py`. "The analyzer" was **ontologically unnameable**, so the model could only describe it or bail to prose; the responsiveness judge correctly flagged `off_target`. Each prior fix relocated the symptom because the defect lives at the identity layer, not at any patch site.

**Axiom-0's invariant:** *a node's identity must be the same unit the user reaches for; addressability is the graph's first axiom.*

### The fix — file granularity (Cassian's hybrid: B's outcome at A's cost)
The edges already exist at **symbol** granularity (`from_symbol_id`/`to_symbol_id`) and every symbol carries `file_path`, so file-level topology is a **GROUP BY change, not new data** (Richter/Halberg, verified live).

- **`get_module_graph`**: a scoped query drops to **file granularity** (`GROUP BY file_path`) — the file the user named is a node **cited as itself**, with its real-import ego graph; the focus resolves by **file path OR symbol name**. An empty scope keeps the directory overview (the right altitude for "show me the project").
- **compositor/prompts**: for a "show/draw/graph" question, prose is `off_target`, not a degraded answer. The widget-recovery off-ramp now **pushes a graph_view rebuild** (the file-granularity evidence is buildable) and no longer sells prose.

## Test Plan
- [x] **TDD red→green**, file granularity: file-node neighborhood, self-citing node, focus-by-path, focus-by-symbol-name, focus survives truncation, empty-scope stays directory; visual-question pushes rebuild-not-prose.
- [x] **Full suite: 656 passed, 3 skipped.** The lone `database is locked` warning is the known Windows-flaky analysis-thread family, unrelated.
- [x] **Live DB end-to-end**: `scope="analyzer"` went from *1 isolated node / 0 edges* to **13 nodes / 14 edges**, `analyzer.py` self-citing (`analyzer.py → cache.py w8, → db.py w2, → tree_sitter_parser…`), only 2 of 14 edges test-coupled — so Voronov's salience caution is empirically moot for this node.
- [x] No frontend change (GraphView renders `node.label`, not `id`); no bundle regen.

## Deferred to Wave 4 (explicitly cut, not needed for these questions)
The analyzer-wide re-model — `_module_from_relpath`, the `symbols.module` column, the #111 root-collapse — so "module" means file everywhere. **Salience** (what "around" should privilege: authored-over-test, last-touched, intra-package) is a separate POST-SHIP spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Module dependency graphs now intelligently adapt granularity: directory-level overview for full-project views, file-level detail when exploring specific modules or symbols.
  * Improved recovery when generating graph visualizations with better identification of file dependencies.

* **Documentation**
  * Updated module graph tool descriptions to clarify scope and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->