### PR TITLE
feat(cuaderno): "What else does this touch?" — blast-radius reveal (comprehension ④)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-blast-radius-kickoff.md
+++ b/docs/superpowers/plans/2026-06-12-blast-radius-kickoff.md
@@ -1,0 +1,56 @@
+# Kickoff — "What else does this touch?" (strategy ④, comprehension benchmark)
+
+> One PR. The first generative-friction strategy (predict-then-reveal); opens Phase 2. From `docs/superpowers/research/2026-06-12-code-comprehension-benchmark.md` strategy #4.
+
+## 1. The wedge this serves
+
+"If you changed this signature, which call sites break?" The human PREDICTS the blast radius before the tool reveals it. Generative friction (the testing/pretesting effect) without the playground: the reveal is real, cited static topology, and the human's own guess sitting beside it does the pedagogical work the tool is forbidden to narrate.
+
+## 2. The constraint we must respect
+
+④ is generative — it needs the human to predict *before* the reveal. But the renderer is a single top-down scroll with **no withhold primitive** (§7 open question): a prediction prompt and its reveal in the same answer would print the answer key right below the question. And the §4 honesty line forbids turning any guess-vs-graph gap into a stored/shown number (that rebuilds the refused W4-3 comprehension score).
+
+## 3. Locked decisions
+
+1. **The reveal is a new deterministic anchor `anchor.get_blast_radius(conn, project_id, symbol, *, file=None)`** — honest by construction (the server computes the real radius; the model never assembles or hallucinates the edges). It reuses `get_callers` (the call sites that break on a signature change) and `get_reverse_dependents` (transitively impacted modules) on the symbol's file, returning one cited artifact with counts. `kind="static_blast_radius"`.
+2. **The prediction is delivered across TWO turns via the existing `followups` mechanism** — no new surface. Turn 1: the tutor POSES the prediction ("before I show you — which call sites break if you change `X`?") and stops; it does NOT reveal. Turn 2: the human answers in the ask bar, and the tutor calls `get_blast_radius` and reveals. The turn boundary IS the withhold; the answer key never prints under its own question.
+3. **Nothing is persisted.** The "witnessed prediction event, logged never scored" the benchmark mentions waits for the deferred witness-event ledger (Lyra's open question). v1 ships the reveal + the generative interaction shape with **zero persistence** — so there is nothing that could be read back as a per-file score. Event-logging arrives only with the ledger, and even then as an event, never a score.
+4. **Honesty gate:** the reveal is cited **static topology, NOT runtime** (`kind="static_blast_radius"`; the tutor must say so, never present it as observed execution). A matching prediction proves the guess matched *these cited edges*, **never** "you understand the blast radius." Reverse-dependents are module-level (a directory's reach), callers are symbol-level (exact call sites) — label each for what it is.
+5. **No two-state "change-it-and-see"** — `playgroundSlot` is single-slot; relaunch evicts the baseline (§6 cut). The reveal is the cited graph, not a perturbation.
+
+## 4. Contract
+
+```
+get_blast_radius(conn, project_id, symbol, *, file=None)
+  -> {
+       "symbol": <queried name>,
+       "entry": {name, kind, file_path, line_start, line_end} | None,
+       "entry_candidates": [ {name, file_path, line_start}, ... ],   # only when ambiguous
+       "direct_callers":   [ {name, kind, file_path, line_start}, ... ],  # break on signature change
+       "caller_count": <int>,
+       "impacted_modules": [ "<module>", ... ],   # transitive reverse-dependents
+       "target_module": "<module>" | "unknown",
+       "module_count": <int>,
+       "kind": "static_blast_radius",
+       "note": <str>?,    # set when the symbol is not indexed
+     }
+```
+
+## 5. TDD plan (red → green)
+
+`tests/test_anchor_blast_radius.py`:
+- direct callers listed, each with a citation (file + line)
+- impacted modules from reverse-dependents on the symbol's file
+- `caller_count` / `module_count`
+- unknown symbol → `entry=None`, empty, note
+- ambiguous entry lists `entry_candidates`
+- a leaf symbol in an isolated module → no callers, no impact
+- `kind == "static_blast_radius"`
+
+`tests/test_cuaderno_tool_catalog.py`: add `get_blast_radius` to the names set + a dispatch test.
+
+Then: tool def + dispatch; `prompts.py` predict-then-reveal guidance; verify live on the real repo DB.
+
+## 6. Out of scope (this PR)
+
+Persisting the prediction event (waits for the witness-event ledger; even then event-not-score). `find_tests`/`git_archaeology` enrichment of the reveal (the tutor can already call them; the deterministic core is callers + reverse-deps). File-level blast (use the existing `get_reverse_dependents`). Any in-frame curtain / guess-capture surface primitive (the turn boundary is the withhold for now).

--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -620,6 +620,77 @@ def get_reverse_dependents(
     return {"target_module": target_module, "impacted_modules": sorted(dependents)}
 
 
+def get_blast_radius(
+    conn: sqlite3.Connection,
+    project_id: int,
+    symbol: str,
+    *,
+    file: Optional[str] = None,
+) -> dict[str, Any]:
+    """What else does this touch — the STATIC blast radius of changing `symbol`:
+    the call sites that reference it (which break on a signature change, symbol
+    level) plus the modules transitively impacted (directory-level reach). The
+    REVEAL half of predict-then-reveal.
+
+    Honest by construction: the server computes the real edges (reusing
+    `get_callers` + `get_reverse_dependents`); the model never assembles or
+    hallucinates them. This is STATIC topology, NOT runtime — a matching
+    prediction proves the guess matched THESE cited edges, never 'you understand
+    the blast radius'. Ambiguous names resolve to the first by (file_path,
+    line_start) with the alternatives in `entry_candidates`; pass `file`."""
+    where = ["project_id = ?", "name = ?"]
+    params: list[Any] = [project_id, symbol]
+    if file:
+        where.append("file_path = ?")
+        params.append(file.replace("\\", "/"))
+    entry_rows = conn.execute(
+        "SELECT id, name, kind, file_path, line_start, line_end FROM symbols "
+        "WHERE " + " AND ".join(where) + " ORDER BY file_path, line_start",
+        params,
+    ).fetchall()
+
+    if not entry_rows:
+        return {
+            "symbol": symbol,
+            "entry": None,
+            "entry_candidates": [],
+            "direct_callers": [],
+            "caller_count": 0,
+            "impacted_modules": [],
+            "target_module": None,
+            "module_count": 0,
+            "kind": "static_blast_radius",
+            "note": (
+                f"no symbol named '{symbol}' in the index — try grep_symbols, or "
+                "ask about a file's blast radius via get_reverse_dependents."
+            ),
+        }
+
+    entry = entry_rows[0]
+    candidates = (
+        [{"name": r[1], "file_path": r[3], "line_start": r[4]} for r in entry_rows]
+        if len(entry_rows) > 1
+        else []
+    )
+    callers = get_callers(conn, project_id, symbol)["callers"]
+    rev = get_reverse_dependents(conn, project_id, entry[3])
+    impacted = rev["impacted_modules"]
+    return {
+        "symbol": symbol,
+        "entry": {
+            "name": entry[1], "kind": entry[2], "file_path": entry[3],
+            "line_start": entry[4], "line_end": entry[5],
+        },
+        "entry_candidates": candidates,
+        "direct_callers": callers,
+        "caller_count": len(callers),
+        "impacted_modules": impacted,
+        "target_module": rev["target_module"],
+        "module_count": len(impacted),
+        "kind": "static_blast_radius",
+    }
+
+
 def _run_git(project_root: str, *args: str) -> tuple[int, str, str]:
     proc = subprocess.run(
         ["git", *args],

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -149,6 +149,15 @@ delegated, anchored to real evidence in the code.
   an AI burst shaped it, cited to a commit sha. On 'untracked', say there is no
   recorded history. Recovering recorded intent is not the human holding it, and a
   paraphrased "why" over a silent ledger is the worst thing you can emit.
+- `get_blast_radius` answers "what else does this touch / what breaks if I change
+  X" — the call sites that break on a signature change (symbol-level) plus the
+  modules impacted (directory-level), all cited. Use it as PREDICT-THEN-REVEAL:
+  when the human asks what breaks, FIRST pose the prediction as ONE followup
+  ("before I show you — which call sites do you think break if you change `X`?")
+  and STOP without revealing; on the NEXT turn, after they answer, call this tool
+  and reveal the real cited graph beside their guess. It is STATIC topology, never
+  runtime — say so. A matching guess matched THESE cited edges, never "you
+  understand the impact", and you never score or grade the guess.
 - `get_entry_cue` is the ENTRY CUE — the proactive launching point. When the
   human opens the cuaderno or asks "where do I start / what should I revisit /
   what did I miss", call it. On a cue, emit ONE cited `callout` ("an AI burst

--- a/src/copyclip/intelligence/cuaderno/tool_catalog.py
+++ b/src/copyclip/intelligence/cuaderno/tool_catalog.py
@@ -206,6 +206,30 @@ def build_tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "get_blast_radius",
+            "description": (
+                "What else does this touch — the STATIC blast radius of changing a "
+                "symbol: the call sites that break on a signature change "
+                "(`direct_callers`, symbol-level, each a citation) plus the modules "
+                "transitively impacted (`impacted_modules`, directory-level reach). "
+                "This is the REVEAL half of a predict-then-reveal: when the human "
+                "asks 'what breaks if I change X', FIRST pose the prediction as a "
+                "followup ('before I show you — which call sites break?') and STOP; "
+                "reveal with this tool on the NEXT turn, beside their guess. It is "
+                "STATIC topology, NOT runtime — say so; a matching guess matched "
+                "THESE cited edges, never 'you understand the blast radius'. Do NOT "
+                "score the guess. An absent entry means the symbol is not indexed."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string", "description": "Symbol whose blast radius to compute."},
+                    "file": {"type": "string", "description": "Project-relative file to disambiguate a shared name. Optional."},
+                },
+                "required": ["symbol"],
+            },
+        },
+        {
             "name": "get_reverse_dependents",
             "description": (
                 "Modules transitively impacted if a file changes (reverse-dependents "
@@ -389,6 +413,8 @@ def dispatch_tool(
         return anchor.get_decisions(
             conn, project_id, status=args.get("status"), limit=args.get("limit", 50)
         )
+    if name == "get_blast_radius":
+        return anchor.get_blast_radius(conn, project_id, args["symbol"], file=args.get("file"))
     if name == "get_reverse_dependents":
         return anchor.get_reverse_dependents(conn, project_id, args["path"])
     if name == "git_archaeology":

--- a/tests/test_anchor_blast_radius.py
+++ b/tests/test_anchor_blast_radius.py
@@ -1,0 +1,106 @@
+"""What else does this touch (comprehension strategy ④) — the static blast radius.
+
+`get_blast_radius` is the REVEAL half of the predict-then-reveal loop: the call
+sites that break if a symbol's signature changes (symbol-level) plus the modules
+transitively impacted (reverse-dependents). Honest by construction — the server
+computes the real edges; the model never assembles them. It is STATIC topology,
+not runtime: a matching prediction matched THESE cited edges, never 'you
+understand the blast radius'.
+"""
+import sqlite3
+
+from copyclip.intelligence.cuaderno.anchor import get_blast_radius
+from copyclip.intelligence.db import init_schema
+
+
+def _conn():
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    cur = conn.execute("INSERT INTO projects(root_path,name) VALUES('/p','P')")
+    return conn, int(cur.lastrowid)
+
+
+def _sym(conn, pid, name, file, ls, le, kind="function"):
+    cur = conn.execute(
+        "INSERT INTO symbols(project_id,name,kind,file_path,line_start,line_end) "
+        "VALUES(?,?,?,?,?,?)", (pid, name, kind, file, ls, le))
+    return int(cur.lastrowid)
+
+
+def _calls(conn, pid, frm, to):
+    conn.execute(
+        "INSERT INTO symbol_edges(project_id,from_symbol_id,to_symbol_id,edge_type) "
+        "VALUES(?,?,?,'calls')", (pid, frm, to))
+
+
+def _module(conn, pid, name, prefix):
+    conn.execute("INSERT INTO modules(project_id,name,path_prefix) VALUES(?,?,?)",
+                 (pid, name, prefix))
+
+
+def _dep(conn, pid, frm, to):
+    conn.execute(
+        "INSERT INTO dependencies(project_id,from_module,to_module,edge_type) "
+        "VALUES(?,?,?,'import')", (pid, frm, to))
+
+
+def test_direct_callers_listed_with_citations():
+    conn, pid = _conn()
+    x = _sym(conn, pid, "x", "src/core/x.py", 10, 20)
+    a = _sym(conn, pid, "a", "src/api/a.py", 1, 5)
+    b = _sym(conn, pid, "b", "src/api/b.py", 1, 5)
+    _calls(conn, pid, a, x)
+    _calls(conn, pid, b, x)
+    out = get_blast_radius(conn, pid, "x")
+    names = {c["name"] for c in out["direct_callers"]}
+    assert names == {"a", "b"}
+    a_caller = next(c for c in out["direct_callers"] if c["name"] == "a")
+    assert a_caller["file_path"] == "src/api/a.py" and a_caller["line_start"] == 1
+    assert out["caller_count"] == 2
+    assert out["kind"] == "static_blast_radius"
+
+
+def test_impacted_modules_from_reverse_dependents():
+    conn, pid = _conn()
+    _sym(conn, pid, "x", "src/core/x.py", 1, 2)
+    _module(conn, pid, "core", "src/core/")
+    _module(conn, pid, "api", "src/api/")
+    _dep(conn, pid, "api", "core")  # api depends on core -> changing core impacts api
+    out = get_blast_radius(conn, pid, "x")
+    assert out["target_module"] == "core"
+    assert out["impacted_modules"] == ["api"]
+    assert out["module_count"] == 1
+
+
+def test_unknown_symbol_is_silent_with_note():
+    conn, pid = _conn()
+    out = get_blast_radius(conn, pid, "ghost")
+    assert out["entry"] is None
+    assert out["direct_callers"] == [] and out["impacted_modules"] == []
+    assert "note" in out
+
+
+def test_leaf_symbol_in_isolated_module_has_no_blast():
+    conn, pid = _conn()
+    _sym(conn, pid, "lonely", "src/x.py", 1, 2)
+    out = get_blast_radius(conn, pid, "lonely")
+    assert out["caller_count"] == 0
+    assert out["module_count"] == 0
+
+
+def test_ambiguous_entry_lists_candidates():
+    conn, pid = _conn()
+    _sym(conn, pid, "f", "src/x.py", 1, 2)
+    _sym(conn, pid, "f", "src/y.py", 1, 2)
+    out = get_blast_radius(conn, pid, "f")
+    assert len(out["entry_candidates"]) == 2
+    assert out["entry"]["file_path"] == "src/x.py"  # first by (file_path, line_start)
+
+
+def test_file_disambiguates_entry():
+    conn, pid = _conn()
+    _sym(conn, pid, "f", "src/x.py", 1, 2)
+    _sym(conn, pid, "f", "src/y.py", 1, 2)
+    out = get_blast_radius(conn, pid, "f", file="src/y.py")
+    assert out["entry"]["file_path"] == "src/y.py"
+    assert out["entry_candidates"] == []

--- a/tests/test_cuaderno_tool_catalog.py
+++ b/tests/test_cuaderno_tool_catalog.py
@@ -13,6 +13,7 @@ def test_tool_definitions_include_all_tools():
         "get_decisions", "get_reverse_dependents", "git_archaeology",
         "get_story_snapshots", "get_reacquaintance_briefing", "get_risks",
         "get_last_contact", "get_call_path", "get_rationale", "get_entry_cue",
+        "get_blast_radius",
         "emit_block", "finish",
     }
 
@@ -133,6 +134,21 @@ def test_dispatch_get_call_path(tmp_path):
                         project_root=str(tmp_path), project_id=pid, conn=conn)
     assert [h["symbol"] for h in out["hops"]] == ["a", "b"]
     assert out["kind"] == "static_call_slice"
+
+
+def test_dispatch_get_blast_radius(tmp_path):
+    conn, pid = _conn_with_project(tmp_path)
+    x = conn.execute("INSERT INTO symbols(project_id,name,kind,file_path,line_start,line_end) "
+                     "VALUES(?,?,?,?,?,?)", (pid, "x", "function", "src/x.py", 1, 5)).lastrowid
+    a = conn.execute("INSERT INTO symbols(project_id,name,kind,file_path,line_start,line_end) "
+                     "VALUES(?,?,?,?,?,?)", (pid, "a", "function", "src/a.py", 1, 5)).lastrowid
+    conn.execute("INSERT INTO symbol_edges(project_id,from_symbol_id,to_symbol_id,edge_type) "
+                 "VALUES(?,?,?,'calls')", (pid, a, x))
+    conn.commit()
+    out = dispatch_tool("get_blast_radius", {"symbol": "x"},
+                        project_root=str(tmp_path), project_id=pid, conn=conn)
+    assert [c["name"] for c in out["direct_callers"]] == ["a"]
+    assert out["kind"] == "static_blast_radius"
 
 
 def test_dispatch_get_entry_cue(tmp_path):


### PR DESCRIPTION
## "What else does this touch?" — comprehension strategy ④ (opens Phase 2)

The first **generative-friction** strategy (predict-then-reveal), from the [comprehension benchmark](docs/superpowers/research/2026-06-12-code-comprehension-benchmark.md).

### What

New deterministic anchor **`get_blast_radius(conn, project_id, symbol, *, file=None)`** — the call sites that break on a signature change (`direct_callers`, symbol-level, each cited) plus the modules transitively impacted (`impacted_modules`, directory-level). Reuses `get_callers` + `get_reverse_dependents`. `kind="static_blast_radius"`.

### How it ships generative friction without a withhold surface

The renderer has no in-frame curtain (§7 open question), and §4 forbids turning a guess-vs-graph gap into a number. So:

- **The reveal is honest by construction** — the server computes the real edges, the model never assembles or hallucinates them.
- **The prediction rides the existing `followups` mechanism across TWO turns** — pose-and-stop on turn 1 ("which call sites break if you change `X`?"), reveal on turn 2 with `get_blast_radius` beside the guess. **The turn boundary is the withhold**, so the answer key never prints under its own question. No new surface primitive.
- **Nothing is persisted.** The "witnessed prediction event" waits for the deferred witness-event ledger; v1 has zero persistence, so there is nothing that could be read back as the refused W4-3 per-file score. Event-logging arrives with the ledger, and even then as an event, never a score.

### Honesty gate

STATIC topology, **not runtime** (the tutor must say so). A matching guess matched *these cited edges*, never "you understand the blast radius". The tutor never scores or grades the guess.

### Verified live

`get_blast_radius('connect')` → **60 cited callers** across the repo (the module reach is empty here because the `modules` table isn't populated in this DB — it degrades cleanly; the symbol-level call sites are the strong signal).

### Tests

`tests/test_anchor_blast_radius.py` (6) + a dispatch/catalog test. Full suite: **811 passed, 1 skipped**; the 3 failures are the pre-existing local-env artifacts, none touched here.

### Deferred

Persisting the prediction event (witness-event ledger; event-not-score). `find_tests`/`git_archaeology` enrichment (the tutor can already call them). Any in-frame curtain/guess-capture surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)