### PR TITLE
feat(cuaderno): the commit change graph — ⑤ "the plan, reassembled" (council-corrected)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-commit-change-graph-kickoff.md
+++ b/docs/superpowers/plans/2026-06-12-commit-change-graph-kickoff.md
@@ -1,0 +1,180 @@
+# Kickoff — ⑤ "The plan, reassembled" → `get_commit_change_graph`
+
+**Date:** 2026-06-12
+**Strategy:** Comprehension benchmark ⑤ (delocalized-plan stitching), Phase 2.
+**Decision authority:** 6-lens roster council (Null Vale, Halberg, Voronov, Serrano, Wren, Cassian) — run `plan-reassembled-council`, 2026-06-12. One BLOCKER, five HIGH, unanimous on a single seam.
+
+---
+
+## The wedge this serves
+
+A solo dev re-owning code an AI wrote and they accepted. An AI burst's change is
+*delocalized* — scattered across the tree. Coming back, the human sees the files
+one at a time and cannot see the shape of the change. ⑤ lays the cited pieces of
+**one commit's change** side by side so the human can reassemble the intent
+*in their own head*. The tool exposes witnessed structure; the human supplies
+meaning. That division of labor is the doctrine.
+
+## What the council killed, and why
+
+The original design — `get_plan_reassembled`, a "spine" of files bound into "the
+plan" — **lies in the noun**, and the lie passes `quality.assess` because every
+citation is real:
+
+- **The seam (BLOCKER).** `symbol_edges` is HEAD-state and timeless;
+  `file_changes` is historical. The commit selects the *node-set* (witnessed,
+  past); a pre-existing *global* edge draws the *line* (witnessed at HEAD, not at
+  the burst). "This is the burst's plan structure" is the **unwitnessed product**
+  — the *mirror* of the banned co-occurrence glue (temporal selection + timeless
+  edge → a temporal membership claim).
+- **Edit-set ≠ intent-set (Voronov).** `file_changes(commit)` witnesses what was
+  *edited*; "plan" asserts what was *intended*. Planned-but-unedited files vanish;
+  incidentally-edited files sharing a HEAD edge get promoted into "the skeleton."
+- **Coverage (Halberg, empirical).** Only **45 / 2603** changed files have any
+  parsed symbol. **63% (49/78)** of multi-file AI bursts return an empty spine.
+  Silence on unparsed files reads as "no relationship" when the truth is "never
+  witnessed."
+- **The ledger is dead here (Cassian/Halberg).** `decision_refs` is **1-of-283**
+  non-silent. A decision-sourced edge can never fire on this repo and cannot be
+  TDD'd against real data.
+- **Naming (Wren).** "plan" is a mind-state word (the *authoring AI's* intent);
+  "reassembled" implies the human now holds it. Both violate the NEVER list.
+
+## The reframe (the locked decision)
+
+**The subject is THE COMMIT — never "the burst," never "the plan."**
+
+The anchor reports: *"Commit `<sha>` (AI-attributed) changed these N files. At
+HEAD, here is the cited call graph among them."* Every word is witnessed. The
+human knows their squash-merge workflow makes commit ≈ PR ≈ burst — the tool
+never makes that leap. This **dissolves the BLOCKER** (no claim crosses the seam)
+instead of patching it. Novelty over `get_module_graph`: the node-set is *scoped
+to one commit's `file_changes`* (a temporal axis module_graph lacks), partitioned
+with coverage + as-of-HEAD provenance.
+
+## Locked contract
+
+```
+get_commit_change_graph(conn, project_id, *, commit=None, file=None,
+                        max_files=60) -> dict
+```
+
+**Burst resolution precedence (Serrano):**
+1. `commit=` given → resolve that exact sha or sha-prefix. Not in `commits` →
+   `note`, empty graph.
+2. else `file=` given → most-recent **AI-attributed** commit touching it
+   (`file_changes` JOIN `commits` WHERE `ai_attributed=1` ORDER BY date DESC,
+   tie-break sha ASC). None → `note`, empty graph.
+3. else (neither) → `note: "pass a commit sha or a file"`, empty graph.
+   **No "most-recent AI overall" fallback** — it lands on docs/1-file commits and
+   2000+-file import blobs (Halberg). Paths normalized `\\`→`/` like all anchor.py.
+
+**Nodes** = distinct `file_path` in that commit's `file_changes`.
+
+**Edge** between changed files A,B iff a `symbol_edges` (edge_type='calls') row
+connects a symbol in A to a symbol in B, **both endpoints among the changed
+files**. Reuse `_file_graph`'s edge SQL scoped to the changed set; **do not author
+new edge logic** (Cassian). Each edge is **cited** (from-symbol@A:line →
+to-symbol@B:line) and carries **`as_of: "head"`** — a non-droppable temporal
+qualifier (Null Vale: the edge is a link AT HEAD, never proven AT the burst).
+
+**Partition (honest labels — Wren):**
+- `linked`: changed files with ≥1 witnessed as-of-HEAD edge to another changed
+  file. (NOT "spine" — that asserts essentialness the substrate never witnessed;
+  tests/config can be load-bearing.)
+- `co_changed_unlinked`: changed files with no such edge **in the current index**.
+  Each carries a `reason`:
+  - `not_indexed` — file has **zero** symbols in the index (deleted, non-code
+    `.md`/`.json`, or unparsed language). Absence-of-witness, not absence-of-link.
+  - `no_edge_in_index` — file HAS symbols but none edges to another changed file
+    *in the current index*. Still not "no relationship exists" — the index is
+    known-incomplete.
+  The label string surfaced is **verbatim**: `"co-changed; no witnessed
+  structural link in the current index"`. Never "no structural link exists."
+
+**Coverage (Halberg — required for Axiom-0):** return `changed_file_count` and
+`indexed_file_count` (files with ≥1 symbol) so an empty `linked` reads as
+"index incomplete," never "files unrelated."
+
+**Caps:** `linked` + `co_changed_unlinked` capped at `max_files` total; set
+`truncated: true` if exceeded (import-blob guard).
+
+**`kind: "static_change_graph"`** — keeps the family's anti-runtime `static_`
+prefix (`static_call_slice`, `static_blast_radius`); drops "plan". The docstring
++ tool description carry the family's anti-runtime sentence: *static intra-commit
+topology, NOT execution order, NOT a held plan.*
+
+**Return shape** (flat `edges` list — each inter-changed-file edge cited once,
+matching the `get_module_graph` nodes+edges family, rather than per-file nesting):
+```python
+{
+  "commit": {"sha","date","message","ai_attributed"} | None,
+  "resolved_via": "commit" | "file" | None,
+  "changed_file_count": int,
+  "indexed_file_count": int,
+  "linked": [file_path, ...],                  # files with >=1 inter-changed edge
+  "edges": [{"from_file","from_symbol","from_line",
+             "to_file","to_symbol","to_line","as_of":"head"}, ...],
+  "co_changed_unlinked": [{"file_path","reason"}, ...],
+  "kind": "static_change_graph",
+  "truncated": bool,
+  "note": str?,   # only when the burst could not be resolved
+}
+```
+
+## Cut to POST-SHIP (Cassian)
+
+- **`decision_ref` edge source** — 1-of-283 on this repo, untestable against real
+  data. v0.1 rests on `symbol_edges` only. (When the ledger comes alive — the
+  recurring substrate gap from ② — add it, typed distinctly, NOT `static_`.)
+- **Git-diff burst-scoped edges** (Null Vale's only-honest-witness path): parse
+  the commit's own diff for a reference *textually introduced in this commit* that
+  resolves to a symbol in another changed file — the sole way to witness "this
+  burst created this link." Real, but expensive (diff parse + ref resolution) and
+  still bounded by the 45/2603 coverage. Defer; name it as the upgrade.
+- **Multi-commit union** ("these 3 commits were one burst" is itself inference).
+  Resolve-one-commit-and-stop.
+
+## NEVER (additions for this anchor)
+
+- Never call the result "the plan" or say it is "reassembled" — the subject is the
+  **commit**; the human reassembles intent themselves.
+- Never drop the `as_of: "head"` stamp from an edge or render it as burst-internal.
+- Never let `co_changed_unlinked` read as "no structural link exists" — only "none
+  in the current index."
+- Never render the graph as execution/authoring order (static topology).
+- Never surface `additions`/`deletions`, edge weights, or any ranking — one step
+  from a refused per-file number.
+
+## Red tests (write first, watch fail)
+
+1. `linked` files carry **cited** edges (from/to symbol + line), `as_of="head"`.
+2. A co-changed file with symbols but no inter-changed-file edge →
+   `co_changed_unlinked` reason `no_edge_in_index`.
+3. A co-changed file with **zero** symbols → reason `not_indexed`.
+4. Resolution by explicit `commit=` (sha-prefix).
+5. Resolution by `file=` picks the most-recent **AI** commit touching it.
+6. `commit=` precedence when both passed.
+7. Neither passed → `note`, empty graph, no crash.
+8. `file=` with no AI commit → `note`, empty graph.
+9. Coverage counts: `changed_file_count` / `indexed_file_count` correct.
+10. Single-file commit → no edges, the one file in `co_changed_unlinked`.
+11. `kind == "static_change_graph"`; `max_files` truncation sets `truncated`.
+
+## Wiring (after green)
+
+- `tool_catalog.py`: definition (description encodes commit-not-plan,
+  as-of-HEAD, coverage, anti-runtime) + dispatch branch + names-set test.
+- `prompts.py`: "How to explore" bullet — emit `linked` as a cited
+  `citation_stack` / module-graph-style block, surface coverage when `linked`
+  empty, stamp as-of-HEAD, NEVER say "the plan," launchable from a
+  `get_entry_cue`/`get_last_contact` file.
+- `test_cuaderno_tool_catalog.py`: add `get_commit_change_graph` to the names
+  set + a dispatch test.
+
+## Definition of done
+
+Strict TDD green; full suite (minus 3 known local-env artifacts); live-verified on
+`./.copyclip/intelligence.db` (the 4-file `88e7358567` burst → full `linked`; the
+24-file `203ea885c0` teardown → all `co_changed_unlinked` with honest reasons);
+PR; squash-merge on green; sync main; delete branch; memory updated.

--- a/src/copyclip/intelligence/cuaderno/anchor.py
+++ b/src/copyclip/intelligence/cuaderno/anchor.py
@@ -691,6 +691,158 @@ def get_blast_radius(
     }
 
 
+def get_commit_change_graph(
+    conn: sqlite3.Connection,
+    project_id: int,
+    *,
+    commit: Optional[str] = None,
+    file: Optional[str] = None,
+    max_files: int = 60,
+) -> dict[str, Any]:
+    """The change graph of ONE commit: the files it changed, and the call edges
+    among them AS OF HEAD. The honest residue of "the plan, reassembled" — the
+    roster council (2026-06-12) found that calling a commit's changed-file set
+    "the plan" lies in the noun. `file_changes` witnesses an EDIT set; "plan"
+    asserts an INTENT set. And `symbol_edges` is HEAD-state, so a drawn line
+    proves "A calls B AT HEAD", never "this wiring belonged to that burst". So the
+    SUBJECT is the COMMIT, never "the plan": the human reassembles the intent
+    themselves; this only lays the cited pieces side by side.
+
+    Resolution (one commit, never a multi-commit "burst" — that is inference):
+      - `commit`: exact sha or sha-prefix (honored even if not AI-attributed; the
+        `ai_attributed` flag is reported, not used to filter).
+      - else `file`: the most-recent AI-attributed commit that touched it.
+      - else: a note — there is no honest default (a bare 'most recent' lands on
+        docs commits and import blobs).
+
+    Partition (honest by construction):
+      - `linked`: changed files with >=1 cited call edge to ANOTHER changed file.
+        Each `edges` row carries `as_of="head"` — the link is at HEAD, never
+        proven created within the commit. NOT called a "spine": linkedness is not
+        essentialness (a test or config file can be load-bearing).
+      - `co_changed_unlinked`: the rest, each with a `reason` —
+        'not_indexed' (no symbols at all: deleted, non-code, or unparsed
+        language) or 'no_edge_in_index' (has symbols, none link here). This is an
+        absence IN THE CURRENT INDEX, never "no structural link exists" (the
+        symbol index is known-incomplete).
+
+    `changed_file_count` vs `indexed_file_count` expose that coverage, so an empty
+    graph reads as "index incomplete", not "files unrelated". This is STATIC
+    intra-commit topology, NOT execution/authoring order, and NOT a held plan."""
+    max_files = max(1, int(max_files))
+
+    def _empty(note: str) -> dict[str, Any]:
+        return {
+            "commit": None,
+            "resolved_via": None,
+            "changed_file_count": 0,
+            "indexed_file_count": 0,
+            "linked": [],
+            "edges": [],
+            "co_changed_unlinked": [],
+            "kind": "static_change_graph",
+            "truncated": False,
+            "note": note,
+        }
+
+    if commit:
+        row = conn.execute(
+            "SELECT sha, date, message, ai_attributed FROM commits "
+            "WHERE project_id=? AND sha LIKE ? ORDER BY sha ASC LIMIT 1",
+            (project_id, commit.replace("\\", "/") + "%"),
+        ).fetchone()
+        if not row:
+            return _empty(f"no commit matching '{commit}' in the index.")
+        resolved_via = "commit"
+    elif file:
+        norm = file.replace("\\", "/")
+        row = conn.execute(
+            "SELECT c.sha, c.date, c.message, c.ai_attributed "
+            "FROM file_changes fc JOIN commits c ON c.sha = fc.commit_sha "
+            "WHERE fc.project_id=? AND fc.file_path=? AND c.ai_attributed=1 "
+            "ORDER BY c.date DESC, c.sha ASC LIMIT 1",
+            (project_id, norm),
+        ).fetchone()
+        if not row:
+            return _empty(f"no AI-attributed commit touched '{file}'.")
+        resolved_via = "file"
+    else:
+        return _empty(
+            "pass a commit sha or a file to resolve the change to one commit."
+        )
+
+    sha = row[0]
+    commit_meta = {
+        "sha": sha, "date": row[1], "message": row[2],
+        "ai_attributed": bool(row[3]),
+    }
+
+    changed = sorted({
+        r[0] for r in conn.execute(
+            "SELECT DISTINCT file_path FROM file_changes "
+            "WHERE project_id=? AND commit_sha=?",
+            (project_id, sha),
+        ).fetchall()
+    })
+    changed_set = set(changed)
+    indexed = {
+        r[0] for r in conn.execute(
+            "SELECT DISTINCT file_path FROM symbols WHERE project_id=?",
+            (project_id,),
+        ).fetchall()
+    } & changed_set
+
+    # Inter-changed-file call edges, AS OF HEAD. Pull all cross-file call edges
+    # and filter to the changed set in Python — avoids a giant IN(...) on a
+    # 2000-file import-blob commit and mirrors how _file_graph finishes in Python.
+    edges: list[dict[str, Any]] = []
+    linked_files: set[str] = set()
+    for s1f, s1n, s1l, s2f, s2n, s2l in conn.execute(
+        "SELECT s1.file_path, s1.name, s1.line_start, s2.file_path, s2.name, s2.line_start "
+        "FROM symbol_edges e "
+        "JOIN symbols s1 ON e.from_symbol_id = s1.id "
+        "JOIN symbols s2 ON e.to_symbol_id = s2.id "
+        "WHERE e.project_id=? AND e.edge_type='calls' AND s1.file_path <> s2.file_path "
+        "ORDER BY s1.file_path, s1.line_start, s2.file_path, s2.line_start",
+        (project_id,),
+    ).fetchall():
+        if s1f in changed_set and s2f in changed_set:
+            edges.append({
+                "from_file": s1f, "from_symbol": s1n, "from_line": s1l,
+                "to_file": s2f, "to_symbol": s2n, "to_line": s2l,
+                "as_of": "head",
+            })
+            linked_files.add(s1f)
+            linked_files.add(s2f)
+
+    linked = sorted(linked_files)
+    unlinked = [
+        {"file_path": f, "reason": "no_edge_in_index" if f in indexed else "not_indexed"}
+        for f in changed
+        if f not in linked_files
+    ]
+
+    truncated = False
+    if len(linked) + len(unlinked) > max_files:
+        truncated = True
+        linked = linked[:max_files]
+        unlinked = unlinked[: max(0, max_files - len(linked))]
+        keep = set(linked)
+        edges = [e for e in edges if e["from_file"] in keep and e["to_file"] in keep]
+
+    return {
+        "commit": commit_meta,
+        "resolved_via": resolved_via,
+        "changed_file_count": len(changed),
+        "indexed_file_count": len(indexed),
+        "linked": linked,
+        "edges": edges,
+        "co_changed_unlinked": unlinked,
+        "kind": "static_change_graph",
+        "truncated": truncated,
+    }
+
+
 def _run_git(project_root: str, *args: str) -> tuple[int, str, str]:
     proc = subprocess.run(
         ["git", *args],

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -158,6 +158,20 @@ delegated, anchored to real evidence in the code.
   and reveal the real cited graph beside their guess. It is STATIC topology, never
   runtime — say so. A matching guess matched THESE cited edges, never "you
   understand the impact", and you never score or grade the guess.
+- `get_commit_change_graph` answers "what was in that change / show me the shape of
+  commit X / re-walk the AI burst that touched this file". The SUBJECT is the
+  COMMIT, never "the plan": say what the commit changed and how those files call
+  each other — NEVER "here is the plan, reassembled" or anything implying the
+  human now holds it (they reassemble the intent themselves). Resolve by `commit`
+  or by `file`. Emit `linked` files as a cited `citation_stack`, ONE item per
+  `edges` row ("`from_symbol` calls `to_symbol`"), and say every edge is AS OF
+  HEAD — never proven created in that commit, never execution order. List
+  `co_changed_unlinked` files with their `reason` ("co-changed; no witnessed
+  structural link in the current index"), NEVER "no relationship exists". If
+  `linked` is empty, cite the coverage (`indexed_file_count` of
+  `changed_file_count`): the symbol index is incomplete, the files are not
+  "unrelated". Never surface additions/deletions or rank the files. A null/empty
+  result with a `note` means the burst could not be resolved — say so, do not guess.
 - `get_entry_cue` is the ENTRY CUE — the proactive launching point. When the
   human opens the cuaderno or asks "where do I start / what should I revisit /
   what did I miss", call it. On a cue, emit ONE cited `callout` ("an AI burst

--- a/src/copyclip/intelligence/cuaderno/tool_catalog.py
+++ b/src/copyclip/intelligence/cuaderno/tool_catalog.py
@@ -230,6 +230,38 @@ def build_tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "get_commit_change_graph",
+            "description": (
+                "The change graph of ONE commit: the files it changed plus the "
+                "call edges among them AS OF HEAD. Use for 'what was in that "
+                "change / show me the shape of commit X / the AI burst that "
+                "touched this file'. The SUBJECT is the COMMIT, never 'the plan' — "
+                "say what the commit changed and how those files call each other; "
+                "NEVER say you reassembled the plan or that the human now holds it "
+                "(they reassemble the intent themselves). Resolve by `commit` (sha "
+                "or prefix) or by `file` (its most-recent AI commit). `linked` "
+                "files have >=1 cited edge to another changed file — emit them as a "
+                "citation_stack, ONE item per `edges` row (from_symbol -> to_symbol "
+                "with lines); every edge is AS OF HEAD, never proven created in the "
+                "commit, and never execution order. `co_changed_unlinked` files "
+                "carry a `reason`: 'not_indexed' (no symbols — deleted/non-code/"
+                "unparsed) or 'no_edge_in_index' (has symbols, none link here) — "
+                "say 'co-changed; no witnessed structural link in the current "
+                "index', NEVER 'no relationship exists'. When `linked` is empty, "
+                "cite the coverage (`indexed_file_count`/`changed_file_count`): the "
+                "index is incomplete, the files are not 'unrelated'. Do NOT surface "
+                "additions/deletions or rank the files."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "commit": {"type": "string", "description": "Commit sha or prefix to graph. Optional."},
+                    "file": {"type": "string", "description": "Project-relative file; resolves to its most-recent AI-attributed commit. Optional."},
+                    "max_files": {"type": "integer", "default": 60, "description": "Cap on files returned (linked preferred); sets `truncated`."},
+                },
+            },
+        },
+        {
             "name": "get_reverse_dependents",
             "description": (
                 "Modules transitively impacted if a file changes (reverse-dependents "
@@ -415,6 +447,12 @@ def dispatch_tool(
         )
     if name == "get_blast_radius":
         return anchor.get_blast_radius(conn, project_id, args["symbol"], file=args.get("file"))
+    if name == "get_commit_change_graph":
+        return anchor.get_commit_change_graph(
+            conn, project_id,
+            commit=args.get("commit"), file=args.get("file"),
+            max_files=args.get("max_files", 60),
+        )
     if name == "get_reverse_dependents":
         return anchor.get_reverse_dependents(conn, project_id, args["path"])
     if name == "git_archaeology":

--- a/tests/test_anchor_commit_change_graph.py
+++ b/tests/test_anchor_commit_change_graph.py
@@ -1,0 +1,239 @@
+"""The commit change graph (comprehension strategy ⑤, council-corrected).
+
+`get_commit_change_graph` is the honest residue of "the plan, reassembled". The
+roster council (2026-06-12) found that calling a commit's changed-file set "the
+plan" lies in the noun: `file_changes` witnesses an EDIT set, "plan" asserts an
+INTENT set, and `symbol_edges` is HEAD-state — so a drawn line proves "A calls B
+AT HEAD", never "this wiring belonged to that burst". The reframe makes the
+COMMIT the subject: "commit X (AI-attributed) changed these files; at HEAD here is
+the cited call graph among them." Every claim witnessed; the human reassembles the
+intent themselves.
+
+Honesty invariants under test:
+  - every edge carries as_of="head" (the link is at HEAD, not proven at the burst)
+  - the unlinked bin distinguishes `not_indexed` (no symbols at all — deleted /
+    non-code / unparsed) from `no_edge_in_index` (has symbols, none link here),
+    and NEVER claims "no structural link exists"
+  - coverage counts (changed vs indexed) so an empty graph reads as "index
+    incomplete", not "files unrelated"
+  - the file= resolution only ever lands on an AI-attributed commit
+"""
+import sqlite3
+
+from copyclip.intelligence.cuaderno.anchor import get_commit_change_graph
+from copyclip.intelligence.db import init_schema
+
+
+def _conn():
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    cur = conn.execute("INSERT INTO projects(root_path,name) VALUES('/p','P')")
+    return conn, int(cur.lastrowid)
+
+
+def _sym(conn, pid, name, file, ls, le=None, kind="function"):
+    cur = conn.execute(
+        "INSERT INTO symbols(project_id,name,kind,file_path,line_start,line_end) "
+        "VALUES(?,?,?,?,?,?)", (pid, name, kind, file, ls, le or ls + 2))
+    return int(cur.lastrowid)
+
+
+def _calls(conn, pid, frm, to):
+    conn.execute(
+        "INSERT INTO symbol_edges(project_id,from_symbol_id,to_symbol_id,edge_type) "
+        "VALUES(?,?,?,'calls')", (pid, frm, to))
+
+
+def _commit(conn, pid, sha, date, ai, message="m"):
+    conn.execute(
+        "INSERT INTO commits(project_id,sha,author,date,message,ai_attributed) "
+        "VALUES(?,?,?,?,?,?)", (pid, sha, "S", date, message, 1 if ai else 0))
+
+
+def _changed(conn, pid, sha, *files):
+    for f in files:
+        conn.execute(
+            "INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) "
+            "VALUES(?,?,?,0,0)", (pid, sha, f))
+
+
+def test_linked_files_carry_cited_head_edges():
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "c1", "src/a.py", "src/b.py")
+    fa = _sym(conn, pid, "fa", "src/a.py", 10)
+    fb = _sym(conn, pid, "fb", "src/b.py", 20)
+    _calls(conn, pid, fa, fb)
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="c1")
+    assert out["resolved_via"] == "commit"
+    assert out["commit"]["sha"] == "c1" and out["commit"]["ai_attributed"] is True
+    assert set(out["linked"]) == {"src/a.py", "src/b.py"}
+    assert out["co_changed_unlinked"] == []
+    assert len(out["edges"]) == 1
+    e = out["edges"][0]
+    assert e["from_file"] == "src/a.py" and e["from_symbol"] == "fa" and e["from_line"] == 10
+    assert e["to_file"] == "src/b.py" and e["to_symbol"] == "fb" and e["to_line"] == 20
+    assert e["as_of"] == "head"
+    assert out["kind"] == "static_change_graph"
+
+
+def test_unlinked_with_symbols_is_no_edge_in_index():
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "c1", "src/a.py", "src/b.py", "src/c.py")
+    fa = _sym(conn, pid, "fa", "src/a.py", 10)
+    fb = _sym(conn, pid, "fb", "src/b.py", 20)
+    _sym(conn, pid, "fc", "src/c.py", 1)  # has a symbol, no edge to a/b
+    _calls(conn, pid, fa, fb)
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="c1")
+    assert set(out["linked"]) == {"src/a.py", "src/b.py"}
+    assert out["co_changed_unlinked"] == [{"file_path": "src/c.py", "reason": "no_edge_in_index"}]
+
+
+def test_unlinked_without_symbols_is_not_indexed():
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "c1", "src/a.py", "src/b.py", "README.md")
+    fa = _sym(conn, pid, "fa", "src/a.py", 10)
+    fb = _sym(conn, pid, "fb", "src/b.py", 20)
+    _calls(conn, pid, fa, fb)  # README.md has NO symbols at all
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="c1")
+    assert out["co_changed_unlinked"] == [{"file_path": "README.md", "reason": "not_indexed"}]
+
+
+def test_resolves_commit_by_sha_prefix():
+    conn, pid = _conn()
+    _commit(conn, pid, "abc123def456", "2026-01-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "abc123def456", "src/a.py", "src/b.py")
+    fa = _sym(conn, pid, "fa", "src/a.py", 1)
+    fb = _sym(conn, pid, "fb", "src/b.py", 1)
+    _calls(conn, pid, fa, fb)
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="abc123")
+    assert out["resolved_via"] == "commit"
+    assert out["commit"]["sha"] == "abc123def456"
+
+
+def test_file_resolution_picks_most_recent_ai_commit():
+    conn, pid = _conn()
+    _commit(conn, pid, "old", "2026-01-01 10:00:00 +0000", ai=True)
+    _commit(conn, pid, "new", "2026-03-01 10:00:00 +0000", ai=True)
+    _commit(conn, pid, "human", "2026-04-01 10:00:00 +0000", ai=False)  # newer but NOT ai
+    _changed(conn, pid, "old", "src/a.py", "src/b.py")
+    _changed(conn, pid, "new", "src/a.py", "src/d.py")
+    _changed(conn, pid, "human", "src/a.py")
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, file="src/a.py")
+    assert out["resolved_via"] == "file"
+    assert out["commit"]["sha"] == "new"  # most recent AI commit, human commit ignored
+
+
+def test_commit_takes_precedence_when_both_passed():
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    _commit(conn, pid, "c2", "2026-02-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "c1", "src/a.py", "src/b.py")
+    _changed(conn, pid, "c2", "src/x.py", "src/y.py")
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="c1", file="src/x.py")
+    assert out["commit"]["sha"] == "c1"
+
+
+def test_neither_arg_returns_note_no_crash():
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "c1", "src/a.py")
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid)
+    assert out["commit"] is None
+    assert out["resolved_via"] is None
+    assert out["linked"] == [] and out["edges"] == [] and out["co_changed_unlinked"] == []
+    assert "note" in out
+
+
+def test_file_with_no_ai_commit_returns_note():
+    conn, pid = _conn()
+    _commit(conn, pid, "human", "2026-01-01 10:00:00 +0000", ai=False)
+    _changed(conn, pid, "human", "src/a.py")
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, file="src/a.py")
+    assert out["commit"] is None
+    assert "note" in out
+
+
+def test_coverage_counts():
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "c1", "src/a.py", "src/b.py", "README.md")
+    _sym(conn, pid, "fa", "src/a.py", 1)
+    _sym(conn, pid, "fb", "src/b.py", 1)
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="c1")
+    assert out["changed_file_count"] == 3
+    assert out["indexed_file_count"] == 2  # README.md has no symbols
+
+
+def test_single_file_commit_has_no_edges():
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "c1", "src/solo.py")
+    _sym(conn, pid, "fsolo", "src/solo.py", 1)
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="c1")
+    assert out["linked"] == [] and out["edges"] == []
+    assert out["co_changed_unlinked"] == [{"file_path": "src/solo.py", "reason": "no_edge_in_index"}]
+    assert out["changed_file_count"] == 1
+
+
+def test_deletion_commit_is_all_not_indexed():
+    """A teardown burst (the 24-file '203ea885c0' analog): changed files no longer
+    have symbols in the index, so the graph is empty and every file is honestly
+    `not_indexed` — never 'no structural link exists'."""
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "c1", "src/gone1.py", "src/gone2.py")  # no symbols inserted
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="c1")
+    assert out["linked"] == [] and out["edges"] == []
+    assert out["indexed_file_count"] == 0
+    reasons = {u["file_path"]: u["reason"] for u in out["co_changed_unlinked"]}
+    assert reasons == {"src/gone1.py": "not_indexed", "src/gone2.py": "not_indexed"}
+
+
+def test_max_files_truncates_and_flags():
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    files = [f"src/f{i}.py" for i in range(5)]
+    _changed(conn, pid, "c1", *files)
+    for i, f in enumerate(files):
+        _sym(conn, pid, f"s{i}", f, 1)  # symbols but no inter-file edges
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="c1", max_files=2)
+    assert out["truncated"] is True
+    assert len(out["linked"]) + len(out["co_changed_unlinked"]) == 2
+
+
+def test_unknown_commit_returns_note():
+    conn, pid = _conn()
+    _commit(conn, pid, "c1", "2026-01-01 10:00:00 +0000", ai=True)
+    _changed(conn, pid, "c1", "src/a.py")
+    conn.commit()
+
+    out = get_commit_change_graph(conn, pid, commit="ZZZ")
+    assert out["commit"] is None
+    assert "note" in out

--- a/tests/test_cuaderno_tool_catalog.py
+++ b/tests/test_cuaderno_tool_catalog.py
@@ -13,7 +13,7 @@ def test_tool_definitions_include_all_tools():
         "get_decisions", "get_reverse_dependents", "git_archaeology",
         "get_story_snapshots", "get_reacquaintance_briefing", "get_risks",
         "get_last_contact", "get_call_path", "get_rationale", "get_entry_cue",
-        "get_blast_radius",
+        "get_blast_radius", "get_commit_change_graph",
         "emit_block", "finish",
     }
 
@@ -149,6 +149,27 @@ def test_dispatch_get_blast_radius(tmp_path):
                         project_root=str(tmp_path), project_id=pid, conn=conn)
     assert [c["name"] for c in out["direct_callers"]] == ["a"]
     assert out["kind"] == "static_blast_radius"
+
+
+def test_dispatch_get_commit_change_graph(tmp_path):
+    conn, pid = _conn_with_project(tmp_path)
+    conn.execute("INSERT INTO commits(project_id,sha,author,date,message,ai_attributed) "
+                 "VALUES(?,?,?,?,?,1)", (pid, "c1", "S", "2026-01-01 00:00:00 +0000", "m"))
+    for f in ("src/a.py", "src/b.py"):
+        conn.execute("INSERT INTO file_changes(project_id,commit_sha,file_path,additions,deletions) "
+                     "VALUES(?,?,?,0,0)", (pid, "c1", f))
+    a = conn.execute("INSERT INTO symbols(project_id,name,kind,file_path,line_start,line_end) "
+                     "VALUES(?,?,?,?,?,?)", (pid, "fa", "function", "src/a.py", 1, 5)).lastrowid
+    b = conn.execute("INSERT INTO symbols(project_id,name,kind,file_path,line_start,line_end) "
+                     "VALUES(?,?,?,?,?,?)", (pid, "fb", "function", "src/b.py", 1, 5)).lastrowid
+    conn.execute("INSERT INTO symbol_edges(project_id,from_symbol_id,to_symbol_id,edge_type) "
+                 "VALUES(?,?,?,'calls')", (pid, a, b))
+    conn.commit()
+    out = dispatch_tool("get_commit_change_graph", {"commit": "c1"},
+                        project_root=str(tmp_path), project_id=pid, conn=conn)
+    assert out["kind"] == "static_change_graph"
+    assert set(out["linked"]) == {"src/a.py", "src/b.py"}
+    assert out["edges"][0]["as_of"] == "head"
 
 
 def test_dispatch_get_entry_cue(tmp_path):


### PR DESCRIPTION
## What

Comprehension strategy **⑤** from the 2026-06-12 benchmark — the honest residue of *"the plan, reassembled."* New read-only anchor `get_commit_change_graph` + tutor wiring.

A 6-lens roster council (Null Vale, Halberg, Voronov, Serrano, Wren, Cassian) was run against the *actual* algorithm before a line was written. It returned **one BLOCKER, five HIGH**, unanimous on one seam.

## The council's finding (why the original design lied)

The original framing — `get_plan_reassembled`, a "spine" of files bound into "the plan" — **lies in the noun**, and the lie passes `quality.assess` because every citation is real:

- **The seam.** `symbol_edges` is HEAD-state and timeless; `file_changes` is historical. The commit selects the *node-set* (witnessed, past); a pre-existing *global* edge draws the *line* (witnessed at HEAD, not at the burst). "This is the burst's plan structure" is the **unwitnessed product** — the *mirror* of the banned co-occurrence glue.
- **Edit-set ≠ intent-set (Voronov).** `file_changes(commit)` witnesses what was *edited*; "plan" asserts what was *intended*.
- **Coverage (Halberg, empirical).** Only **45 / 2603** changed files have parsed symbols; **63%** of multi-file AI bursts return an empty spine. `decision_refs` is **1-of-283** (dead on this repo).
- **Naming (Wren).** "plan" / "reassembled" are mind-state words — they violate the NEVER list.

## The reframe

**The subject is THE COMMIT — never "the burst," never "the plan."** The anchor reports: *"commit X (AI-attributed) changed these files; at HEAD here is the cited call graph among them."* The human reassembles the intent themselves — the honest division of labor. This **dissolves the BLOCKER** rather than patching it.

## Contract (honest by construction)

- Resolve to **one** commit by sha/prefix, or by a file's most-recent **AI** commit; **no bare "most recent" default** (lands on docs commits / import blobs).
- `linked`: files with ≥1 **cited** inter-changed-file call edge; every edge carries **`as_of:"head"`** — a link at HEAD, never proven created in the commit.
- `co_changed_unlinked`: `reason` = `not_indexed` (no symbols: deleted/non-code/unparsed) vs `no_edge_in_index` (has symbols, none link here) — never *"no relationship exists."*
- Coverage counts (`indexed_file_count` / `changed_file_count`) so an empty graph reads *"index incomplete,"* not *"files unrelated."*
- `kind="static_change_graph"`; never execution order; never `additions`/`deletions`/ranking.

**Cut to post-ship:** `decision_ref` edges (dead ledger), git-diff burst-scoped edges (the only true burst-membership witness — Null Vale's path), multi-commit union.

## Verification

Live on the real repo DB:
- feature burst `88e7358567` → **4 linked, 10 cited `[head]` edges** (`analyzer._persist_last_contact → pulso.build_last_contact`, …)
- teardown `203ea885c0` → **24 `not_indexed`, indexed 0/24** (honest, not "unrelated")
- resolve-by-file → most-recent AI commit; neither-arg / unknown-commit → honest `note`, no crash

Strict TDD: 13 anchor tests (red→green) + catalog names/dispatch. **825 passed, 1 skipped, 3 known local-env artifacts** (live-smoke, live-e2e, provider model-name drift — none touch this code).

Kickoff: `docs/superpowers/plans/2026-06-12-commit-change-graph-kickoff.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `get_commit_change_graph` tool that builds a static change graph for a commit, resolving by exact SHA match or most recent AI-attributed commit touching a file. Returns linked files, co-changed files, cross-file symbol call edges, coverage counts, and truncation status.

* **Tests**
  * Added comprehensive test suite for commit change graph functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->