### PR TITLE
feat(pulso): surface "Last contact" as the get_last_contact tutor tool (P4)

### DIFF
--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -258,6 +258,40 @@ def get_risks(
     }
 
 
+def get_last_contact(
+    conn: sqlite3.Connection,
+    project_id: int,
+    *,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Read the Pulso 'Last contact' readings — files an AI burst last shaped that
+    the human has NOT returned to, longest gap first. Reads the persisted
+    `pulso_last_contact_days` (never the dead blame column). Silent files (no AI
+    burst, or the human already returned) are absent, not zero. Each row is
+    citable by `file_path`.
+
+    Recency only: this proves elapsed time since the human's last touch, NOT that
+    the human understands the code. A timestamp cannot witness comprehension."""
+    from ..pulso import build_last_contact
+
+    rows = conn.execute(
+        "SELECT path, pulso_last_contact_days FROM analysis_file_insights "
+        "WHERE project_id = ? AND pulso_last_contact_days IS NOT NULL "
+        "ORDER BY pulso_last_contact_days DESC, path ASC LIMIT ?",
+        (project_id, min(int(limit or 20), 200)),
+    ).fetchall()
+    items: list[dict[str, Any]] = []
+    for path, days in rows:
+        detail = build_last_contact(conn, project_id, path)
+        items.append({
+            "file_path": path,
+            "last_contact_days": days,
+            "ai_burst_days": detail["ai_burst_days"] if detail else None,
+            "never_human_touched": detail["never_human_touched"] if detail else None,
+        })
+    return {"last_contact": items}
+
+
 def _parse_json_or_none(raw: Optional[str]) -> Any:
     if not raw:
         return None

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -133,6 +133,12 @@ delegated, anchored to real evidence in the code.
 - `read_file` reads a FILE, never a directory — use `list_dir` for folders.
 - `get_callers` / `get_callees` trace symbol-level call graphs; `get_module_graph`
   gives the module-level topology — all nodes map to real files (citable).
+- `get_last_contact` answers "what did AI change that I haven't gone back to?":
+  files an AI burst last shaped (Co-Authored-By trailer) that the human has not
+  returned to, with the gap in days. It proves elapsed TIME only — say "you last
+  touched X N days ago; AI changed it since", NEVER "you don't understand X" or
+  "you've lost the thread". Files with no burst or where the human is current are
+  simply absent; an empty result means nothing to report, not a clean bill.
 - Use project-relative POSIX paths only; never absolute paths and never `..`.
 - Never retry a path that errored. If a tool returns nothing useful, move on.
 - Read before you answer. Do not answer a question about the code from memory or

--- a/src/copyclip/intelligence/cuaderno/tool_catalog.py
+++ b/src/copyclip/intelligence/cuaderno/tool_catalog.py
@@ -228,6 +228,24 @@ def build_tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "get_last_contact",
+            "description": (
+                "Read Pulso 'Last contact': files an AI burst last shaped that the "
+                "human has NOT returned to, longest gap (days) first, citable by "
+                "`file_path`. Reads the Co-Authored-By trailer signal, never blame; "
+                "files with no burst (or where the human is current) are absent, not "
+                "zero. Use for 'what did AI change that I haven't gone back to?'. "
+                "It proves elapsed TIME, never comprehension — say so, never imply "
+                "the human does or does not understand the code."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "default": 20},
+                },
+            },
+        },
+        {
             "name": "emit_block",
             "description": (
                 "Emit ONE block of your answer. Call once per block, in order. "
@@ -314,4 +332,6 @@ def dispatch_tool(
             kind=args.get("kind"), severity=args.get("severity"),
             limit=args.get("limit", 50),
         )
+    if name == "get_last_contact":
+        return anchor.get_last_contact(conn, project_id, limit=args.get("limit", 20))
     return {"error": "unknown_tool", "name": name}

--- a/tests/test_cuaderno_tool_catalog.py
+++ b/tests/test_cuaderno_tool_catalog.py
@@ -12,6 +12,7 @@ def test_tool_definitions_include_all_tools():
         "git_log", "git_blame", "git_diff", "find_tests", "get_module_graph",
         "get_decisions", "get_reverse_dependents", "git_archaeology",
         "get_story_snapshots", "get_reacquaintance_briefing", "get_risks",
+        "get_last_contact",
         "emit_block", "finish",
     }
 

--- a/tests/test_pulso_tool.py
+++ b/tests/test_pulso_tool.py
@@ -1,0 +1,74 @@
+"""Pulso PR-P4: the honest surface — the get_last_contact tutor tool.
+
+Lists files an AI burst last shaped that the human has not returned to, longest
+gap first. Reads the persisted column (never blame). Silent files are absent,
+not zero. Each row is citable by file_path. Recency only.
+"""
+import sqlite3
+
+from copyclip.intelligence.db import init_schema
+from copyclip.intelligence.cuaderno.anchor import get_last_contact
+from copyclip.intelligence.cuaderno.tool_catalog import dispatch_tool, build_tool_definitions
+
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    init_schema(c)
+    c.execute("INSERT INTO projects(id, root_path, name) VALUES(1,'/p','P')")
+    return c
+
+
+def _file(c, path, last_contact_days):
+    c.execute(
+        "INSERT INTO analysis_file_insights(project_id, path, module, pulso_last_contact_days) VALUES(1,?,?,?)",
+        (path, "m", last_contact_days),
+    )
+
+
+def _commit(c, sha, date_iso, ai, path):
+    c.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message, ai_attributed) VALUES(1,?,?,?,?,?)",
+        (sha, "Samuel", date_iso, "m", 1 if ai else 0),
+    )
+    c.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) VALUES(1,?,?,0,0)",
+        (sha, path),
+    )
+
+
+def test_lists_open_gaps_longest_first_and_excludes_silent():
+    c = _conn()
+    _file(c, "src/cold.py", 40)
+    _file(c, "src/warm.py", 6)
+    _file(c, "src/current.py", None)  # silent -> must NOT appear
+    for p in ("src/cold.py", "src/warm.py"):
+        _commit(c, f"h-{p}", "2026-01-01 10:00:00 +0000", False, p)
+        _commit(c, f"ai-{p}", "2026-02-01 10:00:00 +0000", True, p)
+
+    res = get_last_contact(c, 1, limit=10)
+    items = res["last_contact"]
+
+    paths = [it["file_path"] for it in items]
+    assert paths == ["src/cold.py", "src/warm.py"]   # longest gap first, NULL excluded
+    assert items[0]["last_contact_days"] == 40
+    # the full honest detail is recomputed for the listed rows
+    assert items[0]["ai_burst_days"] is not None
+    assert items[0]["never_human_touched"] is False
+
+
+def test_empty_when_nothing_to_report():
+    c = _conn()
+    _file(c, "src/current.py", None)
+    assert get_last_contact(c, 1)["last_contact"] == []
+
+
+def test_tool_is_registered_and_dispatches():
+    names = {t["name"] for t in build_tool_definitions()}
+    assert "get_last_contact" in names
+
+    c = _conn()
+    _file(c, "src/a.py", 12)
+    _commit(c, "h", "2026-01-01 10:00:00 +0000", False, "src/a.py")
+    _commit(c, "ai", "2026-02-01 10:00:00 +0000", True, "src/a.py")
+    out = dispatch_tool("get_last_contact", {"limit": 5}, project_root="/p", conn=c, project_id=1)
+    assert out["last_contact"][0]["file_path"] == "src/a.py"


### PR DESCRIPTION
**Pulso PR-P4** — the honest surface. See kickoff (#161). Completes the user-facing v0.1 atom (P1 ingest #162 · P2 metric #163 · P4 surface).

The tutor answers *"what did AI change that I haven't gone back to?"* with a cited list, framed as **time, never comprehension**.

- `anchor.get_last_contact(conn, project_id, limit)`: files an AI burst last shaped that the human has not returned to, longest gap first, citable by `file_path`. Reads the persisted `pulso_last_contact_days` (never blame); recomputes the full honest detail (`ai_burst_days`, `never_human_touched`) for the listed rows. **Silent files are absent, never zero.**
- Registered in `tool_catalog` (def + dispatch); described to the tutor with the confession built in (proves elapsed TIME, never comprehension; an empty result means nothing to report, not a clean bill).
- `prompts.py`: guidance to say *"you last touched X N days ago; AI changed it since"*, never *"you don't understand X"*.

Conversational surface (no UI change) — the cuaderno is the surface.

**Verified live on this repo:** e.g. `tree_sitter_parser.py` → 60d, `never_human_touched=True` (only AI ever committed it); `mcp_server.py` → 98d since a human-only touch, AI-shaped today.

TDD: `tests/test_pulso_tool.py` (ordering, NULL exclusion, registration + dispatch); updated the tool-catalog pin. `pytest` 767 pass (3 known local-only artifacts).

The heat-engine cleanup (delete the dead `agent_authored_ratio` factor + `decision_gap` activation-gate) is a separate **contract-revision** PR — see the status note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "last contact" analysis to identify files last modified by AI activity that users haven't revisited, helping prioritize code review needs.

* **Tests**
  * Added comprehensive test coverage for the new last contact analysis feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->