### PR TITLE
feat(cuaderno): "Hasn't been back" — the live entry cue (comprehension ③)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-hasnt-been-back-kickoff.md
+++ b/docs/superpowers/plans/2026-06-12-hasnt-been-back-kickoff.md
@@ -1,0 +1,54 @@
+# Kickoff — "Hasn't been back" (strategy ③, comprehension benchmark)
+
+> One PR. The entry cue that closes Phase 1. From `docs/superpowers/research/2026-06-12-code-comprehension-benchmark.md` strategy #3. Launches ① Walk the path (#167) and ② Accepted-not-decided (#168).
+
+## 1. The wedge this serves
+
+The proactive launching point: when the human opens the cuaderno or asks "where do I start / what should I revisit", surface the single most-overdue AI burst they have not returned to — and offer ONE followup that re-derives it (① the call slice, or ② the recorded rationale). The data already exists (Pulso `get_last_contact`); ③ turns it from an on-demand list into the curated, honest entry cue.
+
+## 2. The problem with reusing `get_last_contact` as-is
+
+`get_last_contact` SELECTS candidates by the persisted snapshot (`pulso_last_contact_days IS NOT NULL`) and appends every row — even ones where the LIVE recompute (`build_last_contact`) says the human is already current (it appends with `detail=None`). So it can surface a file as "N days unreturned" when the human came back. For an on-demand list that is a minor quirk; for a **proactive entry cue** it is exactly the comprehension-theater the benchmark warned about ("fires on a file the human revisited yesterday"). The cue must be live-verified.
+
+## 3. Locked decisions
+
+1. **New function `pulso.build_entry_cue(conn, project_id, *, now=None, stale_after_days=14)`** — picks the single most-overdue hasn't-been-back file, or `None` (silent).
+2. **Live verdict decides, snapshot only selects.** Candidates come from `pulso_last_contact_days IS NOT NULL`, but each is re-run through `build_last_contact` LIVE; only files where the human genuinely has not returned (non-`None`) survive. Pick the max live `last_contact_days` (tie → path asc).
+3. **Analysis-recency gate (the new build).** Each candidate carries the age of its `analysis_file_insights.updated_at` (UTC `CURRENT_TIMESTAMP`) as `analyzed_age_days`, and `stale = analyzed_age_days > stale_after_days`. The cue never asserts a current gap past what the substrate witnessed: when `stale`, the tutor scopes the claim to "as of the last analysis N days ago" instead of stating a present-tense gap. `updated_at` missing → `analyzed_age_days=None`, `stale=False` (no over-claim of staleness).
+4. **Honesty gate:** the FILE is stale, never the mind. This is recency + a launch, never a comprehension claim. NULL/absence stays silent.
+5. **New anchor `anchor.get_entry_cue(conn, project_id)`** → `{"entry_cue": <dict>|None}`. Tool + dispatch + `prompts.py` guidance: on a cue, emit ONE cited `callout` ("an AI burst shaped `X` ~N days ago; you haven't been back") + ONE `followups` item that launches `get_rationale` or `get_call_path` on that file — **never the playground**. Silent when `None`.
+
+## 4. Contract
+
+```
+build_entry_cue(conn, project_id, *, now=None, stale_after_days=14)
+  -> {
+       "file_path": <posix>,
+       "last_contact_days": <int, live>,
+       "ai_burst_days": <int, live>,
+       "last_contact_source": "git"|"decision"|None,
+       "never_human_touched": <bool>,
+       "analyzed_age_days": <int>|None,   # age of the file's snapshot
+       "stale": <bool>,                   # snapshot older than stale_after_days
+     }
+   | None    # nothing honest to surface
+
+get_entry_cue(conn, project_id) -> {"entry_cue": <the above>|None}
+```
+
+## 5. TDD plan (red → green)
+
+`tests/test_pulso_entry_cue.py`:
+- picks the most-overdue file among several live candidates
+- skips a file the human RETURNED to (live `None`) even if its snapshot column is a positive number; `None` if it was the only candidate
+- silent (`None`) when there are no candidates
+- carries `analyzed_age_days` and flips `stale` at the `stale_after_days` threshold
+- `updated_at` missing → `analyzed_age_days=None`, `stale=False`
+
+`tests/test_cuaderno_tool_catalog.py`: add `get_entry_cue` to the names set + a dispatch test.
+
+Then: tool def + dispatch; `prompts.py` guidance; verify live on the real repo DB.
+
+## 6. Out of scope (this PR)
+
+Fixing `get_last_contact`'s persisted-vs-live append quirk (separate, has tested behavior — the entry cue sidesteps it by recomputing live). Surfacing the cue automatically in the empty frame (the cue is a tool the tutor invokes on entry/"where do I start"; an always-on frame widget is a later surface change). Multi-file ranked cue list (one launch by design).

--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -523,6 +523,24 @@ def get_last_contact(
     return {"last_contact": items}
 
 
+def get_entry_cue(
+    conn: sqlite3.Connection,
+    project_id: int,
+) -> dict[str, Any]:
+    """The cuaderno's entry cue — the single most-overdue AI burst the human has
+    NOT returned to, the proactive launching point into re-deriving it. Returns
+    `{"entry_cue": None}` when there is nothing honest to surface.
+
+    LIVE-verified: the persisted snapshot only selects candidates, the live
+    contact verdict decides, so it never fires on a file the human revisited.
+    Scoped to the snapshot's age (`stale`, `analyzed_age_days`) so it never claims
+    a present-tense gap past what analysis witnessed. The FILE is stale, never the
+    mind — recency plus a launch into re-derivation, never a comprehension claim."""
+    from ..pulso import build_entry_cue
+
+    return {"entry_cue": build_entry_cue(conn, project_id)}
+
+
 def _parse_json_or_none(raw: Optional[str]) -> Any:
     if not raw:
         return None

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -149,6 +149,14 @@ delegated, anchored to real evidence in the code.
   an AI burst shaped it, cited to a commit sha. On 'untracked', say there is no
   recorded history. Recovering recorded intent is not the human holding it, and a
   paraphrased "why" over a silent ledger is the worst thing you can emit.
+- `get_entry_cue` is the ENTRY CUE — the proactive launching point. When the
+  human opens the cuaderno or asks "where do I start / what should I revisit /
+  what did I miss", call it. On a cue, emit ONE cited `callout` ("an AI burst
+  shaped `X` ~N days ago; you haven't been back") and ONE `followups` item that
+  launches `get_rationale` or `get_call_path` on that file — NEVER the playground.
+  If `stale` is true, scope the claim to "as of the last analysis ~N days ago",
+  never a present-tense gap. The FILE is stale, never the mind. A null `entry_cue`
+  means nothing to surface — stay silent, never invent one.
 - `get_last_contact` answers "what did AI change that I haven't gone back to?":
   files an AI burst last shaped (Co-Authored-By trailer) that the human has not
   returned to, with the gap in days. A return is a git commit OR a ratified

--- a/src/copyclip/intelligence/cuaderno/tool_catalog.py
+++ b/src/copyclip/intelligence/cuaderno/tool_catalog.py
@@ -277,6 +277,24 @@ def build_tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "get_entry_cue",
+            "description": (
+                "The cuaderno's ENTRY CUE: the single most-overdue AI burst the "
+                "human has not returned to — the proactive launching point. Use it "
+                "when the human opens the cuaderno or asks 'where do I start / what "
+                "should I revisit / what did I miss'. Live-verified (never fires on "
+                "a file the human came back to). On a cue, emit ONE cited callout "
+                "('an AI burst shaped `X` ~N days ago; you haven't been back') and "
+                "ONE followup that launches get_rationale or get_call_path on that "
+                "file — NEVER the playground. If `stale` is true, scope the claim "
+                "to 'as of the last analysis ~`analyzed_age_days` days ago', do not "
+                "assert a present-tense gap. The FILE is stale, never the mind — "
+                "recency and a launch, never a comprehension claim. A null "
+                "entry_cue means nothing to surface: stay silent, do not invent one."
+            ),
+            "input_schema": {"type": "object", "properties": {}},
+        },
+        {
             "name": "get_last_contact",
             "description": (
                 "Read Pulso 'Last contact': files an AI burst last shaped that the "
@@ -390,6 +408,8 @@ def dispatch_tool(
             kind=args.get("kind"), severity=args.get("severity"),
             limit=args.get("limit", 50),
         )
+    if name == "get_entry_cue":
+        return anchor.get_entry_cue(conn, project_id)
     if name == "get_last_contact":
         return anchor.get_last_contact(conn, project_id, limit=args.get("limit", 20))
     return {"error": "unknown_tool", "name": name}

--- a/src/copyclip/intelligence/pulso.py
+++ b/src/copyclip/intelligence/pulso.py
@@ -120,3 +120,64 @@ def build_last_contact(
         "reviewed_days": days_since(last_review) if last_review is not None else None,
         "never_human_touched": last_human is None,
     }
+
+
+def build_entry_cue(
+    conn,
+    project_id: int,
+    *,
+    now: datetime | None = None,
+    stale_after_days: int = 14,
+) -> dict[str, Any] | None:
+    """The cuaderno's entry cue: the single most-overdue AI burst the human has
+    NOT returned to — the proactive launching point into re-deriving it. Returns
+    None (silent) when there is nothing honest to surface.
+
+    Honest by construction:
+    - The persisted `pulso_last_contact_days` only SELECTS candidates; the LIVE
+      `build_last_contact` verdict DECIDES. A file the human came back to (live
+      None) is dropped even if its snapshot still shows a positive gap — so the
+      cue never fires on a file the human revisited.
+    - It scopes its claim to the snapshot's age: `analyzed_age_days` is the age of
+      `analysis_file_insights.updated_at`, and `stale` flags a snapshot older than
+      `stale_after_days`. Past that line the surface should hedge ("as of the last
+      analysis N days ago") rather than assert a present-tense gap it cannot
+      witness. A missing `updated_at` never over-claims staleness.
+
+    The FILE is stale, never the mind: recency plus a launch, never comprehension.
+    """
+    now = now or datetime.now(timezone.utc)
+
+    rows = conn.execute(
+        "SELECT path, updated_at FROM analysis_file_insights "
+        "WHERE project_id=? AND pulso_last_contact_days IS NOT NULL",
+        (project_id,),
+    ).fetchall()
+
+    candidates: list[tuple[str, str | None, dict[str, Any]]] = []
+    for path, updated_at in rows:
+        detail = build_last_contact(conn, project_id, path, now=now)
+        if detail is None:
+            continue  # human already returned / no burst — not hasn't-been-back
+        candidates.append((path, updated_at, detail))
+
+    if not candidates:
+        return None
+
+    # Most overdue first; ties broken by path for determinism.
+    candidates.sort(key=lambda c: (-c[2]["last_contact_days"], c[0]))
+    path, updated_at, detail = candidates[0]
+
+    parsed = _parse_git_iso(updated_at)
+    analyzed_age_days = max(0, (now - parsed).days) if parsed is not None else None
+    stale = analyzed_age_days is not None and analyzed_age_days > stale_after_days
+
+    return {
+        "file_path": path,
+        "last_contact_days": detail["last_contact_days"],
+        "ai_burst_days": detail["ai_burst_days"],
+        "last_contact_source": detail["last_contact_source"],
+        "never_human_touched": detail["never_human_touched"],
+        "analyzed_age_days": analyzed_age_days,
+        "stale": stale,
+    }

--- a/tests/test_cuaderno_tool_catalog.py
+++ b/tests/test_cuaderno_tool_catalog.py
@@ -12,7 +12,7 @@ def test_tool_definitions_include_all_tools():
         "git_log", "git_blame", "git_diff", "find_tests", "get_module_graph",
         "get_decisions", "get_reverse_dependents", "git_archaeology",
         "get_story_snapshots", "get_reacquaintance_briefing", "get_risks",
-        "get_last_contact", "get_call_path", "get_rationale",
+        "get_last_contact", "get_call_path", "get_rationale", "get_entry_cue",
         "emit_block", "finish",
     }
 
@@ -133,6 +133,24 @@ def test_dispatch_get_call_path(tmp_path):
                         project_root=str(tmp_path), project_id=pid, conn=conn)
     assert [h["symbol"] for h in out["hops"]] == ["a", "b"]
     assert out["kind"] == "static_call_slice"
+
+
+def test_dispatch_get_entry_cue(tmp_path):
+    conn, pid = _conn_with_project(tmp_path)
+    conn.execute("INSERT INTO analysis_file_insights"
+                 "(project_id,path,module,pulso_last_contact_days) VALUES(?,?,?,?)",
+                 (pid, "src/a.py", "m", 30))
+    conn.execute("INSERT INTO commits(project_id,sha,author,date,message,ai_attributed) "
+                 "VALUES(?,?,?,?,?,0)", (pid, "h", "S", "2026-01-01 10:00:00 +0000", "m"))
+    conn.execute("INSERT INTO commits(project_id,sha,author,date,message,ai_attributed) "
+                 "VALUES(?,?,?,?,?,1)", (pid, "ai", "S", "2026-02-01 10:00:00 +0000", "m"))
+    for sha in ("h", "ai"):
+        conn.execute("INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) "
+                     "VALUES(?,?,?,0,0)", (pid, sha, "src/a.py"))
+    conn.commit()
+    out = dispatch_tool("get_entry_cue", {},
+                        project_root=str(tmp_path), project_id=pid, conn=conn)
+    assert out["entry_cue"]["file_path"] == "src/a.py"
 
 
 def test_dispatch_get_rationale(tmp_path):

--- a/tests/test_pulso_entry_cue.py
+++ b/tests/test_pulso_entry_cue.py
@@ -1,0 +1,110 @@
+"""Hasn't been back (comprehension strategy ③) — the cuaderno's entry cue.
+
+`build_entry_cue` picks the single most-overdue AI burst the human has NOT
+returned to — LIVE-verified (the persisted snapshot only selects candidates; the
+live build_last_contact verdict decides), and scoped to the snapshot's age so it
+never claims a present-tense gap past what analysis witnessed. Silent when there
+is nothing honest to surface. The FILE is stale, never the mind.
+"""
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from copyclip.intelligence.db import init_schema
+from copyclip.intelligence.pulso import build_entry_cue
+
+NOW = datetime(2026, 6, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    init_schema(c)
+    c.execute("INSERT INTO projects(id, root_path, name) VALUES(1,'/p','P')")
+    return c
+
+
+def _insight(c, path, days, *, updated_at="2026-06-30 11:00:00"):
+    c.execute(
+        "INSERT INTO analysis_file_insights"
+        "(project_id, path, module, pulso_last_contact_days, updated_at) "
+        "VALUES(1,?,?,?,?)",
+        (path, "m", days, updated_at),
+    )
+
+
+def _commit(c, sha, date_iso, ai, path):
+    c.execute(
+        "INSERT INTO commits(project_id, sha, author, date, message, ai_attributed) "
+        "VALUES(1,?,?,?,?,?)", (sha, "S", date_iso, "m", 1 if ai else 0))
+    c.execute(
+        "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) "
+        "VALUES(1,?,?,0,0)", (sha, path))
+
+
+def _burst_unreturned(c, path, burst="2026-02-01 10:00:00 +0000"):
+    _commit(c, f"h-{path}", "2026-01-01 10:00:00 +0000", False, path)
+    _commit(c, f"ai-{path}", burst, True, path)  # AI after human -> hasn't been back
+
+
+def _burst_returned(c, path):
+    _commit(c, f"ai-{path}", "2026-02-01 10:00:00 +0000", True, path)
+    _commit(c, f"h2-{path}", "2026-03-01 10:00:00 +0000", False, path)  # human after burst
+
+
+def test_picks_the_most_overdue_live_candidate():
+    c = _conn()
+    _insight(c, "src/cold.py", 395)
+    _insight(c, "src/warm.py", 60)
+    # cold: human long ago, AI burst after -> the human hasn't been back for a year
+    _commit(c, "h-cold", "2025-06-01 10:00:00 +0000", False, "src/cold.py")
+    _commit(c, "ai-cold", "2026-01-01 10:00:00 +0000", True, "src/cold.py")
+    # warm: recent human contact, AI burst after -> a much shorter gap
+    _commit(c, "h-warm", "2026-05-01 10:00:00 +0000", False, "src/warm.py")
+    _commit(c, "ai-warm", "2026-06-01 10:00:00 +0000", True, "src/warm.py")
+    cue = build_entry_cue(c, 1, now=NOW)
+    assert cue["file_path"] == "src/cold.py"  # the longest human gap wins
+    assert cue["last_contact_days"] > 300
+
+
+def test_skips_a_file_the_human_returned_to_even_if_snapshot_says_otherwise():
+    c = _conn()
+    _insight(c, "src/back.py", 50)  # stale snapshot claims a 50-day gap
+    _burst_returned(c, "src/back.py")  # but live: the human came back after the burst
+    assert build_entry_cue(c, 1, now=NOW) is None
+
+
+def test_silent_when_no_candidates():
+    c = _conn()
+    _insight(c, "src/x.py", None)  # NULL snapshot is not a candidate
+    assert build_entry_cue(c, 1, now=NOW) is None
+
+
+def test_carries_age_and_flags_stale_snapshot():
+    c = _conn()
+    old = (NOW - timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
+    _insight(c, "src/cold.py", 100, updated_at=old)
+    _burst_unreturned(c, "src/cold.py")
+    cue = build_entry_cue(c, 1, now=NOW, stale_after_days=14)
+    assert cue["analyzed_age_days"] >= 29
+    assert cue["stale"] is True
+
+
+def test_fresh_snapshot_is_not_stale():
+    c = _conn()
+    fresh = (NOW - timedelta(days=2)).strftime("%Y-%m-%d %H:%M:%S")
+    _insight(c, "src/cold.py", 100, updated_at=fresh)
+    _burst_unreturned(c, "src/cold.py")
+    cue = build_entry_cue(c, 1, now=NOW, stale_after_days=14)
+    assert cue["analyzed_age_days"] <= 3
+    assert cue["stale"] is False
+
+
+def test_missing_updated_at_does_not_overclaim_staleness():
+    c = _conn()
+    c.execute(
+        "INSERT INTO analysis_file_insights"
+        "(project_id, path, module, pulso_last_contact_days, updated_at) "
+        "VALUES(1,?,?,?,NULL)", ("src/n.py", "m", 80))
+    _burst_unreturned(c, "src/n.py")
+    cue = build_entry_cue(c, 1, now=NOW)
+    assert cue["analyzed_age_days"] is None
+    assert cue["stale"] is False


### PR DESCRIPTION
## "Hasn't been back" — comprehension strategy ③ (closes Phase 1)

The proactive launching point, from the [comprehension benchmark](docs/superpowers/research/2026-06-12-code-comprehension-benchmark.md). Launches ① Walk the path (#167) and ② Accepted-not-decided (#168).

### What

New `pulso.build_entry_cue` + anchor **`get_entry_cue`**: pick the single most-overdue AI burst the human has not returned to (longest human gap), or stay silent.

### Why it's honest by construction

- **Live verdict decides, snapshot only selects.** Candidates come from `pulso_last_contact_days IS NOT NULL`, but each is re-run through `build_last_contact` LIVE; a file the human came back to (live `None`) is dropped **even if its snapshot still shows a positive gap**. This is exactly the staleness trap the benchmark flagged — `get_last_contact` appends those rows; the entry cue must not, because it is *proactive*.
- **Analysis-recency gate (the new build).** The cue carries `analyzed_age_days` (age of `analysis_file_insights.updated_at`) and a `stale` flag. Past `stale_after_days` the tutor hedges ("as of the last analysis ~N days ago") instead of asserting a present-tense gap it cannot witness. Missing `updated_at` never over-claims staleness.
- **The FILE is stale, never the mind.** Recency + a launch into re-derivation, never a comprehension claim. Null cue → silent.

The tutor calls it on entry / "where do I start", emits ONE cited callout + ONE followup that launches `get_rationale` or `get_call_path` on that file — **never the playground**.

### Verified live

Of 170 candidate files it surfaces `src/copyclip/__main__.py`: human **98 days** absent, AI burst recent (`ai_burst_days=0`), snapshot fresh (`stale=False`) — the honest "you haven't been back, but AI just changed it".

### Tests

`tests/test_pulso_entry_cue.py` (6) + a dispatch/catalog test. Full suite: **803 passed, 1 skipped**; failures are the 3 known local-env artifacts plus `test_reacquaintance_delivery` (a server-startup race — **passes in isolation**, not touched here).

### Phase 1 complete

①②③ of the benchmark are shipped. Deferred: Phase 2 (blast-radius predict, plan-stitching, teach-back) and the compositor-level enforcement hardening for ②.

🤖 Generated with [Claude Code](https://claude.com/claude-code)