### PR TITLE
feat(cuaderno): playground notebook says what it is — header, live call, source accordion

### DIFF
--- a/src/copyclip/intelligence/playground.py
+++ b/src/copyclip/intelligence/playground.py
@@ -353,6 +353,13 @@ def __():
 
 @app.cell
 def __(mo):
+    # Run mode hides code, so the notebook must SAY what it is.
+    mo.md({header_md!r})
+    return
+
+
+@app.cell
+def __(mo):
     # The input — change it and the result below re-runs.
     sample = {input_element}
     sample
@@ -360,11 +367,24 @@ def __(mo):
 
 
 @app.cell
-def __({exported_symbols}, sample):
+def __({exported_symbols}, mo, sample):
     value = sample.value
     result = {call_expr}
-    result
+    # The full invocation, live: flipping the input changes the call AND the result.
+    mo.md("`" + {call_prefix!r} + "(" + repr(value) + ")` → `" + repr(result) + "`")
     return (result,)
+
+
+@app.cell
+def __({exported_symbols}, mo):
+    # The source rides along, collapsed: the branch is visible while you cross it.
+    import inspect as _inspect
+    try:
+        _src = _inspect.getsource({exported_symbols})
+    except (OSError, TypeError):
+        _src = "# source unavailable"
+    mo.accordion({{{file_line!r}: mo.md("```python\\n" + _src + "\\n```")}})
+    return
 
 
 if __name__ == "__main__":
@@ -385,13 +405,19 @@ def generate_marimo_notebook(
     """
     td = temp_dir or tempfile.mkdtemp(prefix="copyclip-playground-")
     notebook_path = os.path.join(td, "playground.py")
-    imports_block, exported_symbols, call_expr = _build_symbol_resolution(resolved)
+    imports_block, exported_symbols, call_expr, call_prefix = _build_symbol_resolution(resolved)
     input_element = _build_input_element(req.suggested_inputs)
     # source is already validated against the PLAYGROUND_SOURCES whitelist, but
     # we sanitize both fields anyway as defense in depth — these end up inside
     # single-line ``#`` comments.
     safe_source = _sanitize_for_comment(req.source)
     safe_breadcrumb = _sanitize_for_comment(req.breadcrumb) or "<unspecified>"
+    # The visible header: every piece is injection-guarded upstream (qualname and
+    # file are identifier/path-validated by FunctionRef, source is whitelisted)
+    # and injected as a repr literal anyway. The breadcrumb deliberately stays a
+    # code comment — it is free text and must never reach a runnable line.
+    file_line = resolved.file + (f":{resolved.line_start}" if resolved.line_start else "")
+    header_md = f"### `{resolved.qualname}`\n\n`{file_line}` · {safe_source}"
     content = _NOTEBOOK_TEMPLATE.format(
         source=safe_source,
         breadcrumb=safe_breadcrumb,
@@ -400,13 +426,18 @@ def generate_marimo_notebook(
         exported_symbols=exported_symbols,
         input_element=input_element,
         call_expr=call_expr,
+        call_prefix=call_prefix,
+        header_md=header_md,
+        file_line=file_line,
     )
     Path(notebook_path).write_text(content, encoding="utf-8")
     return notebook_path
 
 
-def _build_symbol_resolution(resolved: ResolvedFunction) -> tuple[str, str, str]:
-    """Return (imports_block, exported_symbols, call_expr) per the spec's Symbol resolution rules.
+def _build_symbol_resolution(resolved: ResolvedFunction) -> tuple[str, str, str, str]:
+    """Return (imports_block, exported_symbols, call_expr, call_prefix) per the
+    spec's Symbol resolution rules. ``call_prefix`` is the display form of the
+    callable (the call_expr minus its ``(value)``), shown in the live result line.
 
     Staticmethod / classmethod detection is deferred; we default methods to the
     instance form ``Foo(...).method(sample)`` per the spec fallback.
@@ -418,13 +449,13 @@ def _build_symbol_resolution(resolved: ResolvedFunction) -> tuple[str, str, str]
     if parent and parent != name:
         imports = f"    from {mod} import {parent}"
         exported = parent
-        call_expr = f"{parent}(...).{name}(value)"
+        call_prefix = f"{parent}(...).{name}"
     else:
         imports = f"    from {mod} import {name}"
         exported = name
-        call_expr = f"{name}(value)"
+        call_prefix = name
 
-    return imports, exported, call_expr
+    return imports, exported, f"{call_prefix}(value)", call_prefix
 
 
 def _build_input_element(suggested_inputs: list[object] | None) -> str:

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -235,6 +235,79 @@ def test_generate_notebook_method_qualname(tmp_path):
     assert "Foo(...).method_name(value)" in content
 
 
+def test_generate_notebook_header_names_the_function(tmp_path):
+    """Run mode hides code, so the notebook must SAY what it is: a visible
+    markdown header with the function name and its file:line anchor — not a
+    dead code comment."""
+    req = PlaygroundLaunchRequest(
+        source="cuaderno",
+        function_ref=FunctionRef(file="src/copyclip/foo.py", name="bar"),
+        suggested_inputs=["src/copyclip/foo.py"],
+        breadcrumb="Ejecuta bar con un ejemplo",
+    )
+    nb = generate_marimo_notebook(req, str(tmp_path), _make_resolved(), temp_dir=str(tmp_path))
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    assert "### `bar`" in content
+    assert "src/copyclip/foo.py:10" in content
+    assert "cuaderno" in content
+
+
+def test_generate_notebook_displays_the_full_call(tmp_path):
+    """The result cell renders the complete invocation — `bar('x')` -> 'y' —
+    so flipping the input visibly changes the call, not just a bare repr."""
+    req = PlaygroundLaunchRequest(
+        source="cuaderno",
+        function_ref=FunctionRef(file="src/copyclip/foo.py", name="bar"),
+        suggested_inputs=["src/copyclip/foo.py"],
+        breadcrumb="test",
+    )
+    nb = generate_marimo_notebook(req, str(tmp_path), _make_resolved(), temp_dir=str(tmp_path))
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    assert "result = bar(value)" in content          # the call itself is unchanged
+    assert "repr(value)" in content and "repr(result)" in content
+    assert "'bar'" in content                        # the call prefix shown in the md line
+
+
+def test_generate_notebook_source_accordion(tmp_path):
+    """The function's source rides in a collapsed accordion labeled with its
+    file:line — the branch is VISIBLE while the input crosses it."""
+    req = PlaygroundLaunchRequest(
+        source="cuaderno",
+        function_ref=FunctionRef(file="src/copyclip/foo.py", name="bar"),
+        suggested_inputs=["src/copyclip/foo.py"],
+        breadcrumb="test",
+    )
+    nb = generate_marimo_notebook(req, str(tmp_path), _make_resolved(), temp_dir=str(tmp_path))
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    assert "mo.accordion" in content
+    assert "getsource(bar)" in content
+    assert "'src/copyclip/foo.py:10'" in content     # the accordion label
+
+
+def test_generate_notebook_method_call_display_uses_qualified_prefix(tmp_path):
+    req = PlaygroundLaunchRequest(
+        source="atlas",
+        function_ref=FunctionRef(
+            file="src/copyclip/foo.py", name="method_name", qualname="Foo.method_name"
+        ),
+        suggested_inputs=[1],
+        breadcrumb="test",
+    )
+    nb = generate_marimo_notebook(
+        req,
+        str(tmp_path),
+        _make_resolved(name="method_name", parent="Foo", kind="method"),
+        temp_dir=str(tmp_path),
+    )
+    content = Path(nb).read_text(encoding="utf-8")
+    ast.parse(content)
+    assert "'Foo(...).method_name'" in content       # call prefix in the md line
+    assert "getsource(Foo)" in content               # accordion shows the class source
+
+
 def test_generate_notebook_offers_all_inputs(tmp_path):
     """Multiple suggested inputs become a dropdown over ALL of them — the
     'try this / now try that' contrast, not just the first."""


### PR DESCRIPTION
## Qué cambia

El notebook del playground en modo `run` oculta el código, así que lo que se veía era un dropdown y un valor pelado — sin contexto de qué función era ni qué estaba pasando. Tres celdas nuevas en `_NOTEBOOK_TEMPLATE`:

1. **Header markdown**: nombre de la función (`### \`qualname\``), `file:line` y el breadcrumb del cuaderno.
2. **Llamada viva completa**: `` `func(input)` → `result` `` — al mover el input cambia la llamada Y el resultado, no solo el número.
3. **Acordeón de fuente colapsado**: `inspect.getsource` del símbolo, para que la rama sea visible mientras la cruzas.

`_build_symbol_resolution` ahora retorna también el `call_prefix` (maneja el caso método: `Foo(...).method_name`).

## Seguridad

El breadcrumb sigue siendo SOLO un comentario de código — nunca llega a una línea ejecutable ni renderizada. El header usa únicamente `qualname`/`file`/`source` inyectados con `!r`. Los tests de sanitización existentes siguen verdes.

## Tests

4 tests nuevos en `tests/test_playground.py` (header, llamada completa, acordeón, prefijo calificado para métodos). Suite playground completa: 63 passed.

Verificado en vivo: playground de `_module_from_relpath` en `http://127.0.0.1:62685/` — header, llamada y acordeón visibles; cruce del fork funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Marimo notebook generation with improved "live invocation" display showing complete function calls and results.
  * Added markdown headers with file location anchors to notebooks.
  * Improved method call display with qualified prefixes.

* **Tests**
  * Added comprehensive test coverage for notebook generation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->