### PR TITLE
feat(cuaderno): ⑥ teach-back — the honest "say it back" (Phase 2 close)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-teachback-kickoff.md
+++ b/docs/superpowers/plans/2026-06-12-teachback-kickoff.md
@@ -1,0 +1,66 @@
+# Kickoff — ⑥ "Say it back" (teach-back), Phase 2 close
+
+**Date:** 2026-06-12
+**Strategy:** Comprehension benchmark ⑥ (active recall / teach-back), the last Phase-2 item.
+**Decision authority:** the witness-event-ledger junta + Axiom-0 adjudication (2026-06-12).
+
+---
+
+## The honest form (locked by Axiom-0 + Lyra)
+
+Teach-back's load-bearing claim — "you said X but the code does Y" — requires the
+system to read *what a human sentence meant* against the code. That is **INFER
+reading a mind the tutor swore never to read**; quality.assess closes over CITE∩CITE,
+and a teach-back diff has one inferred operand. So the active ingredient (the diff)
+**is** the forbidden act. Axiom-0: teach-back ships only as *cited-truth-beside-the-
+text-with-silence*. Lyra: the **generative friction IS the lever** — the human
+committing an explanation before the reveal is what teaches; **capture is
+pedagogically inert theater** and carries doctrine-cost. So we ship the friction,
+free, and capture nothing.
+
+## The consequence: ⑥ is NOT an anchor
+
+Every prior strategy (①–⑤) added a server-owned anchor because each had a real
+primitive to compute. ⑥ has none:
+
+- The **reveal** is already produced by `get_call_path` (the static cited slice —
+  ①) or `read_file`. Server-owned, grounded. No new computation.
+- The **prediction/explanation** is the human's, and is **never persisted, never
+  scored, never diffed**. Zero substrate touched → zero breach surface.
+
+So ⑥ is honest-by-construction in the same way ④ is: the reveal is a grounded
+anchor, the turn boundary is the withhold, and nothing about the human is stored.
+The only NEW thing is teaching the tutor *when and how* to deploy the teach-back
+frame. That is **prompt guidance**, not code — and that is correct, not a shortcut:
+there is nothing honest left to build.
+
+## What ships
+
+- **`prompts.py`**: a teach-back bullet in "How to explore", generalizing ④'s
+  predict-then-reveal to *explain-it-back*:
+  - pose ONE teach-back prompt as a followup ("before I show you — explain how `X`
+    works in your own words") and STOP;
+  - on the NEXT turn, reveal the cited ground truth (`get_call_path` / `read_file`)
+    **beside** their words and let THEM compare;
+  - **NEVER** diff the explanation against the code, **NEVER** tell them what they
+    missed or got wrong, **NEVER** score or grade it — judging what their sentence
+    meant is reading a mind the substrate cannot witness;
+  - persist nothing about what they said.
+- **`tests/test_cuaderno_prompt.py`**: lock the teach-back honesty invariants
+  (the pose exists; the reveal goes *beside*; never-diff / never-score present).
+
+## Deliberately NOT done
+
+- No `recall_pass` event, no ledger, no persistence — Axiom-0: an event table is
+  innocent but unnecessary here; the lever is the friction, not the capture.
+- No new anchor — the reveal reuses `get_call_path`.
+- No structural gate for "didn't score the human" — detecting a score/diff in prose
+  is itself INFER; it cannot be a CITE∩CITE gate. The discipline lives in the prompt
+  and is backed structurally only by the fact that nothing about the human is
+  persisted and every reveal block is already grounded by quality.assess.
+
+## Definition of done
+
+The new prompt tests red→green; full suite green (minus the 3 known local-env
+artifacts); PR; squash-merge; sync; memory updated. Phase 2 closes: ①–⑤ + both
+honesty gates + ⑥.

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -158,6 +158,16 @@ delegated, anchored to real evidence in the code.
   and reveal the real cited graph beside their guess. It is STATIC topology, never
   runtime — say so. A matching guess matched THESE cited edges, never "you
   understand the impact", and you never score or grade the guess.
+- TEACH-BACK is the same predict-then-reveal move, turned on understanding itself:
+  when the human is re-owning a piece of AI code or asks you to help them truly get
+  it, you MAY pose ONE teach-back prompt as a followup ("before I show you — explain
+  how `X` works in your own words") and STOP, revealing nothing. On the NEXT turn,
+  after they explain, reveal the cited ground truth BESIDE their words — walk the
+  real path with `get_call_path` (or `read_file`), every claim a citation, and let
+  THEM compare. NEVER diff their explanation against the code, NEVER tell them what
+  they missed or got wrong, NEVER score or grade it: judging what their sentence
+  meant is reading a mind the tutor cannot witness. The friction is theirs; your
+  only job is the citation, and you persist nothing about what they said.
 - `get_commit_change_graph` answers "what was in that change / show me the shape of
   commit X / re-walk the AI burst that touched this file". The SUBJECT is the
   COMMIT, never "the plan": say what the commit changed and how those files call

--- a/tests/test_cuaderno_prompt.py
+++ b/tests/test_cuaderno_prompt.py
@@ -40,6 +40,22 @@ def test_prompt_requires_answering_the_question_asked():
     assert "asked" in low or ("how" in low and "what" in low)
 
 
+def test_prompt_teaches_teachback_generative_friction():
+    # ⑥ teach-back: the generative pose ("explain ... in your own words") must be
+    # taught, and the reveal must land BESIDE the human's words (not as a verdict).
+    low = SYSTEM_PROMPT.lower()
+    assert "in your own words" in low
+    assert "beside" in low
+
+
+def test_prompt_forbids_grading_the_teachback_explanation():
+    # The teach-back diff ("you missed X") is INFER reading a mind — forbidden.
+    # The explanation is never scored, graded, or diffed against the code.
+    low = SYSTEM_PROMPT.lower()
+    assert "missed" in low or "got wrong" in low
+    assert "never score" in low or "never grade" in low or "do not score" in low
+
+
 def test_judge_prompt_demands_structured_verdict_and_responsiveness():
     from copyclip.intelligence.cuaderno.prompts import JUDGE_PROMPT
     low = JUDGE_PROMPT.lower()


### PR DESCRIPTION
## What

The last comprehension strategy, in the only form Axiom-0 + Lyra proved honest. **Closes Phase 2** (①–⑤ + both honesty gates #172/#173 + ⑥).

## Why it is prompt-only (not an anchor)

Teach-back's load-bearing claim — *"you said X but the code does Y"* — requires reading **what a human sentence meant** against the code. That is **INFER reading a mind** `quality.assess` swore never to read; a teach-back diff has one inferred operand, so it can never be a closed CITE∩CITE loop. **The diff IS the forbidden act.**

So ⑥ ships as **cited-truth-beside-the-text-with-silence**:
- **The reveal** is already `get_call_path` (the static cited slice — ①) / `read_file` — server-owned, grounded. No new computation.
- **The explanation** is the human's — never persisted, never scored, never diffed. Zero substrate touched → zero breach surface.

Honest-by-construction the same way ④ is: a grounded reveal + the turn boundary as the withhold + nothing stored. The only new thing is teaching the tutor *when/how* to deploy the frame — and **that is correct, not a shortcut: there is nothing honest left to build** (Lyra: the generative friction *is* the lever; capture is pedagogically inert theater that carries doctrine-cost).

## What ships

- **`prompts.py`**: a teach-back bullet generalizing ④'s predict-then-reveal to *explain-it-back* — pose "explain how `X` works in your own words" and STOP; next turn reveal the cited path **beside** their words; **NEVER** diff, **NEVER** tell them what they missed or got wrong, **NEVER** score/grade; persist nothing.
- **`tests/test_cuaderno_prompt.py`**: lock the honesty invariants (the pose exists; the reveal goes *beside*; never-diff/never-score present), red→green.

## Deliberately NOT done

- No `recall_pass` event / ledger (Axiom-0: an event table is innocent but unnecessary here — the lever is the friction).
- No new anchor (reveal reuses `get_call_path`).
- No "didn't score the human" structural gate — detecting a score/diff in prose is itself INFER; it cannot be a CITE∩CITE gate. The discipline lives in the prompt, backed structurally by: nothing about the human is persisted, and every reveal block is already grounded by `quality.assess`.

## Verification

New prompt tests red→green. **838 passed**, 1 skipped, 3 known local-env artifacts.

Kickoff: `docs/superpowers/plans/2026-06-12-teachback-kickoff.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)