### PR TITLE
feat(cuaderno): "Accepted, not decided" — deterministic rationale gate (comprehension ②)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-accepted-not-decided-kickoff.md
+++ b/docs/superpowers/plans/2026-06-12-accepted-not-decided-kickoff.md
@@ -1,0 +1,54 @@
+# Kickoff — "Accepted, not decided" (strategy ②, comprehension benchmark)
+
+> One PR. The wedge in one cited sentence. From `docs/superpowers/research/2026-06-12-code-comprehension-benchmark.md` strategy #2. Pairs with ① Walk the path (#167).
+
+## 1. The wedge this serves
+
+"Why does this exist? / Why was it done this way?" For AI-burst code the honest answer is often: *there is no recorded why — you accepted it, you did not decide it.* Today the tutor can recover decisions (`get_decisions`, `git_archaeology`) but nothing **deterministically** distinguishes *recovered intent* from *absence of intent* — so a model can paraphrase a plausible purpose and it passes every `quality.assess` check (null-vale's central trap: a confident invented "why" is the highest-authority comprehension-theater).
+
+## 2. Locked decisions
+
+1. **New deterministic anchor `anchor.get_rationale(conn, project_id, file)`** (DB-only, like `get_last_contact`). It computes a **verdict the system owns, not the model**: does recorded rationale exist for this file?
+2. **The verdict is the absence-gate** (the "modeled on `_floored_frame`" build the benchmark called the only mandatory new work in Phase 1). It is computed in Python from the ledger, so "accepted, not decided" is **honest by construction** — the model surfaces a constant string, it does not author the judgment.
+3. **Recorded rationale = a decision references the file** — directly (`decision_refs` `ref_type='file'`, the trustworthy edge per Pulso v0.2.1) OR via a commit that touched the file (`ref_type='commit'`). Commit *messages* are history, not deliberation; they do not count as "decided."
+4. **Three verdicts:**
+   - `recovered` — ≥1 decision references the file → present them cited.
+   - `accepted_not_decided` — the file has commits but **no** decision → stamp the constant. `ai_shaped` (any `commits.ai_attributed` touched it) is surfaced so the tutor can say "an AI burst shaped it", cited.
+   - `untracked` — no commits and no decisions → a note, **no stamp** (we cannot prove it was even accepted).
+5. **The stamp is a module constant**, the single source of truth, exact benchmark phrasing: `"no recorded rationale; this was accepted, not decided."`
+6. **No timestamp fix.** The benchmark flagged a `decision_history` `CURRENT_TIMESTAMP` (local) vs ISO-8601 UTC mismatch. **Verified empirically as a non-bug:** SQLite `CURRENT_TIMESTAMP` is UTC (not local); `pulso._parse_git_iso` already normalizes it to aware-UTC and orders correctly against git dates. The premise ("CURRENT_TIMESTAMP is local") was false. Documented, not patched.
+7. **Tutor rendering:** recovered decisions as a cited `citation_stack` ("this exists because…"); when `accepted_not_decided`, **one** `callout` carrying the stamp verbatim; NEVER invent a why. Guidance in `prompts.py`.
+
+## 3. Contract
+
+```
+get_rationale(conn, project_id, file)
+  -> {
+       "file": <posix path>,
+       "decisions": [ {id, title, status, source_type, summary, matched_via:"file"|"commit"}, ... ],
+       "commits":   [ {sha, author, date, message, ai_attributed}, ... ],   # cited by sha
+       "has_recorded_rationale": <bool>,
+       "ai_shaped": <bool>,
+       "verdict": "recovered" | "accepted_not_decided" | "untracked",
+       "stamp": "no recorded rationale; this was accepted, not decided." | None,
+     }
+```
+
+## 4. TDD plan (red → green)
+
+`tests/test_anchor_get_rationale.py`:
+- recovers a direct `file`-ref decision (`matched_via="file"`, verdict `recovered`, stamp None)
+- recovers a `commit`-ref decision for a commit that touched the file (`matched_via="commit"`)
+- `accepted_not_decided` when commits (incl. AI) touched the file but no decision → stamp == constant
+- `ai_shaped` True iff an `ai_attributed` commit touched it
+- `untracked` when no commits and no decisions → stamp None
+- the stamp equals the exact benchmark phrasing (a regression lock on the wording)
+- commits cited by sha
+
+`tests/test_cuaderno_tool_catalog.py`: add `get_rationale` to the names set + a dispatch test.
+
+Then: tool def + dispatch; `prompts.py` guidance; verify live on the real repo DB.
+
+## 5. Out of scope (this PR)
+
+**Compositor-level enforcement** of the absence-gate (rejecting/resealing a frame where the model emits a "why" claim about an `accepted_not_decided` file) — the bulletproof version null-vale wants; it touches the `quality.assess`/`_floored_frame` grounding loop and is the explicit hardening follow-up. This PR ships the deterministic *verdict* (the honest primitive) + strong prompt instruction. Also out: symbol-level rationale (file granularity only); the `decision_links` glob path (fuzzy, excluded by design).

--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -9,6 +9,12 @@ from pathlib import Path
 from typing import Any, Optional
 
 
+# The signature sentence of the wedge. A module constant so the verdict the
+# SYSTEM owns (not the model) has one source of truth — the model surfaces this
+# string verbatim, it never authors the judgment. Do not reword without a council.
+ACCEPTED_NOT_DECIDED = "no recorded rationale; this was accepted, not decided."
+
+
 def _safe_resolve(project_root: str, rel_path: str) -> Optional[Path]:
     """Resolve a project-relative path; return None if it escapes the root."""
     root = Path(project_root).resolve()
@@ -300,6 +306,100 @@ def get_call_path(
         "max_depth": max_depth,
         "truncated": truncated,
         "depth_capped": depth_capped,
+    }
+
+
+def get_rationale(
+    conn: sqlite3.Connection,
+    project_id: int,
+    file: str,
+) -> dict[str, Any]:
+    """Recover the recorded intent behind a file — the deliberation that was
+    delegated — and, when the ledger is SILENT, say so DETERMINISTICALLY so a
+    'why' can never be invented to fill the gap.
+
+    Recorded rationale means a decision REFERENCES the file: directly
+    (`decision_refs` ref_type='file' — the trustworthy file edge) or via a commit
+    that touched it (ref_type='commit'). Commit MESSAGES are history, not
+    deliberation; they do not count as 'decided'.
+
+    Verdict (computed here, never by the model):
+      - 'recovered'             — ≥1 decision references the file.
+      - 'accepted_not_decided'  — the file has commits but NO decision. The
+                                  signature of AI-burst code that was accepted, not
+                                  decided. `stamp` carries the constant sentence;
+                                  `ai_shaped` says whether an AI burst touched it.
+      - 'untracked'             — no commits and no decisions; we cannot prove it
+                                  was even accepted, so NO stamp, only a note.
+
+    Recovering recorded intent is not the human holding it. This proves what the
+    ledger witnessed, never comprehension."""
+    norm = file.replace("\\", "/")
+
+    commit_rows = conn.execute(
+        "SELECT c.sha, c.author, c.date, c.message, c.ai_attributed "
+        "FROM file_changes fc JOIN commits c ON c.sha = fc.commit_sha "
+        "WHERE fc.project_id=? AND fc.file_path=? ORDER BY c.date DESC",
+        (project_id, norm),
+    ).fetchall()
+    commits = [
+        {
+            "sha": r[0],
+            "author": r[1],
+            "date": r[2],
+            "message": r[3],
+            "ai_attributed": bool(r[4]),
+        }
+        for r in commit_rows
+    ]
+    commit_shas = [r[0] for r in commit_rows if r[0]]
+    ai_shaped = any(c["ai_attributed"] for c in commits)
+
+    decisions: dict[int, dict[str, Any]] = {}
+    # Direct file refs first — the trustworthy edge (matched_via wins on a tie).
+    for r in conn.execute(
+        "SELECT d.id, d.title, d.status, d.source_type, d.summary "
+        "FROM decisions d JOIN decision_refs dr ON dr.decision_id = d.id "
+        "WHERE d.project_id=? AND dr.ref_type='file' AND dr.ref_value=?",
+        (project_id, norm),
+    ).fetchall():
+        decisions[r[0]] = {
+            "id": r[0], "title": r[1], "status": r[2],
+            "source_type": r[3], "summary": r[4], "matched_via": "file",
+        }
+    # Commit refs: a decision about a commit that touched this file.
+    if commit_shas:
+        for did, title, status, src, summary, refval in conn.execute(
+            "SELECT d.id, d.title, d.status, d.source_type, d.summary, dr.ref_value "
+            "FROM decisions d JOIN decision_refs dr ON dr.decision_id = d.id "
+            "WHERE d.project_id=? AND dr.ref_type='commit'",
+            (project_id,),
+        ).fetchall():
+            if did in decisions or not refval:
+                continue
+            if any(sha.startswith(refval) for sha in commit_shas):
+                decisions[did] = {
+                    "id": did, "title": title, "status": status,
+                    "source_type": src, "summary": summary, "matched_via": "commit",
+                }
+
+    decision_list = [decisions[k] for k in sorted(decisions)]
+    has_rationale = bool(decision_list)
+    if has_rationale:
+        verdict, stamp = "recovered", None
+    elif commits:
+        verdict, stamp = "accepted_not_decided", ACCEPTED_NOT_DECIDED
+    else:
+        verdict, stamp = "untracked", None
+
+    return {
+        "file": norm,
+        "decisions": decision_list,
+        "commits": commits,
+        "has_recorded_rationale": has_rationale,
+        "ai_shaped": ai_shaped,
+        "verdict": verdict,
+        "stamp": stamp,
     }
 
 

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -141,6 +141,14 @@ delegated, anchored to real evidence in the code.
   runtime). If `truncated` (node cap) or `depth_capped` (callees below the limit)
   is set, say the slice is partial. To re-walk an AI burst, take an entry symbol
   from a `get_last_contact` file.
+- `get_rationale` answers "why does this exist / why this way" for a FILE and
+  returns a verdict the SERVER computes, not you. On 'recovered', emit the
+  `decisions` as a cited citation_stack ("this exists because…"). On
+  'accepted_not_decided', emit ONE callout carrying the `stamp` VERBATIM — do not
+  reword it, do not soften it, do not invent a purpose; if `ai_shaped`, add that
+  an AI burst shaped it, cited to a commit sha. On 'untracked', say there is no
+  recorded history. Recovering recorded intent is not the human holding it, and a
+  paraphrased "why" over a silent ledger is the worst thing you can emit.
 - `get_last_contact` answers "what did AI change that I haven't gone back to?":
   files an AI burst last shaped (Co-Authored-By trailer) that the human has not
   returned to, with the gap in days. A return is a git commit OR a ratified

--- a/src/copyclip/intelligence/cuaderno/tool_catalog.py
+++ b/src/copyclip/intelligence/cuaderno/tool_catalog.py
@@ -168,6 +168,29 @@ def build_tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "get_rationale",
+            "description": (
+                "Recover the recorded intent behind a FILE — the deliberation that "
+                "was delegated — and, when the ledger is silent, get a DETERMINISTIC "
+                "verdict so you never invent a 'why'. The server (not you) decides: "
+                "'recovered' (decisions reference the file → present them as a cited "
+                "citation_stack, 'this exists because…'); 'accepted_not_decided' "
+                "(committed but never deliberated → emit ONE callout carrying the "
+                "`stamp` VERBATIM, and if `ai_shaped` add 'an AI burst shaped it', "
+                "cited to a commit); 'untracked' (no history — say so). NEVER "
+                "paraphrase a plausible purpose: recovering recorded intent is not "
+                "the human holding it, and an invented why is the worst thing you "
+                "can emit. Use for 'why does this exist / why this way'."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "file": {"type": "string", "description": "Project-relative file path."},
+                },
+                "required": ["file"],
+            },
+        },
+        {
             "name": "get_decisions",
             "description": (
                 "Read the decision-ledger — the architectural decisions the human "
@@ -342,6 +365,8 @@ def dispatch_tool(
             max_depth=args.get("max_depth", 4),
             max_nodes=args.get("max_nodes", 40),
         )
+    if name == "get_rationale":
+        return anchor.get_rationale(conn, project_id, args["file"])
     if name == "get_decisions":
         return anchor.get_decisions(
             conn, project_id, status=args.get("status"), limit=args.get("limit", 50)

--- a/tests/test_anchor_get_rationale.py
+++ b/tests/test_anchor_get_rationale.py
@@ -1,0 +1,105 @@
+"""Accepted, not decided (comprehension strategy ②) — deterministic intent recovery.
+
+`get_rationale` recovers the recorded deliberation behind a file (decisions that
+reference it, directly or via a commit that touched it) and, when the ledger is
+SILENT, returns a deterministic verdict + a constant stamp so a 'why' can never be
+invented. Recovering recorded intent is not the human holding it; absence of a
+decision over committed code is the signature of accepted-not-decided AI-burst work.
+"""
+import sqlite3
+
+from copyclip.intelligence.cuaderno.anchor import get_rationale, ACCEPTED_NOT_DECIDED
+from copyclip.intelligence.db import init_schema
+
+
+def _conn():
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    cur = conn.execute("INSERT INTO projects(root_path,name) VALUES('/p','P')")
+    return conn, int(cur.lastrowid)
+
+
+def _commit(conn, pid, sha, path, *, ai=False, msg="m", date="2026-01-01 00:00:00 +0000"):
+    conn.execute(
+        "INSERT INTO commits(project_id,sha,author,date,message,ai_attributed) "
+        "VALUES(?,?,?,?,?,?)", (pid, sha, "S", date, msg, 1 if ai else 0))
+    conn.execute(
+        "INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) "
+        "VALUES(?,?,?,0,0)", (pid, sha, path))
+
+
+def _decision(conn, pid, title, ref_type, ref_value, *, status="accepted"):
+    did = conn.execute(
+        "INSERT INTO decisions(project_id,title,status) VALUES(?,?,?)",
+        (pid, title, status)).lastrowid
+    conn.execute(
+        "INSERT INTO decision_refs(decision_id,ref_type,ref_value) VALUES(?,?,?)",
+        (did, ref_type, ref_value))
+    return int(did)
+
+
+def test_recovers_direct_file_decision():
+    conn, pid = _conn()
+    _commit(conn, pid, "h1", "src/a.py")
+    _decision(conn, pid, "Use X", "file", "src/a.py")
+    out = get_rationale(conn, pid, "src/a.py")
+    assert out["verdict"] == "recovered"
+    assert out["has_recorded_rationale"] is True
+    assert [d["title"] for d in out["decisions"]] == ["Use X"]
+    assert out["decisions"][0]["matched_via"] == "file"
+    assert out["stamp"] is None
+
+
+def test_recovers_commit_linked_decision():
+    conn, pid = _conn()
+    _commit(conn, pid, "abc123def456", "src/a.py")
+    _decision(conn, pid, "Refactor", "commit", "abc123d")  # short sha prefix
+    out = get_rationale(conn, pid, "src/a.py")
+    assert out["verdict"] == "recovered"
+    assert out["decisions"][0]["matched_via"] == "commit"
+
+
+def test_accepted_not_decided_when_no_decision():
+    conn, pid = _conn()
+    _commit(conn, pid, "ai1", "src/a.py", ai=True)
+    out = get_rationale(conn, pid, "src/a.py")
+    assert out["verdict"] == "accepted_not_decided"
+    assert out["has_recorded_rationale"] is False
+    assert out["stamp"] == ACCEPTED_NOT_DECIDED
+    assert out["ai_shaped"] is True
+
+
+def test_ai_shaped_is_false_for_human_only_commits():
+    conn, pid = _conn()
+    _commit(conn, pid, "h1", "src/a.py", ai=False)
+    out = get_rationale(conn, pid, "src/a.py")
+    assert out["ai_shaped"] is False
+    assert out["verdict"] == "accepted_not_decided"
+
+
+def test_untracked_when_no_history_and_no_decision():
+    conn, pid = _conn()
+    out = get_rationale(conn, pid, "src/ghost.py")
+    assert out["verdict"] == "untracked"
+    assert out["stamp"] is None
+    assert out["commits"] == [] and out["decisions"] == []
+
+
+def test_decision_without_commits_is_still_recovered():
+    conn, pid = _conn()
+    _decision(conn, pid, "Plan Y", "file", "src/new.py")  # decided, not yet committed
+    out = get_rationale(conn, pid, "src/new.py")
+    assert out["verdict"] == "recovered"
+
+
+def test_stamp_is_the_exact_benchmark_phrasing():
+    # a regression lock: the signature sentence of the product must not drift
+    assert ACCEPTED_NOT_DECIDED == "no recorded rationale; this was accepted, not decided."
+
+
+def test_commits_are_cited_by_sha():
+    conn, pid = _conn()
+    _commit(conn, pid, "deadbeefcafe", "src/a.py", msg="init")
+    out = get_rationale(conn, pid, "src/a.py")
+    assert out["commits"][0]["sha"].startswith("deadbeef")
+    assert out["commits"][0]["message"] == "init"

--- a/tests/test_cuaderno_tool_catalog.py
+++ b/tests/test_cuaderno_tool_catalog.py
@@ -12,7 +12,7 @@ def test_tool_definitions_include_all_tools():
         "git_log", "git_blame", "git_diff", "find_tests", "get_module_graph",
         "get_decisions", "get_reverse_dependents", "git_archaeology",
         "get_story_snapshots", "get_reacquaintance_briefing", "get_risks",
-        "get_last_contact", "get_call_path",
+        "get_last_contact", "get_call_path", "get_rationale",
         "emit_block", "finish",
     }
 
@@ -133,6 +133,19 @@ def test_dispatch_get_call_path(tmp_path):
                         project_root=str(tmp_path), project_id=pid, conn=conn)
     assert [h["symbol"] for h in out["hops"]] == ["a", "b"]
     assert out["kind"] == "static_call_slice"
+
+
+def test_dispatch_get_rationale(tmp_path):
+    conn, pid = _conn_with_project(tmp_path)
+    conn.execute("INSERT INTO commits(project_id,sha,author,date,message,ai_attributed) "
+                 "VALUES(?,?,?,?,?,1)", (pid, "ai1", "S", "2026-01-01 00:00:00 +0000", "m"))
+    conn.execute("INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) "
+                 "VALUES(?,?,?,0,0)", (pid, "ai1", "src/a.py"))
+    conn.commit()
+    out = dispatch_tool("get_rationale", {"file": "src/a.py"},
+                        project_root=str(tmp_path), project_id=pid, conn=conn)
+    assert out["verdict"] == "accepted_not_decided"
+    assert out["ai_shaped"] is True
 
 
 def test_dispatch_get_risks(tmp_path):


### PR DESCRIPTION
## "Accepted, not decided" — comprehension strategy ②

The wedge in one cited sentence, from the [comprehension benchmark](docs/superpowers/research/2026-06-12-code-comprehension-benchmark.md). Pairs with ① Walk the path (#167).

### What

New DB-only anchor **`get_rationale(conn, project_id, file)`**. It recovers the recorded deliberation behind a file — decisions referencing it directly (`decision_refs` `ref_type='file'`) or via a commit that touched it — and computes a **verdict the server owns, not the model**:

| verdict | meaning | tutor renders |
|---|---|---|
| `recovered` | ≥1 decision references the file | cited `citation_stack`, "this exists because…" |
| `accepted_not_decided` | committed but never deliberated | ONE callout carrying `stamp` **verbatim** (+ "an AI burst shaped it" if `ai_shaped`) |
| `untracked` | no commits, no decisions | a note, **no stamp** |

### Why it's honest by construction

The deterministic verdict is the **absence-gate** the benchmark called the only mandatory new build in Phase 1. Because Python owns the judgment and the model only surfaces the constant `ACCEPTED_NOT_DECIDED = "no recorded rationale; this was accepted, not decided."`, a plausible "why" **cannot be invented** to pass `quality.assess` — null-vale's highest-authority comprehension-theater ("a confident invented why") is closed at the data layer, not by prompt-hope.

### No timestamp fix (verified non-bug)

The benchmark flagged a `decision_history` `CURRENT_TIMESTAMP` (local) vs ISO-8601 UTC mismatch. **Verified empirically as a non-bug:** SQLite `CURRENT_TIMESTAMP` is UTC (not local; measured delta 0.2s vs `utcnow`), and `pulso._parse_git_iso` already normalizes it to aware-UTC and orders correctly against git dates. The premise was false. Documented in the kickoff, not patched.

### Verified live

On the real repo DB: **282/283 files `accepted_not_decided`**, 1 `recovered` (the only file with a linked decision), `ai_shaped` everywhere — the honest picture that almost the entire codebase was *accepted, not decided* (the same ledger-not-linked-to-files gap that silenced Pulso "Last visit"'s decision clock).

### Tests

`tests/test_anchor_get_rationale.py` (8, incl. a regression lock on the exact stamp wording) + a dispatch/catalog test. Full suite: **797 passed, 1 skipped**; the 3 failures are the pre-existing local-env artifacts, none touched here.

### Deferred (hardening follow-up)

Compositor-level **enforcement** — rejecting/resealing a frame where the model emits a "why" claim about an `accepted_not_decided` file (touches the `quality.assess`/`_floored_frame` grounding loop). This PR ships the deterministic verdict primitive + strong prompt instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)