### PR TITLE
feat(cuaderno): deterministic playground floor for run-requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,14 @@ against a SHA-pinned corpus of questions, so answer-quality changes are
 observed rather than guessed at.
 
 See `docs/superpowers/specs/2026-05-28-copyclip-cuaderno-conversacional-design.md`
-for the design. Requires `ANTHROPIC_API_KEY` set in env or `.copyclip/config`.
-Run `copyclip start` to onboard.
+for the design. Run `copyclip start` to configure a provider and onboard.
+
+The cuaderno runs on any configured LLM provider (Anthropic, DeepSeek, or
+OpenAI) and is most reliable on Claude: agentic frame composition leans on the
+model volunteering structured artifacts, which weaker models do less
+consistently. Run-requests are the exception — CopyClip constructs the
+playground deterministically from the resolved symbol, so the runnable artifact
+appears on any provider.
 
 ---
 

--- a/src/copyclip/intelligence/cuaderno/compositor.py
+++ b/src/copyclip/intelligence/cuaderno/compositor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 import time
 from typing import Any, Iterator, Optional
@@ -16,12 +17,13 @@ from .judge import judge_verdict_dict
 from .language import detect_language
 from .i18n import tr
 from .schema import (
-    Block, Frame, frame_from_dict, frame_to_dict, validate_block_dict,
+    Block, Frame, Widget, frame_from_dict, frame_to_dict, validate_block_dict,
     FRAME_STATUS_FALLBACK, FRAME_STATUS_ANSWER,
     FRAME_STATUS_UNGROUNDED, FRAME_STATUS_INSUFFICIENT_EVIDENCE, FRAME_STATUS_OFF_TARGET,
 )
 from .tool_catalog import ANSWER_TOOLS, build_tool_definitions, dispatch_tool
 from .widget_checks import GraphEvidence, validate_widget_payload
+from ..playground import FunctionRef, resolve_function_ref
 
 CLOSING_DIRECTIVE = (
     "You have gathered your evidence — the research tools are no longer "
@@ -71,6 +73,140 @@ def _is_visual_request(question: str) -> bool:
 def _is_run_request(question: str) -> bool:
     q = question.lower()
     return any(term in q for term in _RUN_REQUEST_TERMS)
+
+
+# --- The deterministic playground floor (Epic #139) -------------------------
+# A run-request's required output TYPE (a playground widget) is a property the
+# system guarantees, so it must be enforced OUTSIDE the model: when the model
+# answers a run-request in prose and the turn would seal off_target, the SYSTEM
+# constructs the playground from a symbol that RESOLVES against the symbols table.
+# It never invents — if no symbol resolves, the honest off_target stands.
+
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _candidate_symbol_names(question: str) -> list[str]:
+    """Identifiers in the question that might name a symbol. Underscore-bearing
+    and longer names rank first — they look most like a symbol reference."""
+    seen: list[str] = []
+    for m in _IDENT_RE.findall(question):
+        if len(m) >= 3 and m not in seen:
+            seen.append(m)
+    seen.sort(key=lambda s: (("_" not in s), -len(s)))
+    return seen
+
+
+def _resolve_floor_symbol(conn: sqlite3.Connection, project_id: int,
+                          names: list[str], ledger: Optional[ReadLedger]):
+    """Resolve the FIRST candidate name that maps to a real symbol. A name that
+    spans multiple files is disambiguated to the one the model actually touched
+    (the ledger); still ambiguous -> skip (the floor declines rather than guess)."""
+    touched: set[str] = set()
+    if ledger is not None:
+        touched = set(ledger.read_paths) | set(ledger.evidence_paths)
+    for name in names:
+        rows = conn.execute(
+            "SELECT file_path FROM symbols WHERE project_id=? AND name=? "
+            "AND kind IN ('function','method','class')",
+            (project_id, name),
+        ).fetchall()
+        files = [r[0] for r in rows]
+        if not files:
+            continue
+        if len(files) == 1:
+            chosen = files[0]
+        else:
+            inter = [f for f in files if f in touched]
+            if len(inter) != 1:
+                continue
+            chosen = inter[0]
+        try:
+            return resolve_function_ref(conn, project_id, FunctionRef(file=chosen, name=name))
+        except Exception:  # noqa: BLE001 — any resolution failure means: do not offer a floor
+            continue
+    return None
+
+
+def _has_playground(emitted: list[Block]) -> bool:
+    for b in emitted:
+        if b.kind == "widget":
+            w = b.data.get("widget")
+            if isinstance(w, dict) and w.get("kind") == "playground":
+                return True
+    return False
+
+
+def _construct_playground_floor(question: str, conn: Optional[sqlite3.Connection],
+                                project_id: Optional[int], ledger: Optional[ReadLedger],
+                                emitted: list[Block]) -> Optional[Block]:
+    """Build the playground Block for a run-request from a resolved symbol, or
+    None when nothing resolves (then the honest off_target stands)."""
+    if conn is None or project_id is None or not _is_run_request(question):
+        return None
+    if _has_playground(emitted):
+        return None
+    resolved = _resolve_floor_symbol(conn, project_id,
+                                     _candidate_symbol_names(question), ledger)
+    if resolved is None:
+        return None
+    fr: dict[str, Any] = {"file": resolved.file, "name": resolved.name}
+    if resolved.line_start is not None:
+        fr["line"] = resolved.line_start
+    if resolved.qualname and resolved.qualname != resolved.name:
+        fr["qualname"] = resolved.qualname
+    lang = detect_language(question)
+    breadcrumb = (f"Ejecuta {resolved.name} con un ejemplo"
+                  if lang == "es" else f"Run {resolved.name} with an example")
+    block = Block.widget(Widget.playground(function_ref=fr, breadcrumb=breadcrumb).to_dict())
+    # Defensive: the floor must meet the same emit-time bar as a model widget.
+    if validate_widget_payload(block.to_dict(), GraphEvidence()) is not None:
+        return None
+    return block
+
+
+def _floor_verdict_dict(prior_status: str) -> dict[str, Any]:
+    """Honest verdict for a floor-sealed answer: the artifact is grounded by DB
+    resolution and responsive by construction; `source` marks it system-built and
+    records what it upgraded from."""
+    return {
+        "question_kind": "code_comprehension",
+        "grounded": True,
+        "responsive": True,
+        "language_ok": True,
+        "world": None,
+        "source": "floor",
+        "reason": f"playground constructed deterministically from a resolved symbol (was {prior_status})",
+    }
+
+
+def _floored_frame(frame_dict: dict[str, Any], question: str,
+                   conn: Optional[sqlite3.Connection], project_id: Optional[int],
+                   ledger: Optional[ReadLedger]) -> dict[str, Any]:
+    """Apply the playground floor to a sealed terminal frame: a run-request that
+    would seal `off_target` (prose, not a runnable artifact) or `fallback` (no
+    answer at all) is upgraded to an `answer` carrying a system-constructed
+    playground — when a named symbol RESOLVES against the symbols table. Off_target
+    keeps its grounded prose and gains the artifact; fallback's 'couldn't finish'
+    message is dropped for the artifact. Any other status, or no resolvable symbol,
+    is returned unchanged — the honest verdict stands. Never invents."""
+    status = frame_dict.get("status")
+    if not _is_run_request(question):
+        return frame_dict
+    if status not in (FRAME_STATUS_OFF_TARGET, FRAME_STATUS_FALLBACK):
+        return frame_dict
+    blocks = [Block.from_dict(b) for b in frame_dict.get("blocks", [])]
+    if _has_playground(blocks):
+        # The model already delivered the runnable artifact: a run-request answered
+        # WITH a playground is responsive by definition. An off_target label here is
+        # the judge mislabeling form as relevance — reclassify, don't relabel.
+        return _seal(question, blocks, FRAME_STATUS_ANSWER, _floor_verdict_dict(status))
+    # fallback's only block is a system 'couldn't finish' message — drop it.
+    base: list[Block] = [] if status == FRAME_STATUS_FALLBACK else blocks
+    floor = _construct_playground_floor(question, conn, project_id, ledger, base)
+    if floor is None:
+        return frame_dict
+    base.append(floor)
+    return _seal(question, base, FRAME_STATUS_ANSWER, _floor_verdict_dict(status))
 
 
 def _fallback_frame(question: str, reason: str) -> Frame:
@@ -310,8 +446,10 @@ def iter_compose_events(
                         yield {"type": "reset"}
                         continue
                     yield {"type": "frame",
-                           "frame": _seal(question, emitted, _judge_status(jv),
-                                          judge_verdict_dict(jv))}
+                           "frame": _floored_frame(
+                               _seal(question, emitted, _judge_status(jv),
+                                     judge_verdict_dict(jv)),
+                               question, conn, project_id, ledger)}
                     return
                 yield {"type": "frame",
                        "frame": _seal(question, emitted, FRAME_STATUS_ANSWER,
@@ -319,8 +457,10 @@ def iter_compose_events(
                 return
             else:
                 yield {"type": "frame",
-                       "frame": frame_to_dict(
-                           _fallback_frame(question, "the model produced no answer blocks"))}
+                       "frame": _floored_frame(
+                           frame_to_dict(
+                               _fallback_frame(question, "the model produced no answer blocks")),
+                           question, conn, project_id, ledger)}
             return
 
         # Continue: ack every tool_use block. Dispatch read tools (with events);
@@ -393,10 +533,14 @@ def iter_compose_events(
 
     # Budget exhausted → fallback frame (terminal; parity with the wrapper below).
     if emitted:
-        yield {"type": "frame", "frame": _sealed_frame(question, emitted, ledger, judge=judge)}
+        yield {"type": "frame",
+               "frame": _floored_frame(_sealed_frame(question, emitted, ledger, judge=judge),
+                                       question, conn, project_id, ledger)}
     else:
         yield {"type": "frame",
-               "frame": frame_to_dict(_fallback_frame(question, "tool-call budget exhausted"))}
+               "frame": _floored_frame(
+                   frame_to_dict(_fallback_frame(question, "tool-call budget exhausted")),
+                   question, conn, project_id, ledger)}
 
 
 def compose_frame(

--- a/tests/test_cuaderno_playground_floor.py
+++ b/tests/test_cuaderno_playground_floor.py
@@ -1,0 +1,275 @@
+"""Epic #139 — the deterministic playground floor.
+
+A run-request that names a resolvable symbol must NOT seal off_target when the
+model answers in grounded prose: the compositor constructs the playground widget
+itself from the resolved function_ref. The model authors the words; the SYSTEM
+guarantees the type.
+
+Roster ruling (project memory: capability-not-configuration): a property the
+system guarantees about a model's output must be enforced OUTSIDE the model. The
+run-request -> playground gate was a plea to the model (1-in-6 on DeepSeek); this
+floor makes the artifact type deterministic while keeping authorship the model's.
+The 'never invent' invariant is preserved by construction: the widget is built
+ONLY from a symbol that resolves against the symbols table, else it falls through
+to today's honest off_target.
+"""
+import sqlite3
+from pathlib import Path
+
+from copyclip.intelligence.cuaderno.compositor import iter_compose_events
+from copyclip.intelligence.cuaderno.judge import JudgeVerdict
+from copyclip.intelligence.db import init_schema
+
+
+class StubStream:
+    """Scripted messages_stream, mirroring the AnthropicAdapter contract."""
+
+    def __init__(self, turns):
+        self._turns = list(turns)
+        self.calls = []
+
+    def messages_stream(self, **kwargs):
+        self.calls.append(kwargs)
+        if not self._turns:
+            raise RuntimeError("StubStream ran out of scripted turns")
+        for ev in self._turns.pop(0):
+            yield ev
+
+
+def _tool_stop(block_id, name, inp):
+    return {"type": "block_stop",
+            "block": {"type": "tool_use", "id": block_id, "name": name, "input": inp}}
+
+
+def _content(block_id, name, inp):
+    return {"type": "tool_use", "id": block_id, "name": name, "input": inp}
+
+
+def _msg_stop(stop_reason, content):
+    return {"type": "message_stop", "stop_reason": stop_reason, "content": content}
+
+
+def _seed_symbol_project(conn: sqlite3.Connection) -> int:
+    conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", ("/proj", "test"))
+    pid = int(conn.execute("SELECT id FROM projects WHERE root_path=?", ("/proj",)).fetchone()[0])
+    conn.execute(
+        "INSERT INTO symbols(project_id,name,kind,file_path,line_start,line_end,parent_symbol_id,module) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        (pid, "_module_from_relpath", "function",
+         "src/copyclip/intelligence/analyzer.py", 152, 170, None, "copyclip/intelligence"),
+    )
+    conn.commit()
+    return pid
+
+
+def _grounded_prose_turn(bid: str, fid: str, text: str):
+    return [
+        _tool_stop(bid, "emit_block", {"kind": "lead", "text": text}),
+        _tool_stop(fid, "finish", {}),
+        _msg_stop("tool_use", [
+            _content(bid, "emit_block", {"kind": "lead", "text": text}),
+            _content(fid, "finish", {}),
+        ]),
+    ]
+
+
+def test_run_request_prose_constructs_playground_floor(tmp_path: Path):
+    """The DeepSeek failure trace: model reads, then composes grounded prose for a
+    run-request; the judge flags it non-responsive every time. Today this seals
+    off_target. The floor must instead construct the playground and seal answer."""
+    (tmp_path / "README.md").write_text("# analyzer\n", encoding="utf-8")
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_symbol_project(conn)
+
+    read = [
+        _tool_stop("r1", "read_file", {"path": "README.md"}),
+        _msg_stop("tool_use", [_content("r1", "read_file", {"path": "README.md"})]),
+    ]
+    prose1 = _grounded_prose_turn("b1", "f1", "Convierte una ruta relativa en el nombre del modulo que la contiene.")
+    prose2 = _grounded_prose_turn("b2", "f2", "Colapsa contenedores estructurales como src y lib.")
+    client = StubStream([read, prose1, prose2])
+
+    # The judge keeps flagging the prose as non-responsive for a run-request.
+    jv = JudgeVerdict("code_comprehension", True, False, True, "retry", None,
+                      "give a runnable example, not a description", "describes, does not run")
+    events = list(iter_compose_events(
+        client=client,
+        question="dame un ejemplo ejecutable de _module_from_relpath",
+        project_root=str(tmp_path), project_id=pid, conn=conn,
+        judge=lambda q, b, l: jv,
+    ))
+
+    frame = next(e for e in events if e["type"] == "frame")["frame"]
+    assert frame["status"] == "answer", (
+        f"the floor must seal answer (constructed the artifact), got {frame['status']!r}"
+    )
+    playgrounds = [
+        b for b in frame["blocks"]
+        if b.get("kind") == "widget" and b.get("widget", {}).get("kind") == "playground"
+    ]
+    assert len(playgrounds) == 1, "the floor must construct exactly one playground widget"
+    fr = playgrounds[0]["widget"]["function_ref"]
+    assert fr["name"] == "_module_from_relpath"
+    assert fr["file"] == "src/copyclip/intelligence/analyzer.py"
+
+
+def test_run_request_unresolvable_symbol_stays_off_target(tmp_path: Path):
+    """Never invent: a run-request whose named symbol does NOT resolve against the
+    symbols table must keep the honest off_target — the floor declines to build a
+    widget it cannot ground (which would error at launch)."""
+    (tmp_path / "README.md").write_text("# analyzer\n", encoding="utf-8")
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_symbol_project(conn)  # seeds ONLY _module_from_relpath
+
+    read = [
+        _tool_stop("r1", "read_file", {"path": "README.md"}),
+        _msg_stop("tool_use", [_content("r1", "read_file", {"path": "README.md"})]),
+    ]
+    prose1 = _grounded_prose_turn("b1", "f1", "Una descripcion fundada del comportamiento.")
+    prose2 = _grounded_prose_turn("b2", "f2", "Mas descripcion, todavia sin ejecutar nada.")
+    client = StubStream([read, prose1, prose2])
+
+    jv = JudgeVerdict("code_comprehension", True, False, True, "retry", None,
+                      "give a runnable example, not a description", "describes, does not run")
+    events = list(iter_compose_events(
+        client=client,
+        question="dame un ejemplo ejecutable de funcion_que_no_existe",
+        project_root=str(tmp_path), project_id=pid, conn=conn,
+        judge=lambda q, b, l: jv,
+    ))
+
+    frame = next(e for e in events if e["type"] == "frame")["frame"]
+    assert frame["status"] == "off_target", "no resolvable symbol -> honest off_target stands"
+    playgrounds = [
+        b for b in frame["blocks"]
+        if b.get("kind") == "widget" and b.get("widget", {}).get("kind") == "playground"
+    ]
+    assert playgrounds == [], "the floor must NOT invent a widget for an unresolvable symbol"
+
+
+def _playgrounds(frame: dict) -> list:
+    return [
+        b for b in frame["blocks"]
+        if b.get("kind") == "widget" and b.get("widget", {}).get("kind") == "playground"
+    ]
+
+
+def test_run_request_model_playground_off_target_is_upgraded(tmp_path: Path):
+    """A run-request answered WITH a playground is responsive by definition. If the
+    model itself emits the playground but the (weak) judge still flags off_target,
+    the frame must seal answer — off_target on an artifact-bearing run-request is
+    the judge mislabeling form as relevance (the category error the council named).
+    Reclassify, don't relabel."""
+    analyzer = tmp_path / "src" / "copyclip" / "intelligence" / "analyzer.py"
+    analyzer.parent.mkdir(parents=True)
+    analyzer.write_text("def _module_from_relpath(p):\n    return p.split('/')[0]\n", encoding="utf-8")
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_symbol_project(conn)
+
+    pg_widget = {
+        "kind": "widget",
+        "widget": {
+            "kind": "playground",
+            "function_ref": {
+                "file": "src/copyclip/intelligence/analyzer.py",
+                "name": "_module_from_relpath", "line": 152,
+            },
+            "breadcrumb": "corre la funcion con ejemplos",
+        },
+    }
+    read = [
+        _tool_stop("r1", "read_file", {"path": "src/copyclip/intelligence/analyzer.py"}),
+        _msg_stop("tool_use", [_content("r1", "read_file", {"path": "src/copyclip/intelligence/analyzer.py"})]),
+    ]
+    # Grounded prose + the model's own playground, then finish.
+    emit_pg = [
+        _tool_stop("l1", "emit_block", {"kind": "lead", "text": "La funcion deriva el modulo de una ruta."}),
+        _tool_stop("w1", "emit_block", pg_widget),
+        _tool_stop("f", "finish", {}),
+        _msg_stop("tool_use", [
+            _content("l1", "emit_block", {"kind": "lead", "text": "La funcion deriva el modulo de una ruta."}),
+            _content("w1", "emit_block", pg_widget),
+            _content("f", "finish", {}),
+        ]),
+    ]
+    client = StubStream([read, emit_pg, emit_pg])
+    jv = JudgeVerdict("code_comprehension", True, False, True, "retry", None,
+                      "redo", "judge mislabels an artifact-bearing answer")
+    events = list(iter_compose_events(
+        client=client,
+        question="dame un ejemplo ejecutable de _module_from_relpath",
+        project_root=str(tmp_path), project_id=pid, conn=conn,
+        judge=lambda q, b, l: jv,
+    ))
+    frame = next(e for e in events if e["type"] == "frame")["frame"]
+    assert frame["status"] == "answer", (
+        f"a run-request frame containing a playground must seal answer, got {frame['status']!r}"
+    )
+    assert len(_playgrounds(frame)) == 1, "the model's own playground must survive (not duplicated)"
+
+
+def test_run_request_budget_tail_constructs_playground_floor(tmp_path: Path):
+    """DeepSeek's dominant trace: the model explores to budget exhaustion without
+    a clean finish, the tail judges the grounded prose off_target. The floor must
+    fire at the budget tail too (not only at the clean-finish judge seal)."""
+    (tmp_path / "README.md").write_text("# analyzer\n", encoding="utf-8")
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_symbol_project(conn)
+
+    read = [
+        _tool_stop("r1", "read_file", {"path": "README.md"}),
+        _msg_stop("tool_use", [_content("r1", "read_file", {"path": "README.md"})]),
+    ]
+    # Emits a grounded block but never finishes -> stays tool_use -> budget tail.
+    emit_no_finish = [
+        _tool_stop("b1", "emit_block", {"kind": "lead", "text": "Describe el comportamiento, fundado en el archivo."}),
+        _msg_stop("tool_use", [_content("b1", "emit_block", {"kind": "lead", "text": "Describe el comportamiento, fundado en el archivo."})]),
+    ]
+    client = StubStream([read, emit_no_finish, emit_no_finish])
+    jv = JudgeVerdict("code_comprehension", True, False, True, "retry", None,
+                      "give a runnable example", "describes, does not run")
+    events = list(iter_compose_events(
+        client=client,
+        question="dame un ejemplo ejecutable de _module_from_relpath",
+        project_root=str(tmp_path), project_id=pid, conn=conn,
+        judge=lambda q, b, l: jv, max_tool_rounds=3,
+    ))
+    frame = next(e for e in events if e["type"] == "frame")["frame"]
+    assert frame["status"] == "answer", f"budget-tail off_target run-request must be floored, got {frame['status']!r}"
+    pg = _playgrounds(frame)
+    assert len(pg) == 1
+    assert pg[0]["widget"]["function_ref"]["name"] == "_module_from_relpath"
+
+
+def test_run_request_blank_fallback_constructs_playground_floor(tmp_path: Path):
+    """The known 'never a blank screen' gap: the model explores and emits nothing,
+    the budget exhausts to a fallback. For a run-request naming a resolvable
+    symbol, the floor turns the blank into the runnable artifact."""
+    (tmp_path / "README.md").write_text("# analyzer\n", encoding="utf-8")
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _seed_symbol_project(conn)
+
+    read = [
+        _tool_stop("r1", "read_file", {"path": "README.md"}),
+        _msg_stop("tool_use", [_content("r1", "read_file", {"path": "README.md"})]),
+    ]
+    client = StubStream([read, read, read])  # explores, never composes
+    events = list(iter_compose_events(
+        client=client,
+        question="dame un ejemplo ejecutable de _module_from_relpath",
+        project_root=str(tmp_path), project_id=pid, conn=conn,
+        max_tool_rounds=3,
+    ))
+    frame = next(e for e in events if e["type"] == "frame")["frame"]
+    assert frame["status"] == "answer", f"blank fallback run-request must be floored, got {frame['status']!r}"
+    pg = _playgrounds(frame)
+    assert len(pg) == 1, "the floor must turn a blank into a playground"
+    assert pg[0]["widget"]["function_ref"]["file"] == "src/copyclip/intelligence/analyzer.py"
+    # The 'couldn't finish' fallback message must NOT survive alongside the artifact.
+    leads = [b for b in frame["blocks"] if b.get("kind") == "paragraph"]
+    assert leads == [], "fallback message must be dropped when the floor delivers the artifact"


### PR DESCRIPTION
## What

A run-request (e.g. "dame un ejemplo ejecutable de `_module_from_relpath`") must answer with a playground widget, not prose. That gate (#140) was a SYSTEM_PROMPT plea the model honored only **~1 in 6** on DeepSeek — the rest sealed grounded prose flagged `off_target`, or exhausted the round budget to a blank `fallback`.

This makes the artifact **type** deterministic while leaving authorship to the model: a property the system guarantees is enforced **outside** the model.

## How

`_floored_frame`, applied at **every terminal seal site** (judge seal, budget-tail `_sealed_frame`, blank-fallback): for a run-request that would seal `off_target`/`fallback` with no playground, the system constructs one from a symbol **named in the question** that resolves against the `symbols` table.

- **Never invents.** Construction goes through `resolve_function_ref` (DB), not the structural emit-time check — no resolution → the honest `off_target` stands.
- **Disambiguation.** A name spanning multiple files resolves to the one the model actually read (the ledger); still ambiguous → declines.
- **Reclassify, don't relabel.** A frame already carrying a model-emitted playground seals `answer` — a run-request answered with the artifact is responsive by definition.

## Why this shape

The model-driven gate was a category error: a deterministic control point implemented as a probabilistic plea to the agent it claims to control. A roster council ruled it unanimously — *a capability is not a configuration; a guaranteed output property must be enforced outside the model.*

## Verification

- **TDD**, 5 new tests: construction, never-invent, budget-tail, blank-fallback, mislabel reclassification.
- **Full suite:** 664 passed, 3 skipped (the known `database is locked` analysis-thread flake).
- **End-to-end (DeepSeek + real DB):** ~1/6 → reliable playground.

## Deferred (intentional)

Full capability-axis formalization, typed re-shape retry, a distinct "right-content-wrong-form" terminal state, the `graph_view` twin (same `_is_visual_request` defect), and the `CLOSING_DIRECTIVE` run-requirement (the floor makes it unnecessary).

Refs #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run-requests now deterministically construct runnable playgrounds from resolved code symbols, improving responsiveness even when models are uncertain.

* **Documentation**
  * Updated Cuaderno description to clarify provider-agnostic operation (Anthropic, DeepSeek, OpenAI) and note enhanced reliability on Claude for structured artifacts.

* **Tests**
  * Added tests verifying playground floor construction for various run-request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->