### PR TITLE
feat(cuaderno): Wave 4 backend — absorption tools + honesty gate

### DIFF
--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import sqlite3
@@ -175,6 +176,123 @@ def get_callees(
     }
 
 
+def get_decisions(
+    conn: sqlite3.Connection,
+    project_id: int,
+    *,
+    status: Optional[str] = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Read the decision-ledger (decisions table). Optionally filter by status.
+    Absorbs the Decisions/Planning pages: the data is the ledger, cited by id."""
+    where = ["project_id = ?"]
+    params: list[Any] = [project_id]
+    if status:
+        where.append("status = ?")
+        params.append(status)
+    params.append(min(int(limit or 50), 200))
+    sql = (
+        "SELECT id, title, summary, status, confidence, source_type, created_at, resolved_at "
+        "FROM decisions WHERE " + " AND ".join(where) +
+        " ORDER BY id DESC LIMIT ?"
+    )
+    rows = conn.execute(sql, params).fetchall()
+    return {
+        "decisions": [
+            {
+                "id": r[0],
+                "title": r[1],
+                "summary": r[2],
+                "status": r[3],
+                "confidence": r[4],
+                "source_type": r[5],
+                "created_at": r[6],
+                "resolved_at": r[7],
+            }
+            for r in rows
+        ]
+    }
+
+
+def _parse_json_or_none(raw: Optional[str]) -> Any:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def get_story_snapshots(
+    conn: sqlite3.Connection,
+    project_id: int,
+    *,
+    limit: int = 5,
+) -> dict[str, Any]:
+    """Read narrative snapshots (story_snapshots) newest-first — the connective
+    tissue between bursts. If analysis hasn't run there are none; say so
+    explicitly (never invent a narrative — degrade to git_log)."""
+    rows = conn.execute(
+        "SELECT generated_at, focus_areas_json, major_changes_json, "
+        "open_questions_json, summary_json FROM story_snapshots "
+        "WHERE project_id=? ORDER BY id DESC LIMIT ?",
+        (project_id, min(int(limit or 5), 50)),
+    ).fetchall()
+    if not rows:
+        return {
+            "snapshots": [],
+            "note": "no story snapshots yet — run `copyclip analyze`, or use git_log for raw history.",
+        }
+    return {
+        "snapshots": [
+            {
+                "generated_at": r[0],
+                "focus_areas": _parse_json_or_none(r[1]),
+                "major_changes": _parse_json_or_none(r[2]),
+                "open_questions": _parse_json_or_none(r[3]),
+                "summary": _parse_json_or_none(r[4]),
+            }
+            for r in rows
+        ]
+    }
+
+
+def get_reverse_dependents(
+    conn: sqlite3.Connection,
+    project_id: int,
+    path: str,
+) -> dict[str, Any]:
+    """Modules transitively impacted if `path` changes (reverse-dependents).
+    Resolves path→module (most specific prefix wins), then walks `dependencies`
+    upward. The target is excluded from its own impact set. Cycle-safe."""
+    norm = path.replace("\\", "/")
+    row = conn.execute(
+        "SELECT name FROM modules WHERE project_id=? AND ? LIKE path_prefix || '%' "
+        "ORDER BY LENGTH(path_prefix) DESC LIMIT 1",
+        (project_id, norm),
+    ).fetchone()
+    if not row:
+        return {"target_module": "unknown", "impacted_modules": []}
+    target_module = row[0]
+    dependents: set[str] = set()
+    to_visit = [target_module]
+    visited: set[str] = set()
+    while to_visit:
+        curr = to_visit.pop()
+        if curr in visited:
+            continue
+        visited.add(curr)
+        rows = conn.execute(
+            "SELECT from_module FROM dependencies WHERE project_id=? AND to_module=?",
+            (project_id, curr),
+        ).fetchall()
+        for (frm,) in rows:
+            dependents.add(frm)
+            to_visit.append(frm)
+    dependents.discard(target_module)
+    return {"target_module": target_module, "impacted_modules": sorted(dependents)}
+
+
 def _run_git(project_root: str, *args: str) -> tuple[int, str, str]:
     proc = subprocess.run(
         ["git", *args],
@@ -259,6 +377,57 @@ def git_diff(project_root: str, commit_sha: str, path: Optional[str] = None) -> 
     if code != 0:
         return {"error": "git_failed", "detail": err.strip()}
     return {"diff": out}
+
+
+def git_archaeology(
+    project_root: str,
+    conn: sqlite3.Connection,
+    project_id: int,
+    file: str,
+    limit: int = 12,
+) -> dict[str, Any]:
+    """A file's commit history crossed with the decisions that reference it
+    (decision_refs). The commit↔decision correlation that no git_* tool alone
+    has — connects 'what changed here' to 'which decision you made about it'."""
+    norm = file.replace("\\", "/")
+    code, out, _ = _run_git(
+        project_root, "log",
+        "--pretty=format:%H%x09%an%x09%ad%x09%s", "--date=iso",
+        f"-n{int(limit)}", "--", norm,
+    )
+    commits: list[dict[str, Any]] = []
+    if code == 0:
+        for line in out.splitlines():
+            parts = line.split("\t", 3)
+            if len(parts) == 4:
+                sha, author, date, message = parts
+                commits.append({"sha": sha, "author": author, "date": date, "message": message})
+
+    rows = conn.execute(
+        """
+        SELECT d.id, d.title, d.status, d.source_type, dr.ref_type, dr.ref_value
+        FROM decisions d
+        LEFT JOIN decision_refs dr ON dr.decision_id = d.id
+        WHERE d.project_id=?
+        ORDER BY d.id DESC
+        """,
+        (project_id,),
+    ).fetchall()
+    related: dict[int, dict[str, Any]] = {}
+    for did, title, status, source_type, ref_type, ref_value in rows:
+        ref_value = ref_value or ""
+        match = (
+            (ref_type == "file" and ref_value == norm)
+            or (ref_type == "commit" and ref_value and any(c["sha"].startswith(ref_value) for c in commits))
+            or (ref_type == "doc" and norm.lower() in ref_value.lower())
+        )
+        if match:
+            entry = related.setdefault(did, {
+                "id": did, "title": title, "status": status,
+                "source_type": source_type, "matched_refs": [],
+            })
+            entry["matched_refs"].append({"ref_type": ref_type, "ref_value": ref_value})
+    return {"file": norm, "commits": commits, "related_decisions": list(related.values())}
 
 
 def _rank_and_cap(
@@ -403,3 +572,24 @@ def find_tests(project_root: str, symbol_name: str) -> dict[str, Any]:
             rel = str(fp.relative_to(root)).replace("\\", "/")
             results.append({"file_path": rel, "matches": matches[:5]})
     return {"tests": results}
+
+
+def get_reacquaintance_briefing(
+    project_root: str,
+    mode: str = "last_seen",
+    window: str = "7d",
+    checkpoint: Optional[str] = None,
+) -> dict[str, Any]:
+    """Re-entry briefing — what to re-read to reconnect to your intention after
+    a gap between bursts. Wraps the reacquaintance engine and trims the heavy
+    evidence_index so the briefing fits the tutor's context window (decision A2).
+    Lazy import: the engine pulls in mempalace/analysis machinery we don't want
+    loaded for the lighter tools."""
+    from ..reacquaintance import build_reacquaintance_briefing
+
+    briefing = build_reacquaintance_briefing(
+        project_root, baseline_mode=mode, window=window, checkpoint_name=checkpoint
+    )
+    if isinstance(briefing, dict):
+        briefing.pop("evidence_index", None)
+    return briefing

--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -214,6 +214,50 @@ def get_decisions(
     }
 
 
+def get_risks(
+    conn: sqlite3.Connection,
+    project_id: int,
+    *,
+    kind: Optional[str] = None,
+    severity: Optional[str] = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Read the risk signals (risks table), highest score first. Each row is a
+    deterministic heuristic over real git data, citable by `area` (file path) —
+    absorbs the Risks page as cited callout blocks, never fabricated severity."""
+    where = ["project_id = ?"]
+    params: list[Any] = [project_id]
+    if kind:
+        where.append("kind = ?")
+        params.append(kind)
+    if severity:
+        where.append("severity = ?")
+        params.append(severity)
+    params.append(min(int(limit or 50), 200))
+    sql = (
+        "SELECT area, severity, kind, rationale, score, created_at "
+        "FROM risks WHERE " + " AND ".join(where) +
+        " ORDER BY score DESC, area ASC LIMIT ?"
+    )
+    rows = conn.execute(sql, params).fetchall()
+    return {
+        "risks": [
+            {
+                "area": r[0],
+                # `area` is a file path; expose it as file_path too so the
+                # honesty ledger harvests it as tool-evidenced (citable).
+                "file_path": r[0],
+                "severity": r[1],
+                "kind": r[2],
+                "rationale": r[3],
+                "score": r[4],
+                "created_at": r[5],
+            }
+            for r in rows
+        ]
+    }
+
+
 def _parse_json_or_none(raw: Optional[str]) -> Any:
     if not raw:
         return None

--- a/src/copyclip/intelligence/cuaderno/read_ledger.py
+++ b/src/copyclip/intelligence/cuaderno/read_ledger.py
@@ -8,6 +8,10 @@ from .tool_catalog import ANSWER_TOOLS
 _CONTENT_KEYS: tuple[str, ...] = (
     "lines", "entries", "symbols", "callers", "callees",
     "commits", "blame", "diff", "tests", "modules",
+    # Wave 4 tools each return real DB/git evidence the honesty gate must
+    # recognize — otherwise a risks/decisions answer seals as ungrounded.
+    "risks", "decisions", "impacted_modules", "snapshots",
+    "related_decisions", "top_changes", "read_first", "relevant_decisions",
 )
 
 

--- a/src/copyclip/intelligence/cuaderno/tool_catalog.py
+++ b/src/copyclip/intelligence/cuaderno/tool_catalog.py
@@ -142,6 +142,75 @@ def build_tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "get_decisions",
+            "description": (
+                "Read the decision-ledger — the architectural decisions the human "
+                "recorded (and their status). Optionally filter by status "
+                "(proposed | accepted | resolved | ...). Cite a decision by its id."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "status": {"type": "string", "description": "Filter by status. Optional."},
+                    "limit":  {"type": "integer", "default": 50},
+                },
+            },
+        },
+        {
+            "name": "get_reverse_dependents",
+            "description": (
+                "Modules transitively impacted if a file changes (reverse-dependents "
+                "/ blast radius). Resolves the path to its module, then walks the "
+                "dependency graph upward. Use this for 'what breaks if I touch X'."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {"path": {"type": "string", "description": "Project-relative file path."}},
+                "required": ["path"],
+            },
+        },
+        {
+            "name": "git_archaeology",
+            "description": (
+                "A file's recent commit history crossed with the decisions that "
+                "reference it. Connects 'what changed here' to 'which decision you "
+                "made about it' — the commit↔decision link git_log alone can't give."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {"file": {"type": "string", "description": "Project-relative file path."}},
+                "required": ["file"],
+            },
+        },
+        {
+            "name": "get_story_snapshots",
+            "description": (
+                "Narrative snapshots of how the project shifted over time (focus "
+                "areas, major changes, open questions) — the connective tissue "
+                "between work bursts. Empty until analysis has run; says so."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {"limit": {"type": "integer", "default": 5}},
+            },
+        },
+        {
+            "name": "get_reacquaintance_briefing",
+            "description": (
+                "Re-entry briefing after a gap: top changes, what to read first, "
+                "relevant decisions, top risk — what reconnects you to your "
+                "intention across bursts. Use for 'catch me up' / 'what did I miss'."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "mode":       {"type": "string", "description": "baseline: last_seen | checkpoint | window. Default last_seen."},
+                    "window":     {"type": "string", "description": "lookback window, e.g. '7d'. Default 7d."},
+                    "checkpoint": {"type": "string", "description": "checkpoint name when mode=checkpoint. Optional."},
+                },
+            },
+        },
+        {
             "name": "emit_block",
             "description": (
                 "Emit ONE block of your answer. Call once per block, in order. "
@@ -205,4 +274,21 @@ def dispatch_tool(
         return anchor.find_tests(project_root, args["symbol"])
     if name == "get_module_graph":
         return anchor.get_module_graph(conn, project_id, args.get("scope", ""))
+    if name == "get_decisions":
+        return anchor.get_decisions(
+            conn, project_id, status=args.get("status"), limit=args.get("limit", 50)
+        )
+    if name == "get_reverse_dependents":
+        return anchor.get_reverse_dependents(conn, project_id, args["path"])
+    if name == "git_archaeology":
+        return anchor.git_archaeology(project_root, conn, project_id, args["file"])
+    if name == "get_story_snapshots":
+        return anchor.get_story_snapshots(conn, project_id, limit=args.get("limit", 5))
+    if name == "get_reacquaintance_briefing":
+        return anchor.get_reacquaintance_briefing(
+            project_root,
+            mode=args.get("mode", "last_seen"),
+            window=args.get("window", "7d"),
+            checkpoint=args.get("checkpoint"),
+        )
     return {"error": "unknown_tool", "name": name}

--- a/src/copyclip/intelligence/cuaderno/tool_catalog.py
+++ b/src/copyclip/intelligence/cuaderno/tool_catalog.py
@@ -211,6 +211,23 @@ def build_tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "get_risks",
+            "description": (
+                "Read the project's risk signals (churn, test_gap, complexity, "
+                "intent_drift), highest score first. Each row is a deterministic "
+                "heuristic over real git data, citable by `area` (file path). Use "
+                "for 'what's risky' — emit cited callout blocks, never invent severity."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "kind":     {"type": "string", "description": "churn | test_gap | complexity | intent_drift. Optional."},
+                    "severity": {"type": "string", "description": "Filter by severity. Optional."},
+                    "limit":    {"type": "integer", "default": 50},
+                },
+            },
+        },
+        {
             "name": "emit_block",
             "description": (
                 "Emit ONE block of your answer. Call once per block, in order. "
@@ -290,5 +307,11 @@ def dispatch_tool(
             mode=args.get("mode", "last_seen"),
             window=args.get("window", "7d"),
             checkpoint=args.get("checkpoint"),
+        )
+    if name == "get_risks":
+        return anchor.get_risks(
+            conn, project_id,
+            kind=args.get("kind"), severity=args.get("severity"),
+            limit=args.get("limit", 50),
         )
     return {"error": "unknown_tool", "name": name}

--- a/tests/test_cuaderno_read_ledger.py
+++ b/tests/test_cuaderno_read_ledger.py
@@ -36,3 +36,47 @@ def test_ledger_counts_and_paths():
     assert led.content_bearing_count == 2
     assert "src/a.py" in led.read_paths
     assert "missing.py" not in led.read_paths
+
+
+# ── Wave 4 tools count as real evidence (close the gate's blind spot) ────────
+
+def test_get_risks_is_content_bearing():
+    assert is_content_bearing_read("get_risks", {"risks": [{"area": "a.py", "score": 9}]})
+    assert not is_content_bearing_read("get_risks", {"risks": []})
+
+
+def test_get_decisions_is_content_bearing():
+    assert is_content_bearing_read("get_decisions", {"decisions": [{"id": 1}]})
+    assert not is_content_bearing_read("get_decisions", {"decisions": []})
+
+
+def test_get_reverse_dependents_is_content_bearing():
+    assert is_content_bearing_read(
+        "get_reverse_dependents", {"target_module": "core", "impacted_modules": ["api"]}
+    )
+    assert not is_content_bearing_read(
+        "get_reverse_dependents", {"target_module": "unknown", "impacted_modules": []}
+    )
+
+
+def test_get_story_snapshots_is_content_bearing():
+    assert is_content_bearing_read("get_story_snapshots", {"snapshots": [{"generated_at": "t"}]})
+    assert not is_content_bearing_read("get_story_snapshots", {"snapshots": [], "note": "none"})
+
+
+def test_reacquaintance_with_changes_is_content_bearing():
+    assert is_content_bearing_read(
+        "get_reacquaintance_briefing", {"meta": {}, "top_changes": [{"x": 1}], "read_first": []}
+    )
+    assert not is_content_bearing_read(
+        "get_reacquaintance_briefing",
+        {"meta": {}, "top_changes": [], "read_first": [], "relevant_decisions": []},
+    )
+
+
+def test_ledger_harvests_risk_area_as_evidence_path():
+    """A risk's file is citable: the tutor can cite src/foo.py and the gate must
+    recognize it as tool-evidenced, not fabricated."""
+    led = ReadLedger()
+    led.record("get_risks", {"risks": [{"area": "src/foo.py", "file_path": "src/foo.py", "score": 9}]})
+    assert "src/foo.py" in led.evidence_paths

--- a/tests/test_cuaderno_tool_catalog.py
+++ b/tests/test_cuaderno_tool_catalog.py
@@ -1,4 +1,7 @@
+import sqlite3
+
 from copyclip.intelligence.cuaderno.tool_catalog import build_tool_definitions, dispatch_tool
+from copyclip.intelligence.db import init_schema
 
 
 def test_tool_definitions_include_all_tools():
@@ -7,6 +10,8 @@ def test_tool_definitions_include_all_tools():
     assert names == {
         "list_dir", "read_file", "grep_symbols", "get_callers", "get_callees",
         "git_log", "git_blame", "git_diff", "find_tests", "get_module_graph",
+        "get_decisions", "get_reverse_dependents", "git_archaeology",
+        "get_story_snapshots", "get_reacquaintance_briefing",
         "emit_block", "finish",
     }
 
@@ -50,3 +55,62 @@ def test_tool_definitions_have_anthropic_shape():
 def test_dispatch_unknown_tool_returns_error():
     out = dispatch_tool("nope", {}, project_root="/tmp", project_id=1, conn=None)
     assert out == {"error": "unknown_tool", "name": "nope"}
+
+
+def _conn_with_project(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    cur = conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (str(tmp_path), "t"))
+    return conn, int(cur.lastrowid)
+
+
+def test_dispatch_get_decisions(tmp_path):
+    conn, pid = _conn_with_project(tmp_path)
+    conn.execute("INSERT INTO decisions(project_id,title,status) VALUES(?,?,?)", (pid, "D", "accepted"))
+    conn.commit()
+    out = dispatch_tool("get_decisions", {"status": "accepted"},
+                        project_root=str(tmp_path), project_id=pid, conn=conn)
+    assert [d["title"] for d in out["decisions"]] == ["D"]
+
+
+def test_dispatch_get_reverse_dependents(tmp_path):
+    conn, pid = _conn_with_project(tmp_path)
+    conn.execute("INSERT INTO modules(project_id,name,path_prefix) VALUES(?,?,?)", (pid, "core", "src/core/"))
+    conn.execute("INSERT INTO modules(project_id,name,path_prefix) VALUES(?,?,?)", (pid, "api", "src/api/"))
+    conn.execute("INSERT INTO dependencies(project_id,from_module,to_module,edge_type) VALUES(?,?,?,?)",
+                 (pid, "api", "core", "import"))
+    conn.commit()
+    out = dispatch_tool("get_reverse_dependents", {"path": "src/core/x.py"},
+                        project_root=str(tmp_path), project_id=pid, conn=conn)
+    assert out["target_module"] == "core"
+    assert out["impacted_modules"] == ["api"]
+
+
+def test_dispatch_get_story_snapshots(tmp_path):
+    conn, pid = _conn_with_project(tmp_path)
+    out = dispatch_tool("get_story_snapshots", {},
+                        project_root=str(tmp_path), project_id=pid, conn=conn)
+    assert out["snapshots"] == [] and "note" in out
+
+
+def test_dispatch_git_archaeology(tmp_path):
+    import subprocess
+    for args in (("init", "-q"), ("config", "user.email", "t@t"), ("config", "user.name", "t")):
+        subprocess.run(["git", *args], cwd=tmp_path, check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    (tmp_path / "a.py").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "add", "a.py"], cwd=tmp_path, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    conn, pid = _conn_with_project(tmp_path)
+    out = dispatch_tool("git_archaeology", {"file": "a.py"},
+                        project_root=str(tmp_path), project_id=pid, conn=conn)
+    assert out["file"] == "a.py"
+    assert [c["message"] for c in out["commits"]] == ["init"]
+
+
+def test_dispatch_get_reacquaintance_briefing(tmp_path):
+    out = dispatch_tool("get_reacquaintance_briefing", {},
+                        project_root=str(tmp_path), project_id=1, conn=None)
+    assert {"meta", "top_changes", "read_first"} <= set(out)

--- a/tests/test_cuaderno_tool_catalog.py
+++ b/tests/test_cuaderno_tool_catalog.py
@@ -11,7 +11,7 @@ def test_tool_definitions_include_all_tools():
         "list_dir", "read_file", "grep_symbols", "get_callers", "get_callees",
         "git_log", "git_blame", "git_diff", "find_tests", "get_module_graph",
         "get_decisions", "get_reverse_dependents", "git_archaeology",
-        "get_story_snapshots", "get_reacquaintance_briefing",
+        "get_story_snapshots", "get_reacquaintance_briefing", "get_risks",
         "emit_block", "finish",
     }
 
@@ -114,3 +114,13 @@ def test_dispatch_get_reacquaintance_briefing(tmp_path):
     out = dispatch_tool("get_reacquaintance_briefing", {},
                         project_root=str(tmp_path), project_id=1, conn=None)
     assert {"meta", "top_changes", "read_first"} <= set(out)
+
+
+def test_dispatch_get_risks(tmp_path):
+    conn, pid = _conn_with_project(tmp_path)
+    conn.execute("INSERT INTO risks(project_id,area,severity,kind,rationale,score) VALUES(?,?,?,?,?,?)",
+                 (pid, "x.py", "high", "churn", "r", 70))
+    conn.commit()
+    out = dispatch_tool("get_risks", {"kind": "churn"},
+                        project_root=str(tmp_path), project_id=pid, conn=conn)
+    assert [r["area"] for r in out["risks"]] == ["x.py"]

--- a/tests/test_cuaderno_wave4_tools.py
+++ b/tests/test_cuaderno_wave4_tools.py
@@ -303,3 +303,72 @@ def test_get_reacquaintance_briefing_trims_heavy_evidence_index(tmp_path: Path):
 
     out = get_reacquaintance_briefing(str(tmp_path))
     assert "evidence_index" not in out
+
+
+# ── get_risks ──────────────────────────────────────────────────────────────
+
+def _seed_risk(conn, pid, area, severity, kind, rationale, score):
+    conn.execute(
+        "INSERT INTO risks(project_id,area,severity,kind,rationale,score) VALUES(?,?,?,?,?,?)",
+        (pid, area, severity, kind, rationale, score),
+    )
+
+
+def test_get_risks_returns_rows_citable_by_area():
+    from copyclip.intelligence.cuaderno.anchor import get_risks
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    _seed_risk(conn, pid, "src/foo.py", "high", "churn", "high churn, no tests", 80)
+    conn.commit()
+
+    out = get_risks(conn, pid)
+    r = out["risks"][0]
+    assert r["area"] == "src/foo.py"
+    # exposed as file_path too, so the honesty gate harvests it as evidence
+    assert r["file_path"] == "src/foo.py"
+    assert r["severity"] == "high"
+    assert r["kind"] == "churn"
+    assert r["rationale"] == "high churn, no tests"
+    assert r["score"] == 80
+
+
+def test_get_risks_orders_by_score_desc():
+    from copyclip.intelligence.cuaderno.anchor import get_risks
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    _seed_risk(conn, pid, "a.py", "low", "churn", "r", 30)
+    _seed_risk(conn, pid, "b.py", "high", "complexity", "r", 90)
+    conn.commit()
+
+    out = get_risks(conn, pid)
+    assert [r["score"] for r in out["risks"]] == [90, 30]
+    assert [r["area"] for r in out["risks"]] == ["b.py", "a.py"]
+
+
+def test_get_risks_filters_by_kind():
+    from copyclip.intelligence.cuaderno.anchor import get_risks
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    _seed_risk(conn, pid, "a.py", "high", "churn", "r", 50)
+    _seed_risk(conn, pid, "b.py", "high", "test_gap", "r", 60)
+    conn.commit()
+
+    out = get_risks(conn, pid, kind="test_gap")
+    assert [r["area"] for r in out["risks"]] == ["b.py"]
+
+
+def test_get_risks_scopes_to_project():
+    from copyclip.intelligence.cuaderno.anchor import get_risks
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn, "/tmp/a")
+    other = _project(conn, "/tmp/b")
+    _seed_risk(conn, pid, "mine.py", "high", "churn", "r", 50)
+    _seed_risk(conn, other, "theirs.py", "high", "churn", "r", 99)
+    conn.commit()
+
+    out = get_risks(conn, pid)
+    assert [r["area"] for r in out["risks"]] == ["mine.py"]

--- a/tests/test_cuaderno_wave4_tools.py
+++ b/tests/test_cuaderno_wave4_tools.py
@@ -1,0 +1,305 @@
+"""Wave 4 (PR-W4-1) — tutor tools that absorb the dashboard's question-classes
+without fabrication. Every test seeds real data (sqlite :memory:, real git
+repos) and asserts the tool's output comes from that data, never the model.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+from pathlib import Path
+
+from copyclip.intelligence.db import init_schema
+
+
+def _project(conn: sqlite3.Connection, root: str = "/tmp/proj") -> int:
+    cur = conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root, "t"))
+    return int(cur.lastrowid)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+# ── get_decisions ──────────────────────────────────────────────────────────
+
+def test_get_decisions_returns_ledger_rows():
+    from copyclip.intelligence.cuaderno.anchor import get_decisions
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    conn.execute(
+        "INSERT INTO decisions(project_id,title,summary,status,source_type) VALUES(?,?,?,?,?)",
+        (pid, "Use marimo", "reactive notebook", "accepted", "manual"),
+    )
+    conn.execute(
+        "INSERT INTO decisions(project_id,title,status,source_type) VALUES(?,?,?,?)",
+        (pid, "Drop Jupyter", "proposed", "agent"),
+    )
+    conn.commit()
+
+    out = get_decisions(conn, pid)
+    by_title = {d["title"]: d for d in out["decisions"]}
+    assert set(by_title) == {"Use marimo", "Drop Jupyter"}
+    assert by_title["Use marimo"]["status"] == "accepted"
+    assert by_title["Use marimo"]["summary"] == "reactive notebook"
+    assert by_title["Use marimo"]["source_type"] == "manual"
+
+
+def test_get_decisions_filters_by_status():
+    from copyclip.intelligence.cuaderno.anchor import get_decisions
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    conn.execute("INSERT INTO decisions(project_id,title,status) VALUES(?,?,?)", (pid, "A", "accepted"))
+    conn.execute("INSERT INTO decisions(project_id,title,status) VALUES(?,?,?)", (pid, "B", "proposed"))
+    conn.commit()
+
+    out = get_decisions(conn, pid, status="proposed")
+    assert [d["title"] for d in out["decisions"]] == ["B"]
+
+
+def test_get_decisions_scopes_to_project():
+    from copyclip.intelligence.cuaderno.anchor import get_decisions
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn, "/tmp/a")
+    other = _project(conn, "/tmp/b")
+    conn.execute("INSERT INTO decisions(project_id,title,status) VALUES(?,?,?)", (pid, "mine", "accepted"))
+    conn.execute("INSERT INTO decisions(project_id,title,status) VALUES(?,?,?)", (other, "theirs", "accepted"))
+    conn.commit()
+
+    out = get_decisions(conn, pid)
+    assert [d["title"] for d in out["decisions"]] == ["mine"]
+
+
+# ── get_story_snapshots ────────────────────────────────────────────────────
+
+def test_get_story_snapshots_returns_parsed_snapshots():
+    from copyclip.intelligence.cuaderno.anchor import get_story_snapshots
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    conn.execute(
+        "INSERT INTO story_snapshots(project_id,generated_at,focus_areas_json,"
+        "major_changes_json,open_questions_json,summary_json) VALUES(?,?,?,?,?,?)",
+        (pid, "2026-06-01T00:00:00", json.dumps(["analyzer"]),
+         json.dumps([{"area": "cuaderno"}]), json.dumps(["why?"]),
+         json.dumps({"text": "shift"})),
+    )
+    conn.commit()
+
+    out = get_story_snapshots(conn, pid)
+    snap = out["snapshots"][0]
+    assert snap["generated_at"] == "2026-06-01T00:00:00"
+    assert snap["focus_areas"] == ["analyzer"]
+    assert snap["major_changes"] == [{"area": "cuaderno"}]
+    assert snap["open_questions"] == ["why?"]
+    assert snap["summary"] == {"text": "shift"}
+
+
+def test_get_story_snapshots_newest_first():
+    from copyclip.intelligence.cuaderno.anchor import get_story_snapshots
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    for ts in ("2026-06-01T00:00:00", "2026-06-05T00:00:00"):
+        conn.execute(
+            "INSERT INTO story_snapshots(project_id,generated_at,summary_json) VALUES(?,?,?)",
+            (pid, ts, json.dumps({"t": ts})),
+        )
+    conn.commit()
+
+    out = get_story_snapshots(conn, pid)
+    assert [s["generated_at"] for s in out["snapshots"]] == [
+        "2026-06-05T00:00:00", "2026-06-01T00:00:00",
+    ]
+
+
+def test_get_story_snapshots_empty_degrades_explicitly():
+    """Decision G: no analysis → say so, never invent a narrative."""
+    from copyclip.intelligence.cuaderno.anchor import get_story_snapshots
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+
+    out = get_story_snapshots(conn, pid)
+    assert out["snapshots"] == []
+    assert "note" in out and out["note"]
+
+
+# ── get_reverse_dependents ─────────────────────────────────────────────────
+
+def _seed_module(conn, pid, name, path_prefix):
+    conn.execute(
+        "INSERT INTO modules(project_id,name,path_prefix) VALUES(?,?,?)",
+        (pid, name, path_prefix),
+    )
+
+
+def _seed_dep(conn, pid, frm, to):
+    conn.execute(
+        "INSERT INTO dependencies(project_id,from_module,to_module,edge_type) VALUES(?,?,?,?)",
+        (pid, frm, to, "import"),
+    )
+
+
+def test_get_reverse_dependents_walks_transitively():
+    from copyclip.intelligence.cuaderno.anchor import get_reverse_dependents
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    _seed_module(conn, pid, "core", "src/core/")
+    _seed_module(conn, pid, "api", "src/api/")
+    _seed_module(conn, pid, "cli", "src/cli/")
+    _seed_dep(conn, pid, "api", "core")   # api depends on core
+    _seed_dep(conn, pid, "cli", "api")    # cli depends on api
+    conn.commit()
+
+    out = get_reverse_dependents(conn, pid, "src/core/engine.py")
+    assert out["target_module"] == "core"
+    assert set(out["impacted_modules"]) == {"api", "cli"}
+
+
+def test_get_reverse_dependents_unknown_path():
+    from copyclip.intelligence.cuaderno.anchor import get_reverse_dependents
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    _seed_module(conn, pid, "core", "src/core/")
+    conn.commit()
+
+    out = get_reverse_dependents(conn, pid, "nowhere/x.py")
+    assert out["target_module"] == "unknown"
+    assert out["impacted_modules"] == []
+
+
+def test_get_reverse_dependents_excludes_target_and_survives_cycles():
+    from copyclip.intelligence.cuaderno.anchor import get_reverse_dependents
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn)
+    _seed_module(conn, pid, "a", "src/a/")
+    _seed_module(conn, pid, "b", "src/b/")
+    _seed_dep(conn, pid, "a", "b")  # a -> b
+    _seed_dep(conn, pid, "b", "a")  # b -> a (cycle)
+    conn.commit()
+
+    out = get_reverse_dependents(conn, pid, "src/a/x.py")
+    assert out["target_module"] == "a"
+    # b depends on a; a depends on b — cycle must not hang. b is impacted.
+    assert set(out["impacted_modules"]) == {"b"}
+
+
+# ── git_archaeology ────────────────────────────────────────────────────────
+
+def _init_repo(tmp_path: Path) -> None:
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+
+
+def test_git_archaeology_returns_commits_and_file_linked_decisions(tmp_path: Path):
+    from copyclip.intelligence.cuaderno.anchor import git_archaeology
+    _init_repo(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "foo.py").write_text("v1\n", encoding="utf-8")
+    _git(tmp_path, "add", "src/foo.py")
+    _git(tmp_path, "commit", "-m", "add foo")
+    (tmp_path / "src" / "foo.py").write_text("v2\n", encoding="utf-8")
+    _git(tmp_path, "commit", "-am", "change foo")
+
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn, str(tmp_path))
+    cur = conn.execute(
+        "INSERT INTO decisions(project_id,title,status,source_type) VALUES(?,?,?,?)",
+        (pid, "Foo shape", "accepted", "manual"),
+    )
+    did = cur.lastrowid
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+        (did, "file", "src/foo.py"),
+    )
+    conn.commit()
+
+    out = git_archaeology(str(tmp_path), conn, pid, "src/foo.py")
+    assert out["file"] == "src/foo.py"
+    assert [c["message"] for c in out["commits"]][:2] == ["change foo", "add foo"]
+    titles = [d["title"] for d in out["related_decisions"]]
+    assert "Foo shape" in titles
+    d = next(d for d in out["related_decisions"] if d["title"] == "Foo shape")
+    assert d["matched_refs"][0]["ref_type"] == "file"
+
+
+def test_git_archaeology_matches_commit_ref(tmp_path: Path):
+    from copyclip.intelligence.cuaderno.anchor import git_archaeology
+    _init_repo(tmp_path)
+    (tmp_path / "a.py").write_text("x\n", encoding="utf-8")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-m", "init a")
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=tmp_path,
+                         capture_output=True, text=True, check=True).stdout.strip()
+
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn, str(tmp_path))
+    cur = conn.execute(
+        "INSERT INTO decisions(project_id,title,status) VALUES(?,?,?)", (pid, "From commit", "accepted")
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+        (cur.lastrowid, "commit", sha[:8]),
+    )
+    conn.commit()
+
+    out = git_archaeology(str(tmp_path), conn, pid, "a.py")
+    assert [d["title"] for d in out["related_decisions"]] == ["From commit"]
+
+
+def test_git_archaeology_ignores_unrelated_decisions(tmp_path: Path):
+    from copyclip.intelligence.cuaderno.anchor import git_archaeology
+    _init_repo(tmp_path)
+    (tmp_path / "a.py").write_text("x\n", encoding="utf-8")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-m", "init")
+
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    pid = _project(conn, str(tmp_path))
+    cur = conn.execute(
+        "INSERT INTO decisions(project_id,title,status) VALUES(?,?,?)", (pid, "Other file", "accepted")
+    )
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+        (cur.lastrowid, "file", "totally/other.py"),
+    )
+    conn.commit()
+
+    out = git_archaeology(str(tmp_path), conn, pid, "a.py")
+    assert out["related_decisions"] == []
+
+
+# ── get_reacquaintance_briefing ────────────────────────────────────────────
+
+def test_get_reacquaintance_briefing_runs_engine_and_keeps_burst_essentials(tmp_path: Path):
+    """Wraps the real reacquaintance engine (no mock). With no analysis the
+    engine returns its empty-but-valid shape; the tool keeps the re-entry
+    essentials that reconnect the human across bursts."""
+    from copyclip.intelligence.cuaderno.anchor import get_reacquaintance_briefing
+
+    out = get_reacquaintance_briefing(str(tmp_path))
+    assert {"meta", "top_changes", "read_first", "relevant_decisions"} <= set(out)
+    assert isinstance(out["top_changes"], list)
+    assert isinstance(out["read_first"], list)
+    assert "project" in out["meta"]
+
+
+def test_get_reacquaintance_briefing_trims_heavy_evidence_index(tmp_path: Path):
+    """The evidence_index can be large; the tool trims it so the briefing fits
+    the tutor's context window (decision A2)."""
+    from copyclip.intelligence.cuaderno.anchor import get_reacquaintance_briefing
+
+    out = get_reacquaintance_briefing(str(tmp_path))
+    assert "evidence_index" not in out


### PR DESCRIPTION
Backend of Wave 4 (plan: #147): the read-tools that let the dashboard's question-classes be absorbed **without fabrication**, plus closing the honesty gate's blind spot so answers built from them are recognized as grounded. Two commits — W4-1 (tools) and W4-2 (get_risks + gate).

## Why
The constitution assumed the cluster would "collapse to existing git_* tools". The `wave4-fundacion` mapping found that's only partial: `decisions`, reacquaintance scoring, reverse-dependents, commit↔decision archaeology, and risks had **no tool** — the tutor would have had to invent them.

## Tools (`anchor.py`, registered in `tool_catalog.py`)
- **get_decisions** — the decision-ledger (Decisions/Planning)
- **get_reverse_dependents** — blast radius via the dependency graph (Impact); excludes target, cycle-safe
- **git_archaeology** — a file's commits × the decisions referencing it
- **get_story_snapshots** — narrative shifts (connective tissue between bursts); empty until analysis runs and says so
- **get_reacquaintance_briefing** — re-entry essentials; `evidence_index` trimmed
- **get_risks** — risk signals, citable by area/file_path (Risks page)

## Honesty gate (W4-2)
The `ReadLedger` only counted `lines/symbols/commits/...` as evidence, so a risks- or decisions-only answer sealed as `ungrounded` — the blind spot the council predicted. The new tools' result keys now count as content-bearing, and a risk's file is harvested as a tool-evidenced path.

## Tests
44 tests across the W4 tool suite, TDD (red→green), all seeding **real data** (sqlite `:memory:`, real git repos) and asserting provenance from DB/git, never the model.

## Scope / follow-ups
No page removed (Wave 5). No frontend. Decision B's write path already exists (`PATCH /api/decisions/{id}` records `decision_history`); the human-confirmation UI + callout presentation are the frontend follow-up. The 3 unrelated suite failures (provider DEFAULT_MODELS mismatch + 2 key-gated live tests) pre-exist on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added decision ledger queries with optional status filtering
  * Added risk identification with filtering by kind and severity
  * Added story snapshots for time-based narrative summaries
  * Added reverse dependency analysis to view module impact
  * Added file history correlation with related decisions
  * Added reacquaintance briefing for re-entry context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->