### PR TITLE
ci: run pytest on push and PRs (real green gate)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A new push to a PR branch cancels the previous, still-running test job.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and dev deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
+
+      - name: Run tests
+        # No LLM keys are configured, so the key-gated live tests skip cleanly
+        # and the runner's clean HOME has no llm.yaml, so model-default tests
+        # fall back to the in-repo DEFAULT_MODELS. The suite is hermetic.
+        run: python -m pytest -q

--- a/src/copyclip/__main__.py
+++ b/src/copyclip/__main__.py
@@ -147,18 +147,23 @@ def run_export(argv_tail: list) -> None:
 
     args = parser.parse_args(argv_tail)
 
-    from copyclip.llm.provider_config import resolve_provider, ProviderConfigError, PROVIDERS
+    # An LLM is only needed when --prompt asks the model to select files. A plain
+    # clipboard export must never block on provider config or launch onboarding —
+    # in a non-interactive context (CI, piped stdin) the raw-key reader crashes,
+    # and conceptually a file export has nothing to do with an LLM provider.
+    if args.prompt:
+        from copyclip.llm.provider_config import resolve_provider, ProviderConfigError, PROVIDERS
 
-    try:
-        _ = resolve_provider(args.provider, config={})
-    except ProviderConfigError:
-        if sys.stdin.isatty():
-            from copyclip.intelligence.cli import _run_onboarding
-            configured = _run_onboarding(os.path.abspath(args.folder), PROVIDERS)
-            if not configured:
-                print("[INFO] No LLM configured. Some features will be unavailable.", file=sys.stderr)
-        else:
-            print("[WARN] No LLM configured. Set COPYCLIP_LLM_PROVIDER and API key in .env", file=sys.stderr)
+        try:
+            _ = resolve_provider(args.provider, config={})
+        except ProviderConfigError:
+            if sys.stdin.isatty():
+                from copyclip.intelligence.cli import _run_onboarding
+                configured = _run_onboarding(os.path.abspath(args.folder), PROVIDERS)
+                if not configured:
+                    print("[INFO] No LLM configured. Some features will be unavailable.", file=sys.stderr)
+            else:
+                print("[WARN] No LLM configured. Set COPYCLIP_LLM_PROVIDER and API key in .env", file=sys.stderr)
     
     # Always search for .copyclipignore upward from the provided folder
     base_path = os.path.abspath(args.folder)

--- a/tests/test_flow_diagram.py
+++ b/tests/test_flow_diagram.py
@@ -174,6 +174,46 @@ def test_cli_view_prompt(mock_print, mock_copy, mock_read, mock_scan, monkeypatc
     assert "Flow Diagram for file.py" in printed_text
     assert "def foo(): pass" not in printed_text
 
+
+@mock.patch("copyclip.__main__.scan_files")
+@mock.patch("copyclip.__main__.read_files_concurrently")
+@mock.patch("copyclip.clipboard.ClipboardManager.copy", return_value=True)
+@mock.patch("builtins.print")
+def test_export_without_prompt_does_not_onboard(mock_print, mock_copy, mock_read, mock_scan, monkeypatch):
+    """Regression (CI): `export --print` with no provider configured must NOT
+    launch interactive LLM onboarding — export needs no LLM unless --prompt.
+    Onboarding's raw-key reader crashes under CI (captured stdin has no fileno);
+    more fundamentally, a clipboard export shouldn't ask for an LLM at all."""
+    from copyclip.llm.provider_config import ProviderConfigError
+
+    # Reproduce CI: no provider resolves (in CI there's no .env to load a key
+    # from, so resolve_provider raises). Mock it directly because main() calls
+    # load_dotenv(override=True), which would re-inject a dev's local .env key.
+    def _no_provider(*_a, **_k):
+        raise ProviderConfigError("no provider configured")
+
+    monkeypatch.setattr("copyclip.llm.provider_config.resolve_provider", _no_provider)
+
+    onboarded = {"called": False}
+
+    def _spy_onboard(*_a, **_k):
+        onboarded["called"] = True
+        return False
+
+    monkeypatch.setattr("copyclip.intelligence.cli._run_onboarding", _spy_onboard)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "2")  # the view prompt -> flow
+    mock_scan.return_value = ["file.py"]
+    mock_read.return_value = {"file.py": "def foo(): pass"}
+
+    sys.argv = ["copyclip", "export", ".", "--print"]
+    main_module.main()
+
+    assert onboarded["called"] is False, "export without --prompt must not launch LLM onboarding"
+    printed_text = mock_print.call_args_list[-1].args[0]
+    assert "Flow Diagram for file.py" in printed_text
+
+
 def test_large_codebase_performance():
     large_source = "\n".join(
         [f"class Class{i}:\n    def method{i}(self):\n        pass\n" for i in range(2000)]


### PR DESCRIPTION
Adds a real test gate so "merge on green" means the suite passed, not just that bot reviews ran.

## What
A `tests` workflow running `pytest -q` on every push to `main` and every PR — Python 3.12, pip-cached, 15-min cap, concurrency-cancel on new pushes.

## Why it's hermetic in CI
The 3 tests that fail on a developer's machine are **local-environment artifacts**, not bugs:
- 2 live tests (`test_bench_live_smoke`, `test_cuaderno_live_e2e`) are `skipif` on a missing provider key → with no secrets configured they **skip**.
- `test_falls_back_to_default_model_when_unset` fails locally only because a user's `~/.config/copyclip/llm.yaml` pins an older anthropic model; the runner's clean HOME has no such file, so resolution falls back to the in-repo `DEFAULT_MODELS` and it **passes**.

Verified in a CI-simulated env (clean HOME, no LLM env vars): **734 passed, 3 skipped, 0 failed**. This PR's own run is the live proof.

## Security note (separate, for the author)
That `~/.config/copyclip/llm.yaml` stores OpenAI and DeepSeek API keys in plaintext. Consider moving them to `${ENV:...}` / `${FILE:...}` (as the anthropic entry already does) and rotating them. Not part of this PR (it's user config, outside the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Continuous testing workflow added to run the test suite on commits and pull requests.
* **Bug Fixes**
  * Exporting without a prompt no longer triggers onboarding or provider validation warnings.
* **Tests**
  * Added a regression test ensuring export-to-clipboard/print does not launch onboarding when no prompt is supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->