### PR TITLE
feat(heat): v2 contract — delete dead agent_authored_ratio + gate decision_gap

### DIFF
--- a/docs/COGNITIVE_DEBT_CONTRACT.md
+++ b/docs/COGNITIVE_DEBT_CONTRACT.md
@@ -59,7 +59,7 @@ Labels are stable. Tuning factor weights does not change bucket semantics.
   "meta": {
     "project": "copyclip",
     "generated_at": "2026-04-20T10:00:00Z",
-    "contract_version": "v1",
+    "contract_version": "v2",
     "scope_kind": "file",
     "scope_id": "src/copyclip/mcp_server.py"
   },
@@ -83,27 +83,30 @@ Factors are measured independently, normalized to `[0, 100]`, weighted, and summ
 
 | `factor_id`              | Signal source                                                    | Normalization                                                   | Weight |
 |--------------------------|------------------------------------------------------------------|-----------------------------------------------------------------|--------|
-| `churn_pressure`         | `file_changes` rows over the lookback window                     | `min(100, churn_count * churn_unit)`                            | 0.18   |
-| `agent_authored_ratio`   | `git blame` agent-authored lines / total lines                   | `ratio * 100`                                                   | 0.22   |
-| `review_staleness`       | days since last human-authored line                              | `min(100, days_since_human / 60 * 100)`                         | 0.15   |
+| `churn_pressure`         | `file_changes` rows over the lookback window                     | `min(100, churn_count * churn_unit)`                            | 0.26   |
+| `review_staleness`       | days since last human-authored line                              | `min(100, days_since_human / 60 * 100)`                         | 0.22   |
 | `test_evidence_gap`      | linked test files / (files × 1) over the module or file's module | `(1 - coverage_hint) * 100`                                     | 0.12   |
-| `decision_gap`           | decisions linked to the area vs touched decisions across churn   | `(1 - decision_link_ratio) * 100`                               | 0.13   |
-| `ownership_ambiguity`    | distinct authors + tenure dispersion in blame                    | `min(100, distinct_authors * tenure_weight)`                    | 0.08   |
-| `blast_radius`           | module fan-out and import-graph depth                            | `min(100, (fan_out_normalized + import_depth_normalized) * 50)` | 0.07   |
-| `novelty_recency`        | `commits` whose SHA first introduced the file, within window     | `age_recency_bump()`                                            | 0.05   |
+| `decision_gap`           | decisions linked to the area (gated, see below)                  | `0` if linked, else `100`                                       | 0.13   |
+| `ownership_ambiguity`    | distinct authors + tenure dispersion in blame                    | `min(100, distinct_authors * tenure_weight)`                    | 0.10   |
+| `blast_radius`           | module fan-out and import-graph depth                            | `min(100, (fan_out_normalized + import_depth_normalized) * 50)` | 0.09   |
+| `novelty_recency`        | `commits` whose SHA first introduced the file, within window     | `age_recency_bump()`                                            | 0.08   |
 
-Weights sum to `1.00`. The default weights above are the v1 baseline; different weight profiles may exist later (e.g. delegation-mode vs review-mode) but the contract version must be bumped when profiles change.
+Weights sum to `1.00`. **v2** removed `agent_authored_ratio` (it was git-blame author-matched, which reads ~0 when the human commits the AI's work under his own name — a dead, diluting signal; its `Co-Authored-By` replacement lives in the separate Pulso "Last contact" metric, not here). Its 0.22 weight was redistributed to the continuous, discriminating factors, not the binary gap factors.
+
+**`decision_gap` activation-gate (v2):** the factor deactivates (`signal_available=false`, leaving the denominator) when the project links *no* accepted/resolved decisions to any file at all — there, a per-file decision gap is a project-level documentation fact in disguise, not a discriminating signal. When the project does use decisions, a file lacking one is a real gap and fires at `100`.
+
+Different weight profiles may exist later (e.g. delegation-mode vs review-mode) but the contract version must be bumped when profiles change.
 
 ### Factor breakdown item shape
 
 ```json
 {
-  "factor_id": "agent_authored_ratio",
-  "label": "Agent-authored ratio",
+  "factor_id": "review_staleness",
+  "label": "Review staleness",
   "weight": 0.22,
-  "raw_signal": { "agent_lines": 140, "total_lines": 220 },
-  "normalized_contribution": 63.6,
-  "weighted_contribution": 14.0,
+  "raw_signal": { "days_since_human": 42.0 },
+  "normalized_contribution": 70.0,
+  "weighted_contribution": 15.4,
   "signal_available": true,
   "rationale": "63.6% of current lines were authored by external agents.",
   "evidence": ["file:src/copyclip/mcp_server.py", "blame:agent"]

--- a/src/copyclip/intelligence/cognitive_debt.py
+++ b/src/copyclip/intelligence/cognitive_debt.py
@@ -18,17 +18,23 @@ import math
 from typing import Any, Iterable
 
 
-CONTRACT_VERSION = "v1"
+# v2 (Pulso heat cleanup): the dead agent_authored_ratio factor is removed — it
+# was git-blame author-matched, which reads 0 here (the human commits the AI's
+# work under his own name), so it only diluted the score. Its 0.22 weight is
+# redistributed to the CONTINUOUS, discriminating factors (churn, staleness,
+# ownership, blast, novelty), NOT the binary gap factors — amplifying a binary
+# near-constant is whack-a-mole. decision_gap also gains an activation-gate (it
+# leaves the denominator when the project links no decisions at all).
+CONTRACT_VERSION = "v2"
 
 COGNITIVE_DEBT_FACTORS: list[dict[str, Any]] = [
-    {"id": "churn_pressure", "label": "Churn pressure", "weight": 0.18},
-    {"id": "agent_authored_ratio", "label": "Agent-authored ratio", "weight": 0.22},
-    {"id": "review_staleness", "label": "Review staleness", "weight": 0.15},
+    {"id": "churn_pressure", "label": "Churn pressure", "weight": 0.26},
+    {"id": "review_staleness", "label": "Review staleness", "weight": 0.22},
     {"id": "test_evidence_gap", "label": "Test evidence gap", "weight": 0.12},
     {"id": "decision_gap", "label": "Decision gap", "weight": 0.13},
-    {"id": "ownership_ambiguity", "label": "Ownership ambiguity", "weight": 0.08},
-    {"id": "blast_radius", "label": "Blast radius", "weight": 0.07},
-    {"id": "novelty_recency", "label": "Novelty recency", "weight": 0.05},
+    {"id": "ownership_ambiguity", "label": "Ownership ambiguity", "weight": 0.10},
+    {"id": "blast_radius", "label": "Blast radius", "weight": 0.09},
+    {"id": "novelty_recency", "label": "Novelty recency", "weight": 0.08},
 ]
 
 FACTOR_WEIGHT = {f["id"]: f["weight"] for f in COGNITIVE_DEBT_FACTORS}
@@ -180,6 +186,25 @@ def _decision_links_for_file(conn, project_id: int, path: str) -> list[int]:
     return [int(r[0]) for r in rows if r[0] is not None]
 
 
+def _project_uses_decisions(conn, project_id: int) -> bool:
+    """True iff the project links any accepted/resolved decision to any file.
+    When False, a per-file decision_gap is a project-level documentation fact in
+    disguise, not a discriminating signal — so the factor deactivates."""
+    row = conn.execute(
+        """
+        SELECT 1
+        FROM decisions d
+        LEFT JOIN decision_refs dr ON dr.decision_id = d.id AND dr.ref_type='file'
+        LEFT JOIN decision_links dl ON dl.decision_id = d.id AND dl.project_id = d.project_id AND dl.link_type='file'
+        WHERE d.project_id=? AND d.status IN ('accepted', 'resolved')
+          AND (dr.ref_value IS NOT NULL OR dl.target_pattern IS NOT NULL)
+        LIMIT 1
+        """,
+        (project_id,),
+    ).fetchone()
+    return row is not None
+
+
 def _module_has_tests(conn, project_id: int, module: str, files: Iterable[str]) -> bool:
     for path in files:
         lowered = path.lower()
@@ -228,7 +253,7 @@ def _factor_item(
     }
 
 
-def _build_file_factors(conn, project_id: int, path: str, *, lookback_days: int, now_ts: float) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+def _build_file_factors(conn, project_id: int, path: str, *, lookback_days: int, now_ts: float, project_uses_decisions: bool | None = None) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     insight = _file_insight(conn, project_id, path)
     if insight is None:
         insight = {"module": None, "complexity": None, "cognitive_debt": None, "agent_line_ratio": None, "last_human_ts": None}
@@ -252,29 +277,6 @@ def _build_file_factors(conn, project_id: int, path: str, *, lookback_days: int,
         rationale=f"{churn_count} recorded change(s) for this file.",
         evidence=[f"file:{path}"],
     ))
-
-    # agent_authored_ratio
-    agent_ratio = insight.get("agent_line_ratio")
-    if agent_ratio is not None:
-        agent_pct = _clamp(float(agent_ratio) * 100.0)
-        factors.append(_factor_item(
-            "agent_authored_ratio",
-            normalized=agent_pct,
-            raw_signal={"agent_line_ratio": round(float(agent_ratio), 4)},
-            available=True,
-            rationale=f"{agent_pct:.1f}% of current lines are agent-authored.",
-            evidence=[f"file:{path}", "blame:agent"],
-        ))
-        _append_evidence(evidence_index, {"id": "blame:agent", "type": "blame", "label": "agent-authored lines", "ref": "blame:agent"})
-    else:
-        factors.append(_factor_item(
-            "agent_authored_ratio",
-            normalized=None,
-            raw_signal={"agent_line_ratio": None},
-            available=False,
-            rationale="No blame data available for this file.",
-            evidence=[],
-        ))
 
     # review_staleness
     last_human_ts = insight.get("last_human_ts")
@@ -314,16 +316,23 @@ def _build_file_factors(conn, project_id: int, path: str, *, lookback_days: int,
         evidence=[f"module:{module}"] if module else [f"file:{path}"],
     ))
 
-    # decision_gap
+    # decision_gap — gated: a per-file decision gap only discriminates in a
+    # project that links decisions at all. Where the project links none, the
+    # factor would fire on ~every file (a project-level documentation fact in a
+    # per-file costume) and saturate the score, so it deactivates and leaves the
+    # denominator instead of firing at 100.
+    if project_uses_decisions is None:
+        project_uses_decisions = _project_uses_decisions(conn, project_id)
     decisions = _decision_links_for_file(conn, project_id, path)
-    decision_coverage = 1.0 if decisions else 0.0
     factors.append(_factor_item(
         "decision_gap",
-        normalized=(1.0 - decision_coverage) * 100.0,
-        raw_signal={"linked_decisions": decisions},
-        available=True,
+        normalized=(0.0 if decisions else 100.0),
+        raw_signal={"linked_decisions": decisions, "project_uses_decisions": project_uses_decisions},
+        available=bool(project_uses_decisions),
         rationale=(
-            f"File is linked to {len(decisions)} accepted/resolved decision(s)." if decisions else "No accepted decision is linked to this file."
+            f"File is linked to {len(decisions)} accepted/resolved decision(s)." if decisions
+            else ("No accepted decision is linked to this file." if project_uses_decisions
+                  else "Project links no decisions to code; decision gap not scored per file.")
         ),
         evidence=[f"file:{path}"] + [f"decision:{d}" for d in decisions],
     ))
@@ -450,8 +459,10 @@ def _aggregate_module_from_files(conn, project_id: int, module: str, files: list
     combined_factors: dict[str, dict[str, Any]] = {}
     combined_evidence: list[dict[str, Any]] = []
 
+    # Compute the project-level decision-gate ONCE, not once per file.
+    uses_decisions = _project_uses_decisions(conn, project_id)
     for path in files:
-        factors, evidence_index = _build_file_factors(conn, project_id, path, lookback_days=lookback_days, now_ts=now_ts)
+        factors, evidence_index = _build_file_factors(conn, project_id, path, lookback_days=lookback_days, now_ts=now_ts, project_uses_decisions=uses_decisions)
         file_score, _ = _compose_score(factors)
         per_file_breakdowns.append({"path": path, "score": file_score, "severity": _severity_for(file_score)})
         for ev in evidence_index:

--- a/src/copyclip/intelligence/debt_remediation.py
+++ b/src/copyclip/intelligence/debt_remediation.py
@@ -25,7 +25,6 @@ REMEDIATION_ACTION_TYPES = {
 # Minimum normalized contribution (0-100) for a factor to trigger its template.
 # High contribution → candidate is worth surfacing; low contribution → noise.
 _FACTOR_ACTIVATION_FLOOR = {
-    "agent_authored_ratio": 40.0,
     "review_staleness": 40.0,
     "decision_gap": 60.0,
     "test_evidence_gap": 60.0,
@@ -101,16 +100,16 @@ def _estimate_impact(factor_map: dict[str, dict[str, Any]], factor_ids: list[str
 
 
 def _candidate_for_human_review(factor_map, target, evidence_ids, agent_commits) -> dict[str, Any] | None:
-    if not _is_factor_active(factor_map, "agent_authored_ratio") and not _is_factor_active(factor_map, "review_staleness"):
+    if not _is_factor_active(factor_map, "review_staleness"):
         return None
-    delta = _estimate_impact(factor_map, ["agent_authored_ratio", "review_staleness"], reduction=0.5)
+    delta = _estimate_impact(factor_map, ["review_staleness"], reduction=0.5)
     commit_evidence = [f"commit:{c['sha']}" for c in agent_commits[:3]]
     return {
         "id": "human_review_recent_changes",
         "action_type": "review_this_recent_change",
         "label": "Human-review the recent agent-authored changes to restore continuity",
         "target": target,
-        "reduces_factors": ["agent_authored_ratio", "review_staleness"],
+        "reduces_factors": ["review_staleness"],
         "expected_impact": {"score_delta": delta, "confidence": "medium"},
         "rationale": "Human review of recent non-human commits is the cheapest single reduction for drift and staleness.",
         "evidence": evidence_ids + commit_evidence,
@@ -203,16 +202,16 @@ def _candidate_for_blast_radius(factor_map, target) -> dict[str, Any] | None:
 def _candidate_for_read_anchor(factor_map, target, human_commits, last_human_ts) -> dict[str, Any] | None:
     if not human_commits:
         return None
-    if not (_is_factor_active(factor_map, "agent_authored_ratio") or _is_factor_active(factor_map, "review_staleness")):
+    if not _is_factor_active(factor_map, "review_staleness"):
         return None
-    delta = _estimate_impact(factor_map, ["agent_authored_ratio", "review_staleness"], reduction=0.2)
+    delta = _estimate_impact(factor_map, ["review_staleness"], reduction=0.2)
     first_human = human_commits[0]
     return {
         "id": "read_last_human_anchor",
         "action_type": "read_this_first",
         "label": f"Read the last human-authored anchor commit ({first_human['sha'][:7]})",
         "target": target,
-        "reduces_factors": ["agent_authored_ratio", "review_staleness"],
+        "reduces_factors": ["review_staleness"],
         "expected_impact": {"score_delta": delta, "confidence": "low"},
         "rationale": "Re-anchoring on the last human-authored version of this area is the fastest context-restore step.",
         "evidence": [f"{target['kind']}:{target.get('id') or target.get('module')}", f"commit:{first_human['sha']}"],

--- a/tests/fixtures/cog_debt_fixtures.py
+++ b/tests/fixtures/cog_debt_fixtures.py
@@ -9,8 +9,8 @@ Three scenarios cover the realistic shapes a debt breakdown has to handle:
 - ``seed_clean_project``: a small project where no file reaches activation
   floors; used to verify remediation returns a ``no_action_needed`` note.
 - ``seed_greenfield_project``: persisted rows without blame so
-  ``agent_authored_ratio`` and ``review_staleness`` are unavailable and
-  confidence must fall to ``low`` or ``medium``.
+  ``review_staleness`` is unavailable (``agent_authored_ratio`` was removed in
+  the v2 contract) and confidence must fall to ``low`` or ``medium``.
 """
 
 from __future__ import annotations

--- a/tests/test_cognitive_debt_api.py
+++ b/tests/test_cognitive_debt_api.py
@@ -74,9 +74,9 @@ def test_breakdown_endpoint_returns_file_breakdown():
         breakdown = resp["breakdown"]
         assert breakdown["meta"]["scope_kind"] == "file"
         assert breakdown["meta"]["scope_id"] == "src/copyclip/mcp_server.py"
-        assert breakdown["meta"]["contract_version"] == "v1"
+        assert breakdown["meta"]["contract_version"] == "v2"
         factor_ids = [f["factor_id"] for f in breakdown["factor_breakdown"]]
-        assert "agent_authored_ratio" in factor_ids
+        assert "agent_authored_ratio" not in factor_ids  # removed in v2
         assert "decision_gap" in factor_ids
 
 

--- a/tests/test_cognitive_debt_breakdown.py
+++ b/tests/test_cognitive_debt_breakdown.py
@@ -76,9 +76,9 @@ def test_missing_blame_signals_lower_confidence_but_keep_score_bounded(tmp_path)
     breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/mcp_server.py", now_ts=_NOW_TS)
     conn.close()
 
-    # agent_authored_ratio and review_staleness should be unavailable without blame
+    # review_staleness should be unavailable without blame (agent_authored_ratio
+    # was the dead W4-3 signal and is removed in the v2 contract).
     unavailable = {f["factor_id"] for f in breakdown["factor_breakdown"] if not f["signal_available"]}
-    assert "agent_authored_ratio" in unavailable
     assert "review_staleness" in unavailable
     # signal_coverage must be strictly below 1.0 and confidence not 'high'
     assert breakdown["score"]["signal_coverage"] < 1.0

--- a/tests/test_debt_integration.py
+++ b/tests/test_debt_integration.py
@@ -63,12 +63,12 @@ def test_quick_debt_signal_returns_severity_and_primary_signal(tmp_path):
     conn.close()
 
     assert signal is not None
-    # Under the v1 factor model the dark file lands in "high" or "critical"
-    # depending on how aged the seeded blame is at test runtime; the heaviest
-    # weighted factor for this fixture is the agent-authored ratio.
+    # Under the v2 factor model the dark file still lands "high"/"critical"; with
+    # the dead agent_authored_ratio removed, the heaviest surviving factor for
+    # this fixture is review staleness (the human-recency signal).
     assert signal["value"] >= 50
     assert signal["severity"] in {"high", "critical"}
-    assert signal["primary_signal"] == "agent_authored_ratio"
+    assert signal["primary_signal"] == "review_staleness"
 
 
 def test_quick_debt_signal_returns_none_for_unknown_path(tmp_path):

--- a/tests/test_debt_remediation.py
+++ b/tests/test_debt_remediation.py
@@ -84,7 +84,7 @@ def test_high_agent_ratio_produces_human_review_candidate(tmp_path):
     action_types = {c["action_type"] for c in plan["remediation_candidates"]}
     assert "review_this_recent_change" in action_types
     review = next(c for c in plan["remediation_candidates"] if c["action_type"] == "review_this_recent_change")
-    assert "agent_authored_ratio" in review["reduces_factors"]
+    assert "review_staleness" in review["reduces_factors"]
     assert review["expected_impact"]["score_delta"] < 0
     # must reference concrete commits in evidence
     assert any(ev.startswith("commit:") for ev in review["evidence"])

--- a/tests/test_debt_scenarios.py
+++ b/tests/test_debt_scenarios.py
@@ -53,9 +53,8 @@ def test_greenfield_file_lowers_confidence_without_zeroing_score(tmp_path):
     breakdown = build_debt_breakdown(conn, pid, "file", "src/copyclip/new/alpha.py", now_ts=STABLE_NOW_TS)
     conn.close()
 
-    # blame-dependent factors unavailable
+    # blame-dependent factor unavailable (agent_authored_ratio removed in v2)
     unavailable = {f["factor_id"] for f in breakdown["factor_breakdown"] if not f["signal_available"]}
-    assert "agent_authored_ratio" in unavailable
     assert "review_staleness" in unavailable
     # confidence must drop below "high"
     assert breakdown["score"]["confidence"] in {"low", "medium"}

--- a/tests/test_heat_decision_gap_gate.py
+++ b/tests/test_heat_decision_gap_gate.py
@@ -1,0 +1,59 @@
+"""Heat v2: decision_gap activation-gate.
+
+decision_gap fired on ~200/203 files because this repo barely links decisions —
+a project-level documentation fact wearing a per-file costume, saturating the
+score. When the PROJECT links no decisions at all, decision_gap is not a per-file
+signal: it deactivates (leaves the denominator) instead of firing at 100. When
+the project DOES use decisions, a file lacking one is a real gap and still fires.
+"""
+import sqlite3
+
+from copyclip.intelligence.db import init_schema
+from copyclip.intelligence.cognitive_debt import build_debt_breakdown
+
+NOW = 1_700_000_000.0
+
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    init_schema(c)
+    c.execute("INSERT INTO projects(id, root_path, name) VALUES(1,'/p','P')")
+    return c
+
+
+def _file(c, path, module):
+    c.execute("INSERT INTO files(project_id,path,language,size_bytes,mtime,hash) VALUES(1,?,?,?,?,?)", (path, "python", 100, 1.0, "h-" + path))
+    c.execute("INSERT INTO analysis_file_insights(project_id,path,module,imports_json,complexity) VALUES(1,?,?,?,?)", (path, module, "[]", 5))
+
+
+def _decision_gap(bd):
+    return next(f for f in bd["factor_breakdown"] if f["factor_id"] == "decision_gap")
+
+
+def test_deactivates_when_project_links_no_decisions():
+    c = _conn()
+    _file(c, "src/a.py", "a")
+    bd = build_debt_breakdown(c, 1, "file", "src/a.py", now_ts=NOW)
+    dg = _decision_gap(bd)
+    assert dg["signal_available"] is False  # project fact, not a per-file signal
+
+
+def test_fires_per_file_when_project_uses_decisions():
+    c = _conn()
+    _file(c, "src/a.py", "a")
+    _file(c, "src/b.py", "b")
+    c.execute("INSERT INTO decisions(project_id,title,summary,status) VALUES(1,'D','x','accepted')")
+    c.execute("INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(1,'file','src/a.py')")
+
+    a = _decision_gap(build_debt_breakdown(c, 1, "file", "src/a.py", now_ts=NOW))
+    b = _decision_gap(build_debt_breakdown(c, 1, "file", "src/b.py", now_ts=NOW))
+    assert a["signal_available"] is True and a["normalized_contribution"] == 0.0     # linked
+    assert b["signal_available"] is True and b["normalized_contribution"] == 100.0   # real gap
+
+
+def test_agent_authored_ratio_factor_is_gone():
+    c = _conn()
+    _file(c, "src/a.py", "a")
+    bd = build_debt_breakdown(c, 1, "file", "src/a.py", now_ts=NOW)
+    ids = {f["factor_id"] for f in bd["factor_breakdown"]}
+    assert "agent_authored_ratio" not in ids  # the dead W4-3 signal is deleted


### PR DESCRIPTION
The Pulso council's heat cleanup (the final piece of v0.1). Two changes to the live 8-factor heat engine, both **verified live** to decompress the distribution #152 named.

### 1. Delete `agent_authored_ratio` (was 0.22)
It was git-blame author-matched → reads **0/203** here (the human commits the AI's work under his own name): a dead, diluting signal (the W4-3 corpse, demoted to a factor). Its live `Co-Authored-By` replacement is the separate Pulso **"Last contact"** metric, not a heat factor. The 0.22 weight is redistributed to the **continuous, discriminating** factors (churn 0.18→0.26, review_staleness 0.15→0.22, ownership/blast/novelty up), **not** the binary gap factors — amplifying a binary near-constant is the whack-a-mole Richter warned about.

### 2. Gate `decision_gap`
It fired on **~200/203 files** (binary 0/100) — a project-level documentation fact in a per-file costume that saturated the score. It now **deactivates** (leaves the denominator) when the project links no accepted/resolved decisions to any file; when the project does use decisions, a file lacking one still fires at 100.

`CONTRACT_VERSION` **v1 → v2** (removing a factor is a major bump, per the contract's own rule). Ripple updated: `debt_remediation.py`, `COGNITIVE_DEBT_CONTRACT.md`, and the six debt tests that pinned the old factor.

### Verified live
Re-analyzed this repo: heat range **0..66** (v1 was a compressed, floored ~29-74) — files now discriminate across the full low→high range; `decision_gap` correctly deactivates here (the repo has decisions but links none to files).

TDD: `tests/test_heat_decision_gap_gate.py`. `pytest` 770 pass (3 known local-only artifacts). No bench `corpus_sha` regen needed — internal scoring, not the question corpus.

This completes **Pulso v0.1**: P1 ingest (#162) · P2 metric (#163) · P4 surface (#164) · heat v2 (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)