### PR TITLE
feat(pulso): v0.2.1 "Last visit" — decision ratification as a second contact clock

### DIFF
--- a/docs/superpowers/plans/2026-06-11-pulso-v02-last-visit-kickoff.md
+++ b/docs/superpowers/plans/2026-06-11-pulso-v02-last-visit-kickoff.md
@@ -1,0 +1,54 @@
+# Pulso v0.2.1 — "Last visit" (kickoff)
+
+**Fecha:** 2026-06-11
+**Estado:** Ratificado por Samuel tras consejo del roster + Axiom-0 (workflow `pulso-v02-council`).
+**Sigue a:** Pulso v0.1 (#161-#165, "Last contact"). **Extiende:** `intelligence/pulso.py`.
+
+---
+
+## 0. El invariante (Axiom-0, v0.2)
+
+> **Un testigo da fe de su acto; el resto es el sistema hablando en nombre del humano.**
+
+Avanza el invariante de v0.1 una capa: el substrato atestiguó **actos** (clics, preguntas, cambios de estado), nunca **holdings** (comprensión). Una métrica solo puede hablar la mitad atestiguada (el acto), nunca la inferida (comprensión), y debe cargar su distancia-al-referente en su propio nombre y forma.
+
+## 1. Lo que el consejo corrigió (unánime)
+
+**El substrato del cuaderno NO contiene comprensión.** Registra la relación humano↔*sistema* (actos contra una interfaz), no humano↔código. Un score de comprensión es **W4-3 una capa arriba, con un disfraz más fino** — rechazado.
+
+Los tres actos de testigo son tres verbos distintos, rankeados **ratificar > preguntar > got_it**, anti-correlacionados en autoridad-vs-precisión (Voronov) — **nunca se promedian en un escalar**:
+
+- **`got_it='got'`** — auto-reporte, **sin timestamp propio** (`set_got_it` no escribe `got_it_at` → decay incomputable), un loop cerrado que mide la persuasión del tutor. La cara honesta es **`'didnt'`** (confesión contra interés). → **diferido**.
+- **Preguntas** — rastro de *ausencia* (uno pregunta porque NO lo tiene); honesto solo como recencia de atención. → **diferido**.
+- **Ratificación de decisión** — el testigo más fuerte y **ya event-shaped + timestamped** (`decision_history`, append-only). El único shippable honesto hoy.
+
+## 2. Decisiones ratificadas (Samuel, 2026-06-11)
+
+**A. v0.2 = "Last visit", no un score de comprensión. ✅**
+Extender el reloj de contacto de v0.1 con la ratificación de decisión como **segundo reloj datado de "vuelta del humano"**. Recencia + review, **NUNCA comprensión**. Diferir got_it (solo la cara `'didnt'` luego) y preguntas; rechazar el score de comprensión (inconstruible honestamente desde este substrato).
+
+**B. Ship sobre el substrato de hoy. ✅ (Cassian/A, sobre Richter/B)**
+Construir sobre lo que hay: `decision_history` filtrado a `action='status_change'` (la ratificación humana vía DecisionConfirm; `created`/`ref_added`/`link_added` son de sistema) + `decision_refs` **directos** (`ref_type='file'`, `ref_value=path`), NUNCA los globs de `decision_links.target_pattern`. Diferir la instrumentación (un `witness_events` ledger, `got_it_at`) hasta admitir got_it/preguntas. Ganar la siguiente lección con datos reales.
+
+## 3. Arquitectura lockeada
+
+1. **Un acto solo da fe de su verbo.** La ratificación atestigua "el humano autoró un estado sobre una decisión ligada a este archivo en fecha T" — nunca "comprende el archivo". El nombre debe sostener el gap.
+2. **Composición en el `max(anchor)` existente, no un substrato nuevo** (Cassian). `contact_anchor = max(último_commit_humano, última_ratificación)`. Mismas reglas de silencio de v0.1 (ausencia → None, nunca 0).
+3. **Solo `decision_refs` directos** (identidad), no `decision_links` globs (fuzzy → sobreclamo).
+4. **Vocabulario honesto** (Wren): "Last visit" / acto "ratified"; jamás "understood"/"in sync"/"owned". Línea-confesión: *"A visit proves you were here, not that you understood."*
+5. **No promediar los tres actos en un escalar** — cuando entren got_it/preguntas, serán eventos datados+tipados, no pesos.
+
+## 4. El plan (v0.2.1, un PR)
+
+- `pulso.py · _last_ratified_decision(conn, project_id, path)` → `MAX(decision_history.created_at)` de decisiones con `action='status_change'` y un `decision_refs(ref_type='file', ref_value=path)` directo. None si no hay.
+- `build_last_contact`: computar `last_review`; el ancla de "vuelta" pasa a ser `max(last_human_commit, last_review)`; misma regla de silencio (si la última vuelta ≥ la ráfaga → silencio). Añadir `last_contact_source: 'git' | 'decision' | None` y `reviewed_days` (nullable). Las claves existentes (`last_contact_days`, `ai_burst_days`, `never_human_touched`) mantienen forma; `last_contact_days` ahora también cierra el gap en una ratificación.
+- `anchor.get_last_contact` + `prompts.py`: superficie "Last visit" — un commit O una decisión ratificada cuentan como vuelta; "ratified" es el más firme (acto de autoría); sigue siendo tiempo/review, **nunca comprensión**.
+- **DoD:** ratificación-tras-ráfaga rompe el silencio; ratificación-antes no; `max()` elige la más reciente entre git/decisión; ausencia → None; ningún string de salida contiene "comprehen"/"understood". `pytest -q` verde.
+
+## 5. Diferido (guard de scope)
+
+- **`got_it`** — necesita un `got_it_at` antes de poder hablar honesto; cuando entre, solo la cara `'didnt'` como marcador de "flagged-for-revisit", nunca `'got'` como comprensión.
+- **Preguntas** (engagement = rastro de ausencia) — recencia de atención, evento aparte.
+- **El score de comprensión** — NUNCA (inconstruible desde este substrato).
+- **El `witness_events` ledger unificado** (Richter) + instrumentación (`got_it_at`, actor en `decision_history`) — cuando se admitan got_it/preguntas.
+- **Curva de decay dedicada** — el reloj ya decae solo (los días crecen).

--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -264,14 +264,16 @@ def get_last_contact(
     *,
     limit: int = 20,
 ) -> dict[str, Any]:
-    """Read the Pulso 'Last contact' readings — files an AI burst last shaped that
-    the human has NOT returned to, longest gap first. Reads the persisted
-    `pulso_last_contact_days` (never the dead blame column). Silent files (no AI
-    burst, or the human already returned) are absent, not zero. Each row is
-    citable by `file_path`.
+    """Read the Pulso 'Last visit' readings — files an AI burst last shaped that
+    the human has NOT returned to, longest gap first. A return is a git commit OR
+    a ratified decision touching the file (`last_contact_source` says which).
+    Reads the persisted `pulso_last_contact_days` (never the dead blame column).
+    Silent files (no AI burst, or the human already returned) are absent, not
+    zero. Each row is citable by `file_path`.
 
-    Recency only: this proves elapsed time since the human's last touch, NOT that
-    the human understands the code. A timestamp cannot witness comprehension."""
+    Recency only: this proves elapsed time since the human last visited the file
+    (committed it, or ratified a decision on it), NOT that the human understands
+    the code. A visit proves you were here, not that you hold it."""
     from ..pulso import build_last_contact
 
     rows = conn.execute(
@@ -287,6 +289,8 @@ def get_last_contact(
             "file_path": path,
             "last_contact_days": days,
             "ai_burst_days": detail["ai_burst_days"] if detail else None,
+            "last_contact_source": detail["last_contact_source"] if detail else None,
+            "reviewed_days": detail.get("reviewed_days") if detail else None,
             "never_human_touched": detail["never_human_touched"] if detail else None,
         })
     return {"last_contact": items}

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -135,10 +135,15 @@ delegated, anchored to real evidence in the code.
   gives the module-level topology — all nodes map to real files (citable).
 - `get_last_contact` answers "what did AI change that I haven't gone back to?":
   files an AI burst last shaped (Co-Authored-By trailer) that the human has not
-  returned to, with the gap in days. It proves elapsed TIME only — say "you last
-  touched X N days ago; AI changed it since", NEVER "you don't understand X" or
-  "you've lost the thread". Files with no burst or where the human is current are
-  simply absent; an empty result means nothing to report, not a clean bill.
+  returned to, with the gap in days. A return is a git commit OR a ratified
+  decision on the file (`last_contact_source` = 'git' | 'decision'); a ratified
+  decision is the firmer signal (an authoring act over the human's own ledger).
+  It proves elapsed TIME and the fact of a visit ONLY — say "you last visited X
+  N days ago (committed it / ratified a decision on it); AI changed it since",
+  NEVER "you don't understand X", "you've lost the thread", or "you've reviewed X"
+  as a comprehension claim. A visit proves you were here, not that you hold it.
+  Files with no burst or where the human is current are simply absent; an empty
+  result means nothing to report, not a clean bill.
 - Use project-relative POSIX paths only; never absolute paths and never `..`.
 - Never retry a path that errored. If a tool returns nothing useful, move on.
 - Read before you answer. Do not answer a question about the code from memory or

--- a/src/copyclip/intelligence/pulso.py
+++ b/src/copyclip/intelligence/pulso.py
@@ -32,6 +32,27 @@ def _parse_git_iso(value: str | None) -> datetime | None:
         return None
 
 
+def _last_ratified_decision(conn, project_id: int, path: str) -> datetime | None:
+    """The most recent time the human RATIFIED a decision directly linked to this
+    file — the strongest witness act the cuaderno records (an authoring write over
+    the human's own ledger, already timestamped). 'status_change' is the human's
+    PATCH (DecisionConfirm); 'created'/'ref_added'/'link_added' are system writes.
+    Only DIRECT decision_refs (ref_type='file') count — never decision_links globs,
+    which are fuzzy and would overclaim the file edge. Witnesses review, not
+    comprehension."""
+    row = conn.execute(
+        """
+        SELECT MAX(dh.created_at)
+        FROM decision_history dh
+        JOIN decisions d ON d.id = dh.decision_id
+        JOIN decision_refs dr ON dr.decision_id = d.id AND dr.ref_type = 'file' AND dr.ref_value = ?
+        WHERE d.project_id = ? AND dh.action = 'status_change'
+        """,
+        (path, project_id),
+    ).fetchone()
+    return _parse_git_iso(row[0]) if row and row[0] else None
+
+
 def build_last_contact(
     conn, project_id: int, path: str, *, now: datetime | None = None
 ) -> dict[str, Any] | None:
@@ -71,16 +92,31 @@ def build_last_contact(
     if last_ai is None:
         return None
 
+    # v0.2: the human "returns" to a file via a commit OR a ratified decision (the
+    # strongest cuaderno witness). Take the later of the two as the contact event;
+    # on a tie, prefer the ratification (the firmer, authoring act).
+    last_review = _last_ratified_decision(conn, project_id, path)
+    last_return: datetime | None = None
+    source: str | None = None
+    if last_human is not None:
+        last_return, source = last_human, "git"
+    if last_review is not None and (last_return is None or last_review >= last_return):
+        last_return, source = last_review, "decision"
+
     # The human already returned since the most recent burst -> current, silent.
-    if last_human is not None and last_human >= last_ai:
+    if last_return is not None and last_return >= last_ai:
         return None
 
     def days_since(dt: datetime) -> int:
         return max(0, (now - dt).days)
 
-    contact_anchor = last_human if last_human is not None else last_ai
+    contact_anchor = last_return if last_return is not None else last_ai
     return {
         "last_contact_days": days_since(contact_anchor),
         "ai_burst_days": days_since(last_ai),
+        # 'git' (a commit) | 'decision' (a ratified decision) | None (never returned;
+        # gap measured since the burst). This proves return/review, never comprehension.
+        "last_contact_source": source,
+        "reviewed_days": days_since(last_review) if last_review is not None else None,
         "never_human_touched": last_human is None,
     }

--- a/tests/test_pulso_last_visit.py
+++ b/tests/test_pulso_last_visit.py
@@ -1,0 +1,77 @@
+"""Pulso v0.2.1 — "Last visit".
+
+A ratified decision touching a file (decision_history action='status_change' via a
+DIRECT decision_refs file link) is the strongest witness act the cuaderno records
+(an authoring write over the human's own ledger, already timestamped). It counts
+as the human RETURNING to a file — a second dated contact clock beside git. It
+proves return/review, NEVER comprehension. Silence rules unchanged.
+"""
+import sqlite3
+from datetime import datetime, timezone
+
+from copyclip.intelligence.db import init_schema
+from copyclip.intelligence.pulso import build_last_contact, _last_ratified_decision
+
+NOW = datetime(2026, 6, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    init_schema(c)
+    c.execute("INSERT INTO projects(id, root_path, name) VALUES(1,'/p','P')")
+    return c
+
+
+def _commit(c, sha, date_iso, ai, path):
+    c.execute("INSERT INTO commits(project_id,sha,author,date,message,ai_attributed) VALUES(1,?,?,?,?,?)", (sha, "S", date_iso, "m", 1 if ai else 0))
+    c.execute("INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) VALUES(1,?,?,0,0)", (sha, path))
+
+
+def _ratify(c, decision_id, path, when, *, action="status_change", with_ref=True):
+    c.execute("INSERT OR IGNORE INTO decisions(id,project_id,title,summary,status) VALUES(?,1,'D','x','accepted')", (decision_id,))
+    if with_ref:
+        c.execute("INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,'file',?)", (decision_id, path))
+    c.execute("INSERT INTO decision_history(decision_id,action,from_status,to_status,note,created_at) VALUES(?,?,?,?,?,?)", (decision_id, action, "proposed", "accepted", "n", when))
+
+
+def test_reads_human_status_change_via_direct_ref():
+    c = _conn()
+    _ratify(c, 1, "src/a.py", "2026-03-01 12:00:00")
+    dt = _last_ratified_decision(c, 1, "src/a.py")
+    assert dt is not None and (dt.year, dt.month) == (2026, 3)
+
+
+def test_ignores_system_actions_and_unlinked_decisions():
+    c = _conn()
+    _ratify(c, 1, "src/a.py", "2026-03-01 12:00:00", action="created")  # system action
+    assert _last_ratified_decision(c, 1, "src/a.py") is None
+    _ratify(c, 2, "src/a.py", "2026-04-01 12:00:00", with_ref=False)    # no direct file ref
+    assert _last_ratified_decision(c, 1, "src/a.py") is None
+
+
+def test_ratification_after_burst_breaks_the_silence():
+    c = _conn()
+    _commit(c, "ai", "2026-02-01 10:00:00 +0000", True, "src/a.py")
+    _ratify(c, 1, "src/a.py", "2026-03-01 12:00:00")  # reviewed after the burst
+    assert build_last_contact(c, 1, "src/a.py", now=NOW) is None  # current via review
+
+
+def test_ratification_is_the_latest_contact_when_git_is_older():
+    c = _conn()
+    _commit(c, "h", "2026-01-01 12:00:00 +0000", False, "src/a.py")   # human commit Jan
+    _ratify(c, 1, "src/a.py", "2026-02-01 12:00:00")                  # ratified Feb (later)
+    _commit(c, "ai", "2026-06-01 12:00:00 +0000", True, "src/a.py")   # AI burst Jun
+    res = build_last_contact(c, 1, "src/a.py", now=NOW)
+    assert res is not None
+    assert res["last_contact_source"] == "decision"
+    assert res["last_contact_days"] == 149   # since 2026-02-01
+    assert res["reviewed_days"] == 149
+
+
+def test_git_is_the_source_when_no_review():
+    c = _conn()
+    _commit(c, "h", "2026-01-01 12:00:00 +0000", False, "src/a.py")
+    _commit(c, "ai", "2026-06-01 12:00:00 +0000", True, "src/a.py")
+    res = build_last_contact(c, 1, "src/a.py", now=NOW)
+    assert res["last_contact_source"] == "git"
+    assert res["reviewed_days"] is None


### PR DESCRIPTION
The Pulso **v0.2 council** (7 personas + Axiom-0) corrected the framing; Samuel ratified.

**The correction:** a comprehension SCORE is unbuildable honestly from the cuaderno substrate — it records the human's relationship to the **system** (deeds against an interface), not to the **code**. A score would be W4-3 one layer up, "wearing a finer costume." The one honest v0.2 is to extend the contact clock with the **strongest witness act** the cuaderno already records.

**Axiom-0 (v0.2):** *a witness attests to its deed; the rest is the system speaking in the human's name.*

Ranked **ratify > ask > got_it**, never averaged (authority-of-witness and precision-of-referent are anti-correlated). got_it='got' is the weakest + most dangerous (self-report, **no `got_it_at` timestamp** → decay uncomputable, a closed loop measuring the tutor's persuasiveness); questions are the trace of *absence*. Only **decision ratification** is shippable honest today.

### What this ships
- `pulso._last_ratified_decision`: most recent human ratification (`decision_history.action='status_change'`) of a decision linked to a file via **direct** `decision_refs` (never `decision_links` globs).
- `build_last_contact`: the "human returned" anchor is now `max(last_human_commit, last_ratified_decision)`; same silence rules. Adds `last_contact_source` (`'git'|'decision'|None`) + `reviewed_days`; existing keys unchanged.
- Surfaced via `get_last_contact` + prompts as **"Last visit"** — a commit OR a ratified decision counts as a return, "ratified" the firmer — **recency/review only, never comprehension** (*"a visit proves you were here, not that you hold it"*).

### Deferred (with reasons)
got_it (self-report, no timestamp → only the `'didnt'` face later), question-engagement (trace of absence), **the comprehension score (never)**, a `witness_events` ledger + substrate instrumentation (`got_it_at`, an actor on `decision_history`).

### Verification
TDD: `tests/test_pulso_last_visit.py`. Verified live — the decision clock is correctly **silent** on this repo (no ratified decision-to-file links) and falls back to git. `pytest` 775 pass (3 known local-only artifacts). Additive, backward-compatible with v0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced "Last visit" tracking now incorporates human ratified decisions alongside git commits for more accurate contact recency metrics.

* **Documentation**
  * Added Pulso v0.2.1 — Last visit feature specification and implementation roadmap.

* **Tests**
  * Added comprehensive test coverage for last visit contact tracking logic and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->