### PR TITLE
docs: roadmap ≤3 + reframe README/spec post-dashboard (W5-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ Built first for the author's own daily use, working alongside AI agents on long-
 
 ## What CopyClip does
 
+The cuaderno is the single surface: you ask, and an evidence-first tutor answers, reaching the capabilities below through cited tools and widgets. Two views live alongside it as side surfaces — the codebase map and safe handoff — and MCP exposes the same bounded views to external agents.
+
 ### Reacquaintance Mode
 Open any project after time away and get a five-minute briefing: what changed, who changed it, which decisions were made in your absence, and which files to read first. Anchored on the most recent human-authored commit so you re-enter through code you actually wrote, not through whatever an agent touched last.
 
 ### Ask Project — evidence-first answers
 Every answer is grounded in specific commits, decisions, and files. If the evidence is thin, CopyClip says so instead of confidently hallucinating. Contradictions in the codebase are flagged explicitly, not papered over.
 
-### Cognitive Debt Navigator
-Identifies modules that have drifted from your understanding — high churn, high agent-authored ratio, stale human review, missing decisions, weak test coverage. Each dark zone comes with a remediation plan: which commits to read first, which decisions to re-check, where to focus your next hour.
+### Heat & dark zones
+Flags the modules under the most maintenance and attention pressure — high churn, high agent-authored ratio, stale human review, missing decisions, weak test coverage. (Heat points your attention; it does not claim to measure how well you understand the code.) Each dark zone comes with a remediation plan: which commits to read first, which decisions to re-check, where to focus your next hour.
 
 ### Agent Handoff Contract
 Before you delegate work to a coding agent, CopyClip builds a bounded handoff packet: scope, constraints, do-not-touch boundaries, review gates. When the agent reports back, CopyClip generates a review summary comparing what changed against what was declared. Scope violations and unexpected dark-zone entries surface before merge, not after.

--- a/docs/superpowers/specs/2026-05-22-anchored-playground-design.md
+++ b/docs/superpowers/specs/2026-05-22-anchored-playground-design.md
@@ -1,8 +1,8 @@
 # Anchored Playground — Design Spec
 
 **Date**: 2026-05-22
-**Status**: Approved for implementation
-**Tracking**: Epic #86 — child issues #87 (backend), #88 (subprocess), #89 (frontend), #90 (Atlas connector), #91-#96 (follow-up connectors)
+**Status**: Superseded by the 2026-06-04 cuaderno-shell consensus. The playground was not cut — it was reborn inside the cuaderno (a single anchored slot), and the dashboard connectors this spec describes target a surface that no longer exists. The forward arc is Cruces / Junctions v0.1 (#146). Kept as a historical design record.
+**Tracking**: Epic #86 and children #87-#96 closed as superseded (Wave 5, 2026-06).
 
 ## Why
 

--- a/src/copyclip/roadmap.md
+++ b/src/copyclip/roadmap.md
@@ -1,42 +1,40 @@
-# 🚀 CopyClip → Capability Roadmap
+# 🚀 CopyClip — Capability Roadmap
 
-> Note: runtime/package version is currently `v0.4.0`. The milestones below describe product capability progress, not a strict semver changelog.
+> Runtime/package version is currently `v0.4.0`. This describes product capability
+> direction, not a strict semver changelog.
 
-## Scheduled: dashboard retirement — Friday 2026-06-19
+## The surface: the cuaderno
 
-Ratified 2026-06-04 (cuaderno-shell consensus, Wave 5): the legacy App.tsx
-router, the Sidebar, and the remaining dashboard pages are deleted on
-2026-06-19, after every surviving route is re-homed to a tutor tool or a
-side surface. Until then the dashboard is reachable only through the
-cuaderno's existing toggle — it is an escape hatch, not a peer. No
-indefinite coexistence.
+CopyClip **is** the cuaderno — an evidence-first tutor over a codebase you
+increasingly did not write by hand. It keeps the author's intention connected
+across the bursts of AI-assisted development; the gap between bursts is where
+ownership leaks. Everything it shows is anchored to real code, git, or the
+decision ledger — *exposición, no autoría*.
 
-## ✅ Completed (current shipped baseline)
-- [x] **Project Memory:** Dynamic chat-first interface with component injection.
-- [x] **MCP integration:** Robust server for external agent alignment and semantic auditing.
-- [x] **Codebase Map:** 3D Three.js engine with Sitting Tree and Constellation algorithms.
-- [x] **Vivid UX:** Interactive parallax, planetary scaling, and high-fidelity sidebar restoration.
-- [x] **Project Timeline:** Unified event timeline (commits + decisions + narrative).
-- [x] **Interactive Setup:** In-situ LLM configuration (DeepSeek, OpenAI, etc.) with persistence.
-- [x] **Cognitive Load Tracker:** Visualizing "Unfamiliar Code" based on agentic code ratio.
+The legacy dashboard (the `App.tsx` router, the Sidebar, and the absorbed pages)
+was retired in Wave 5 (2026-06). Each question class it answered now lives in a
+cited tutor tool or widget; three auxiliary views survive — **codebase map**,
+**safe handoff**, **settings** — reached from the cuaderno's ⊞ menu. MCP exposes
+the same bounded, audited views to external agents.
 
----
+## ✅ Shipped baseline
+- [x] **Cuaderno:** evidence-first tutor; answers stream as cited blocks + widgets; the human ratifies decision status (the one write).
+- [x] **MCP server:** bounded, audited project views for external agents (intent manifesto, context bundle, audit, heat, handoff).
+- [x] **Codebase map:** interactive graph of the codebase (a survivor side surface).
+- [x] **Safe handoff:** bounded delegation packets with pre-delegation review.
+- [x] **Heat:** maintenance/attention pressure per file, from the live composite engine.
+- [x] **In-situ setup + background analysis:** LLM config and re-index from settings; analysis follows the rhythm of bursts.
 
-## 🌟 Priorities (Short-Term)
-1. **Interactive Artifacts:** Allow clicking Codebase Map nodes to trigger chat actions (e.g., "Summarize this module").
-2. **Planning Bi-directionality:** Enable drag-and-drop between Kanban columns to update DB status.
-3. **Audit Webhooks:** Automatic auditing of incoming Git commits via background workers.
-4. **Enhanced 3D Layers:** Filter Codebase Map nodes by author (Human vs. Agent) or specific architectural decisions.
+## 🎯 Forward (≤3)
+1. **Cruces / Junctions v0.1** ([#146]) — in the playground, show *which branch executed the input you just edited*, as a computed value, never narrated. High-level debugging anchored to a real run.
+2. **Pulso** ([#152]) — continuous, incremental, background analysis that follows the rhythm of development bursts (filesystem watch or commit trigger, non-intrusive notices). The connective tissue that lets CopyClip survive the gap between bursts.
+3. **Intent Drift Surface** — a passive layer that flags code regions drifted from registered architectural decisions and surfaces the drift to the author for inspection. Never proposes refactors or triggers agentic action — *exposición, no autoría*.
 
----
-
-## 🛠️ Long-term capability goals (no launch date)
-- [ ] **VSCode Extension:** Integrated intent-aware handoffs directly in the IDE.
-- [ ] **Intent Drift Surface:** Passive detection layer that flags code regions which have drifted from registered architectural decisions. Surfaces the drift to the author for inspection; does NOT propose refactors or trigger agentic action. Refactor decisions stay with the author.
-- [ ] **Multi-Repo Project Memory:** If the author ever needs to navigate multiple repos as a single cognitive surface, connect them. Currently single-repo only.
-- [ ] **Exportable Constraints:** Generate `.copyclip/constraints.json` for external LLM system prompts.
-
----
+[#146]: https://github.com/sssamuelll/copyclip/issues/146
+[#152]: https://github.com/sssamuelll/copyclip/issues/152
 
 # 🎯 Vision
-A personal cognitive sentinel for the author — the tool that lets him stay attached to his own codebases as AI agents write more of the code. If others with the same pain eventually find it useful, that's downstream of the author's own daily use working.
+A personal cognitive sentinel for the author — the tool that lets him stay
+attached to his own codebases as AI agents write more of the code. If others
+with the same pain eventually find it useful, that's downstream of the author's
+own daily use working.


### PR DESCRIPTION
**Wave 5 / PR-W5-3** — the docs sweep. See kickoff (#157).

- **`roadmap.md` → ≤3 forward items:** Cruces/Junctions v0.1 (#146), Pulso (#152), Intent Drift Surface. Cuts the dashboard-era priorities (interactive artifacts, kanban, audit webhooks, 3D author filters, VSCode ext, multi-repo, exportable constraints); reframes the shipped baseline in cuaderno/tool vocabulary; flips the "scheduled retirement" header to past tense.
- **README:** frames "What CopyClip does" around the cuaderno as the single surface (codebase map + safe handoff as side surfaces, MCP for agents); renames the **"Cognitive Debt Navigator"** section to **"Heat & dark zones"** with honest framing (heat = maintenance/attention pressure, not a comprehension claim) — removing the lone remaining public "cognitive debt" reference.
- **Anchored-playground spec (2026-05-22):** marked superseded by the cuaderno-shell consensus (reborn inside the cuaderno; #86/#87-#96 closed).

Docs only. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature descriptions to clarify CopyClip's core surfaces and capabilities, including evidence-first organization and heat/dark zone identification.
  * Refreshed product roadmap with new structure highlighting shipped baseline, near-term initiatives, and long-term vision.
  * Marked superseded design specifications as historical references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->