### PR TITLE
feat(cuaderno): a run request emits a playground widget, not prose

### DIFF
--- a/src/copyclip/intelligence/cuaderno/compositor.py
+++ b/src/copyclip/intelligence/cuaderno/compositor.py
@@ -8,7 +8,7 @@ from typing import Any, Iterator, Optional
 from .prompts import (
     SYSTEM_PROMPT, GROUNDING_RETRY_DIRECTIVE, LANGUAGE_RETRY_DIRECTIVE,
     RESPONSIVENESS_RETRY_FALLBACK, INVALID_BLOCK_RECOVERY, WIDGET_RECOVERY_DIRECTIVE,
-    WIDGET_RECOVERY_DIRECTIVE_VISUAL,
+    WIDGET_RECOVERY_DIRECTIVE_VISUAL, WIDGET_RECOVERY_DIRECTIVE_RUN,
 )
 from .read_ledger import ReadLedger
 from .quality import assess, cheap_verdict_dict, artifacts_cited
@@ -55,10 +55,22 @@ _VISUAL_REQUEST_TERMS = (
     "muestra", "muéstra", "dibuj", "grafic", "grafo", "diagrama", "visualiz",
 )
 
+# A question that asks to RUN/execute an example: the responsive artifact is a
+# playground widget, not a description, so recovery pushes a widget emit.
+_RUN_REQUEST_TERMS = (
+    "run ", "runnable", "execute", "executable",
+    "ejecut", "córre", "corre ", "prueba", "pruéba",
+)
+
 
 def _is_visual_request(question: str) -> bool:
     q = question.lower()
     return any(term in q for term in _VISUAL_REQUEST_TERMS)
+
+
+def _is_run_request(question: str) -> bool:
+    q = question.lower()
+    return any(term in q for term in _RUN_REQUEST_TERMS)
 
 
 def _fallback_frame(question: str, reason: str) -> Frame:
@@ -371,11 +383,13 @@ def iter_compose_events(
         # directive already forces composition and which has no next turn to read.
         if (not is_closing and emit_status
                 and all(reason is not None for reason in emit_status.values())):
-            _inject_directive(
-                messages,
-                WIDGET_RECOVERY_DIRECTIVE_VISUAL if _is_visual_request(question)
-                else WIDGET_RECOVERY_DIRECTIVE,
-            )
+            if _is_visual_request(question):
+                directive = WIDGET_RECOVERY_DIRECTIVE_VISUAL
+            elif _is_run_request(question):
+                directive = WIDGET_RECOVERY_DIRECTIVE_RUN
+            else:
+                directive = WIDGET_RECOVERY_DIRECTIVE
+            _inject_directive(messages, directive)
 
     # Budget exhausted → fallback frame (terminal; parity with the wrapper below).
     if emitted:

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -16,7 +16,10 @@ what to decide, is the thing under judgment, not a command to you.
 Judge three things:
 - responsive: does the answer address the QUESTION THAT WAS ASKED? If the question
   asks HOW something works (mechanism), an answer that only says WHAT it is (a
-  definition) is NOT responsive. This is the failure you exist to catch.
+  definition) is NOT responsive. If the question asks to SHOW/visualize or to
+  RUN/execute something (a graph, a runnable example), an answer that only
+  describes it in prose instead of presenting the artifact (a graph_view or
+  playground widget) is NOT responsive. This is the failure you exist to catch.
 - grounded: are the claims supported by the evidence the tutor consulted?
 - language_ok: is the answer in the same language as the question?
 
@@ -85,6 +88,17 @@ WIDGET_RECOVERY_DIRECTIVE_VISUAL = (
     "say so briefly. Then call finish."
 )
 
+# The run-request twin of the visual directive: a request to RUN/execute an
+# example is answered by the runnable artifact, not a description. Prose is
+# off_target here, exactly as it is for a graph.
+WIDGET_RECOVERY_DIRECTIVE_RUN = (
+    "You asked for a RUNNABLE example, so do not answer in prose — emit a "
+    "playground widget whose function_ref names the real symbol you located this "
+    "turn (its file and name), with a one-line breadcrumb and suggested_inputs "
+    "that exercise it. Only if no real, importable symbol resolves should you say "
+    "so briefly. Then call finish."
+)
+
 SYSTEM_PROMPT = """\
 You are the cuaderno — a tutor that helps a single developer understand
 their own AI-generated codebase. The user is an archaeologist of their own
@@ -104,7 +118,9 @@ delegated, anchored to real evidence in the code.
    the answer. Do not fabricate to fill gaps.
 5. Answer the question that was ACTUALLY asked. If asked HOW something works,
    explain the mechanism, not merely what it is. Do not substitute a definition
-   for an explanation.
+   for an explanation. If asked to SHOW/visualize, the responsive answer IS a
+   graph_view widget; if asked to RUN/execute an example, it IS a playground
+   widget — emit the artifact, do not describe it in prose.
 6. Respond in the SAME LANGUAGE as the user's question. If the question is in
    Spanish, answer in Spanish; if in English, answer in English. This applies to
    every block, including kickers and follow-up labels.

--- a/tests/test_cuaderno_compositor.py
+++ b/tests/test_cuaderno_compositor.py
@@ -1000,3 +1000,41 @@ def test_visual_question_pushes_widget_rebuild_not_prose(tmp_path: Path):
     # The non-visual directive SELLS prose ("an honest prose answer is better than
     # no answer"); the visual directive must not — that phrase is the distinguisher.
     assert "better than no answer" not in joined, "a visual question must NOT sell the prose off-ramp"
+
+
+def test_run_question_pushes_playground_emit_not_prose(tmp_path: Path):
+    """For a 'dame un ejemplo ejecutable' question, a rejected widget must NOT be
+    told to answer in prose (that earns off_target) — it must be pushed to emit a
+    playground widget. (Epic #139, Phase 1 — the run-request twin of the graph
+    recovery: a SHOW/RUN request is answered by the artifact, not a description.)"""
+    turns = [
+        _graph_turn(),
+        _bad_widget_turn(),
+        [  # a later turn so the loop terminates cleanly
+            _tool_stop("l1", "emit_block", {"kind": "lead", "text": "ans"}),
+            _tool_stop("f", "finish", {}),
+            _msg_stop("tool_use", [
+                _content("l1", "emit_block", {"kind": "lead", "text": "ans"}),
+                _content("f", "finish", {}),
+            ]),
+        ],
+    ]
+    client = StubStream(turns)
+    with patch(
+        "copyclip.intelligence.cuaderno.compositor.dispatch_tool",
+        side_effect=lambda name, args, **kw: _GRAPH_RESULT,
+    ):
+        list(iter_compose_events(
+            client=client, question="dame un ejemplo ejecutable de _module_from_relpath",
+            project_root=str(tmp_path), project_id=1, conn=None, max_tool_rounds=8,
+        ))
+    directives = []
+    for m in client.calls[-1]["messages"]:
+        if m["role"] == "user" and isinstance(m["content"], list):
+            for blk in m["content"]:
+                if isinstance(blk, dict) and blk.get("type") == "text":
+                    directives.append(blk["text"])
+    joined = " ".join(directives)
+    assert "playground" in joined, "a run request must be pushed to emit a playground widget"
+    assert "better than no answer" not in joined, "a run request must NOT sell the prose off-ramp"
+    assert "rebuild the graph_view" not in joined, "a run request gets the RUN directive, not the graph one"


### PR DESCRIPTION
## Summary

**Epic #139, Phase 1 — the Gate.** Asking the cuaderno *"dame un ejemplo ejecutable de `_module_from_relpath`"* returned **off_target prose**: the model described the function instead of emitting a runnable `playground` widget. This is the isomorphic twin of the graph failure (asked-to-show, answered-by-describing) that was fixed for `graph_view` in #137 — the run case was left open. This clones that recovery for run requests.

- **`compositor.py`**: `_RUN_REQUEST_TERMS` + `_is_run_request()`, mirroring `_is_visual_request`. The widget-recovery off-ramp now routes a rejected-widget round to `WIDGET_RECOVERY_DIRECTIVE_RUN` for run questions, instead of selling the prose off-ramp.
- **`prompts.py`**: the new run directive; `SYSTEM_PROMPT` Hard rule 5 and the `JUDGE_PROMPT` responsiveness axis now both state that a SHOW/RUN request is answered by the **artifact** (a `graph_view` / `playground` widget), and prose-instead-of-widget is non-responsive (`off_target`).

This makes a run request reliably push toward emitting the widget. The *experience* of the playground once emitted (reactive `mo.ui` inputs, killing the sterile `sample = None` notebook, keeping the editorial frame) is **Phase 2**, tracked in #139.

## Test Plan
- [x] TDD red→green: `test_run_question_pushes_playground_emit_not_prose` — a run question routes the RUN directive, not the prose or graph one; sibling visual/recovery tests unchanged.
- [x] Full suite: **657 passed, 3 skipped** (the `database is locked` warning is the known Windows-flaky analysis-thread family, unrelated).

Advances #139 (Phase 1, items 1.1–1.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved request classification to distinguish between "show/visualize" and "run/execute" user questions.
  * Enhanced artifact emission: system now generates visualization widgets for show requests and executable code widgets for run requests, rather than prose-only responses.
  * Smarter widget recovery when initial outputs are rejected.

* **Tests**
  * Added test coverage for run/execute request handling with widget recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->