### PR TITLE
feat(cuaderno): a callout must cite — risk/decision answers carry their evidence

### DIFF
--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -162,8 +162,13 @@ question; it is recorded automatically.
 - {"kind": "ascii_block", "text": "<preformatted ascii diagram>"}
 - {"kind": "citation", "citation": <Citation>}
 - {"kind": "citation_stack", "items": [{"citation": <Citation>, "note": "..."}, ...]}
-- {"kind": "callout", "kicker": "key point | recovered decision | explicit commitment | ...",
-   "text": "<body of the callout>", "citations": [<Citation>, ...]?}
+- {"kind": "callout", "kicker": "key point | recovered decision | risk | explicit commitment | ...",
+   "text": "<body of the callout>", "citations": [<Citation>, ...]}
+   a callout is a CLAIM block — it MUST carry at least one citation (the row or
+   file that proves it), or it is rejected. Answer a RISK question with a callout
+   citing its get_risks row (area, kind, score); answer a "what decisions"
+   question from the get_decisions ledger. Never assert a risk or a decision
+   without the citation that substantiates it.
 - {"kind": "widget", "widget": <Widget>}
 - {"kind": "followups", "items": [{"label": "the analyzer", "question": "explore the analyzer"}, ...]}
 

--- a/src/copyclip/intelligence/cuaderno/schema.py
+++ b/src/copyclip/intelligence/cuaderno/schema.py
@@ -205,4 +205,13 @@ def validate_block_dict(d: Any) -> Optional[str]:
     kind = d.get("kind")
     if kind not in KNOWN_BLOCK_KINDS:
         return f"unknown or missing block kind: {kind!r}"
+    if kind == "callout":
+        # A callout is the cuaderno's claim block (a risk, a recovered decision,
+        # an explicit commitment). In an evidence-first surface a claim without
+        # evidence is fabrication, so a callout MUST carry at least one citation.
+        citations = d.get("citations")
+        if not isinstance(citations, list) or not any(
+            isinstance(c, dict) and (c.get("path") or c.get("commit")) for c in citations
+        ):
+            return "callout must carry at least one citation (a claim needs evidence)"
     return None

--- a/tests/test_cuaderno_schema.py
+++ b/tests/test_cuaderno_schema.py
@@ -124,3 +124,31 @@ def test_frame_verdict_defaults_none_for_legacy():
     from copyclip.intelligence.cuaderno.schema import frame_from_dict
     f = frame_from_dict({"question": "q", "blocks": [{"kind": "lead", "text": "x"}]})
     assert f.verdict is None and f.status == "legacy"
+
+
+# W4-2: a callout is the cuaderno's claim block; in an evidence-first surface a
+# claim without evidence is fabrication, so a callout MUST carry a citation.
+def test_callout_without_citation_rejected():
+    reason = validate_block_dict({"kind": "callout", "kicker": "risk", "text": "this area is risky"})
+    assert reason and "citation" in reason
+
+
+def test_callout_empty_citations_rejected():
+    reason = validate_block_dict({"kind": "callout", "kicker": "k", "text": "t", "citations": []})
+    assert reason and "citation" in reason
+
+
+def test_callout_with_path_citation_ok():
+    ok = validate_block_dict({
+        "kind": "callout", "kicker": "risk", "text": "churn-heavy",
+        "citations": [{"kind": "path", "path": "src/x.py"}],
+    })
+    assert ok is None
+
+
+def test_callout_with_commit_citation_ok():
+    ok = validate_block_dict({
+        "kind": "callout", "kicker": "decision", "text": "anchored",
+        "citations": [{"kind": "commit", "commit": "a0dae63"}],
+    })
+    assert ok is None


### PR DESCRIPTION
## W4-2 absorption (read side)

The tutor answers **risk** questions with callouts and **decision** questions from the ledger. A callout is the cuaderno's CLAIM block, so in an evidence-first surface it must carry at least one citation — a risk or decision asserted without the row that proves it is fabrication (the council's predicted blind spot: the gate *collected* callout citations but never *required* them).

- `validate_block_dict` now rejects a callout with no path/commit citation (emit gate at `compositor:417`).
- `prompts.py`: callout citations are REQUIRED; answer risk questions citing the `get_risks` row (area/kind/score), decisions from the `get_decisions` ledger.

`get_risks` / `get_decisions` already exist (W4-1). 750 backend tests pass; 4 new callout-citation tests.

## Next (separate increment)
Decision B's **write-tool** `set_decision_status` (the cuaderno's only write, with explicit human confirmation + `decision_history`) — needs a confirmation-UX decision before build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Callout blocks now require substantiated citations; validation ensures each callout includes at least one source reference.

* **Tests**
  * Added validation tests for callout citation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->