### PR TITLE
feat(pulso): the "Last contact" burst-recency atom (P2)

### DIFF
--- a/src/copyclip/intelligence/analyzer.py
+++ b/src/copyclip/intelligence/analyzer.py
@@ -377,6 +377,29 @@ def _analyze_git_folder(project_root: str, project_id: int, conn) -> Dict:
 
 # Brief: analyze
 
+def _persist_last_contact(conn, project_id: int) -> None:
+    """Final pass: persist the Pulso 'Last contact' reading (days since a human
+    last touched a file after the most recent AI-attributed burst). NULL where
+    there is nothing honest to report — no burst, or the human already returned.
+    Reads commits.ai_attributed (the live trailer signal), never blame. Must run
+    after commits/file_changes are ingested; one file's failure never aborts."""
+    from .pulso import build_last_contact
+
+    rows = conn.execute(
+        "SELECT path FROM analysis_file_insights WHERE project_id=?",
+        (project_id,),
+    ).fetchall()
+    for (path,) in rows:
+        try:
+            reading = build_last_contact(conn, project_id, path)
+        except Exception:  # noqa: BLE001 — one file's reading must not abort the pass
+            reading = None
+        conn.execute(
+            "UPDATE analysis_file_insights SET pulso_last_contact_days=? WHERE project_id=? AND path=?",
+            (reading["last_contact_days"] if reading else None, project_id, path),
+        )
+
+
 def _persist_composite_scores(conn, project_id: int) -> None:
     """Final pass: overwrite each file's cognitive_debt with the LIVE 8-factor
     composite (build_debt_breakdown), not the dead single-factor scalar. One
@@ -1065,6 +1088,7 @@ async def analyze(project_root: str, progress_cb=None, start_cursor: int = 0, ch
     # Collapse to one debt engine: the persisted column now holds the live
     # 8-factor composite, read by the fog, the MCP map, and handoff risks.
     _persist_composite_scores(conn, project_id)
+    _persist_last_contact(conn, project_id)
 
     summary = {
         "files": indexed,

--- a/src/copyclip/intelligence/db.py
+++ b/src/copyclip/intelligence/db.py
@@ -278,6 +278,7 @@ def init_schema(conn: sqlite3.Connection) -> None:
             cognitive_debt REAL DEFAULT 0,
             agent_line_ratio REAL,
             last_human_ts REAL,
+            pulso_last_contact_days INTEGER,
             updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(project_id, path)
         );
@@ -337,6 +338,14 @@ def init_schema(conn: sqlite3.Connection) -> None:
         commit_cols = {row[1] for row in conn.execute("PRAGMA table_info(commits)").fetchall()}
         if commit_cols and "ai_attributed" not in commit_cols:
             conn.execute("ALTER TABLE commits ADD COLUMN ai_attributed INTEGER NOT NULL DEFAULT 0")
+    except Exception:
+        pass
+
+    # Backfill the Pulso "Last contact" column on older insight tables.
+    try:
+        afi_cols = {row[1] for row in conn.execute("PRAGMA table_info(analysis_file_insights)").fetchall()}
+        if afi_cols and "pulso_last_contact_days" not in afi_cols:
+            conn.execute("ALTER TABLE analysis_file_insights ADD COLUMN pulso_last_contact_days INTEGER")
     except Exception:
         pass
 

--- a/src/copyclip/intelligence/pulso.py
+++ b/src/copyclip/intelligence/pulso.py
@@ -1,0 +1,86 @@
+"""Pulso — the honest burst-recency atom ("Last contact").
+
+The wedge is keeping the human connected to their intention across AI bursts.
+The only LIVE trace of a burst is the Co-Authored-By trailer (git-blame author is
+dead here — the human commits the AI's work under his own name). So Pulso reads
+`commits.ai_attributed` (set at ingest, PR-P1), never the blame column.
+
+What this proves, and nothing more: *an AI burst last shaped this file N days ago
+and a human has not touched it since.* It measures elapsed time and recency. It
+does NOT measure comprehension — a timestamp cannot witness understanding. When
+there is no burst, or the human has already returned, Pulso is silent (None),
+never a reassuring zero.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _parse_git_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    s = value.strip()
+    try:
+        return datetime.strptime(s, "%Y-%m-%d %H:%M:%S %z")
+    except ValueError:
+        pass
+    try:
+        dt = datetime.fromisoformat(s)
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def build_last_contact(
+    conn, project_id: int, path: str, *, now: datetime | None = None
+) -> dict[str, Any] | None:
+    """Return the Last-contact reading for a file, or None when there is nothing
+    honest to report (no AI burst, or the human already returned).
+
+    Keys: last_contact_days (days since the human's last touch, or since the
+    burst if never), ai_burst_days (days since the most recent AI burst),
+    never_human_touched (the human has no commit on this file).
+    """
+    now = now or datetime.now(timezone.utc)
+
+    rows = conn.execute(
+        """
+        SELECT c.date, c.ai_attributed
+        FROM file_changes fc
+        JOIN commits c ON c.sha = fc.commit_sha
+        WHERE fc.project_id = ? AND fc.file_path = ?
+        """,
+        (project_id, path),
+    ).fetchall()
+
+    last_ai: datetime | None = None
+    last_human: datetime | None = None
+    for date_str, ai_attributed in rows:
+        dt = _parse_git_iso(date_str)
+        if dt is None:
+            continue
+        if ai_attributed:
+            if last_ai is None or dt > last_ai:
+                last_ai = dt
+        else:
+            if last_human is None or dt > last_human:
+                last_human = dt
+
+    # No burst ever shaped this file -> nothing to track. Absence, not zero.
+    if last_ai is None:
+        return None
+
+    # The human already returned since the most recent burst -> current, silent.
+    if last_human is not None and last_human >= last_ai:
+        return None
+
+    def days_since(dt: datetime) -> int:
+        return max(0, (now - dt).days)
+
+    contact_anchor = last_human if last_human is not None else last_ai
+    return {
+        "last_contact_days": days_since(contact_anchor),
+        "ai_burst_days": days_since(last_ai),
+        "never_human_touched": last_human is None,
+    }

--- a/tests/test_pulso_last_contact.py
+++ b/tests/test_pulso_last_contact.py
@@ -1,0 +1,90 @@
+"""Pulso PR-P2: the "Last contact" atom.
+
+days since a human last touched a file AFTER the most recent AI-attributed
+(Co-Authored-By) commit. Silent (None, not 0) when there is no AI burst, or when
+the human has already returned since the last burst. Recency only — never a
+comprehension claim.
+"""
+import sqlite3
+from datetime import datetime, timezone
+
+from copyclip.intelligence.db import init_schema
+from copyclip.intelligence.pulso import build_last_contact
+
+NOW = datetime(2026, 6, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _seed(conn):
+    conn.execute("INSERT INTO projects(id, root_path, name) VALUES(1,'/p','P')")
+
+
+def _commit(conn, sha, date_iso, ai, path):
+    conn.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message, ai_attributed) VALUES(1,?,?,?,?,?)",
+        (sha, "Samuel", date_iso, "msg", 1 if ai else 0),
+    )
+    conn.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(1,?,?,0,0)",
+        (sha, path),
+    )
+
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    init_schema(c)
+    _seed(c)
+    return c
+
+
+def test_no_ai_burst_is_silent():
+    c = _conn()
+    _commit(c, "h1", "2026-06-01 10:00:00 +0000", False, "src/a.py")
+    assert build_last_contact(c, 1, "src/a.py", now=NOW) is None
+
+
+def test_human_returned_after_burst_is_silent():
+    # AI burst on the 1st, human came back on the 10th -> current, nothing to track.
+    c = _conn()
+    _commit(c, "ai1", "2026-06-01 10:00:00 +0000", True, "src/a.py")
+    _commit(c, "h1", "2026-06-10 10:00:00 +0000", False, "src/a.py")
+    assert build_last_contact(c, 1, "src/a.py", now=NOW) is None
+
+
+def test_burst_after_last_human_touch_reports_gap():
+    # Human touched on the 1st, AI burst on the 20th, human hasn't returned.
+    c = _conn()
+    _commit(c, "h1", "2026-06-01 12:00:00 +0000", False, "src/a.py")
+    _commit(c, "ai1", "2026-06-20 12:00:00 +0000", True, "src/a.py")
+    res = build_last_contact(c, 1, "src/a.py", now=NOW)
+    assert res is not None
+    assert res["last_contact_days"] == 29  # since 2026-06-01
+    assert res["ai_burst_days"] == 10      # since 2026-06-20
+    assert res["never_human_touched"] is False
+
+
+def test_never_human_touched_file_reports_since_burst():
+    # Only AI ever touched it -> the strongest leak; contact measured since burst.
+    c = _conn()
+    _commit(c, "ai1", "2026-06-20 12:00:00 +0000", True, "src/gen.py")
+    res = build_last_contact(c, 1, "src/gen.py", now=NOW)
+    assert res is not None
+    assert res["never_human_touched"] is True
+    assert res["last_contact_days"] == 10
+    assert res["ai_burst_days"] == 10
+
+
+def test_persist_writes_nullable_column():
+    from copyclip.intelligence.analyzer import _persist_last_contact
+
+    c = _conn()
+    # one file with an open burst-gap, one with no burst (must persist NULL).
+    for p in ("src/a.py", "src/b.py"):
+        c.execute("INSERT INTO analysis_file_insights(project_id, path, module) VALUES(1,?,?)", (p, "m"))
+    _commit(c, "h1", "2024-01-01 12:00:00 +0000", False, "src/a.py")
+    _commit(c, "ai1", "2024-02-01 12:00:00 +0000", True, "src/a.py")
+    _commit(c, "h2", "2024-01-01 12:00:00 +0000", False, "src/b.py")  # no burst on b
+    _persist_last_contact(c, 1)
+    a = c.execute("SELECT pulso_last_contact_days FROM analysis_file_insights WHERE path='src/a.py'").fetchone()[0]
+    b = c.execute("SELECT pulso_last_contact_days FROM analysis_file_insights WHERE path='src/b.py'").fetchone()[0]
+    assert a is not None and a > 0   # open gap recorded
+    assert b is None                 # absence persists as NULL, never 0


### PR DESCRIPTION
**Pulso PR-P2** — the honest metric, built on P1's trailer signal (#162). See kickoff (#161).

`intelligence/pulso.py` · `build_last_contact(conn, project_id, path)`: **days since a human last touched a file AFTER the most recent AI-attributed (`Co-Authored-By`) commit.** Reads `commits.ai_attributed` (live), never the dead blame column. Returns **None — silent, never a reassuring zero** — when there is no burst, or when the human already returned since the last burst. Flags `never_human_touched` for files only AI ever shaped. **Recency only; no comprehension claim.**

Persisted as a nullable `analysis_file_insights.pulso_last_contact_days` in a final pass (`_persist_last_contact`); NULL where silent.

**Verified live (re-analyzed this repo):** 202 files, **167 with a reading, 35 silent**; range **0..98 days, median 9** — a real, discriminating distribution where heat is compressed to 29-74. Absence persists as NULL.

TDD: `tests/test_pulso_last_contact.py` (the four burst/gap cases + nullable persistence). `pytest` 764 pass (3 known local-only artifacts).

Scope: no surface yet (P4); the heat-engine cleanup (delete the dead `agent_authored_ratio` factor + `decision_gap` activation-gate) is the next PR (P3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)