### PR TITLE
feat(cuaderno): explain by altitude — the cognitive-load doctrine

### DIFF
--- a/docs/superpowers/2026-06-12-cognitive-load-doctrine.md
+++ b/docs/superpowers/2026-06-12-cognitive-load-doctrine.md
@@ -1,0 +1,81 @@
+# The cognitive-load doctrine — CopyClip's organizing invariant
+
+**Date:** 2026-06-12
+**Authority:** owner reframe + Voronov-led architectural pass (Voronov, Null Vale, Iris Tane). Unanimous; no contradiction (no Axiom-0 needed).
+
+---
+
+## The reframe (the owner's law)
+
+> "It is a code-UNDERSTANDING tool. Whether the human or the AI wrote the code is
+> irrelevant. It will always be useful to have a cuaderno-type tool that can
+> explain ANY piece of the code or project in a way that LOWERS its level of
+> complexity and the cognitive load it generates."
+
+The authorship axis ("did the human write/decide this?") is rejected as the wrong
+axis. The wedge "re-own YOUR accepted AI code" is demoted from organizing principle
+to one use case. The organizing goal is now: **lower the complexity and cognitive
+load of understanding any code, for anyone, regardless of authorship.**
+
+## THE INVARIANT
+
+> **An explanation may reduce only the COST OF REACHING the structure, never the
+> structure that must be reached. Every claim is a doorway with a live,
+> always-present descent to the cited real code — never a terminus.**
+
+Voronov's test: *legible = lossy compression with a recoverable original; theater =
+the same compression sold AS the original. The check is: is the original
+recoverable on descent?*
+
+## THE TRAP (never cross it)
+
+**Never measure or optimize "did cognitive load go down."** Load is a state in a
+skull, not a property of an utterance — and **a lie lowers load better than the
+truth** (the truth has irreducible structure to carry; the lie has none). Optimize
+load directly and **comprehension-theater is the global optimum**: a per-explanation
+load-delta is W4-3's refused per-file comprehension score, reborn. **Measure the
+staircase, never the climber.**
+
+Two faces of the trap (both are "grounded-but-illegible"):
+- **FLOAT** — a fluent summary with nothing reachable beneath it. (The classic IOED.)
+- **FLOOD** — everything dumped at once (e.g. a 10-citation wall). *Flooding is
+  hiding.* This was the live failure on 2026-06-12: high load, taught nothing.
+
+## THE MECHANISM (checkable, honest load-reduction)
+
+Progressive disclosure where **citation density RISES as abstraction falls**:
+- the lead carries **exactly one anchor** (a plain sentence that is a citation read
+  aloud, every noun true of the cited code — never a paraphrase standing in for one);
+- **a descent block exists for every code claim** — no altitude is empty;
+- each level **collapses into the one above without losing truth**, reachable in
+  bounded steps;
+- the descent path is **ALWAYS-PRESENT-THOUGH-COLLAPSED**, never optional/skippable
+  — if the real lines are skippable, altitude becomes a lid, not a staircase.
+
+**Enforcement (the honest-by-construction path):** the descent edge should be
+structurally REQUIRED, not prompt-hope — the way `quality.py` seals grounding and
+the ② gate seals the stamp. Without an enforced descent, load-reduction is
+unfalsifiable and ships theater.
+
+## Fate of the prior doctrine (clarified, not demolished)
+
+- **exposición, no autoría — UNTOUCHED.** It was never an authorship doctrine; it
+  is the fluency-vs-structure membrane confession. It loses only the word "autoría"
+  and its domain widens to all code.
+- **Axiom-0 — UNTOUCHED, now MORE load-bearing.** It becomes the sole governor
+  against IOED: the substrate cannot measure load, so the tool must not fake it.
+- **W4-3 (no comprehension score) — UNTOUCHED.** The load-delta IS the refused
+  score; the prohibition now reads at the per-explanation level.
+- **Generative friction (predict/teach-back) — DEMOTED.** From "the only teacher"
+  to one optional altitude-mechanism (an interaction shape that makes the descent
+  the human's). Honest form intact; primacy gone.
+
+## Consequences for the build
+
+1. Remove the authorship axis everywhere (no "did you write it?" branch).
+2. Rebuild the reveal/explanation around altitude: plain anchored lead → structure
+   → full cited detail on descent. Neither FLOAT nor FLOOD.
+3. Demote teach-back/predict-first to an optional self-test mode, never the spine.
+4. Eventually: a structural descent-edge requirement (honest-by-construction), so
+   "every claim is a doorway" is enforced, not hoped.
+5. Forbidden forever: any metric/score of "load reduced for this human."

--- a/docs/superpowers/plans/2026-06-12-teachback-kickoff.md
+++ b/docs/superpowers/plans/2026-06-12-teachback-kickoff.md
@@ -28,11 +28,17 @@ primitive to compute. ⑥ has none:
 - The **prediction/explanation** is the human's, and is **never persisted, never
   scored, never diffed**. Zero substrate touched → zero breach surface.
 
-So ⑥ is honest-by-construction in the same way ④ is: the reveal is a grounded
-anchor, the turn boundary is the withhold, and nothing about the human is stored.
-The only NEW thing is teaching the tutor *when and how* to deploy the teach-back
-frame. That is **prompt guidance**, not code — and that is correct, not a shortcut:
-there is nothing honest left to build.
+⑥'s REVEAL is grounded the way ④'s is (a server-owned anchor, the turn boundary
+the withhold, nothing about the human stored), and nothing it persists can breach.
+But its POSE is NOT honest the way ④'s is — **CORRECTION (Serrano, 2026-06-12):**
+④'s pose is PREDICT-from-name/site and needs no prior model; ⑥ shipped a RECALL
+pose ("explain in your own words") that presupposes a model the wedge reader —
+accepted-but-never-internalized code — does not have. Sharing a reveal anchor does
+NOT make them share an honest pose. The first live run proved it (the reader had
+nothing to recall). The cognitive-load doctrine
+(`docs/superpowers/2026-06-12-cognitive-load-doctrine.md`) supersedes this kickoff:
+teach-back is DEMOTED to an optional self-test, re-posed as predict-from-SITE, and
+the DEFAULT is to explain by altitude, not to quiz.
 
 ## What ships
 

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -100,11 +100,11 @@ WIDGET_RECOVERY_DIRECTIVE_RUN = (
 )
 
 SYSTEM_PROMPT = """\
-You are the cuaderno — a tutor that helps a single developer understand
-their own AI-generated codebase. The user is an archaeologist of their own
-output: they wrote the code with AI assistance, but do not remember the
-detail-level decisions. Your job is to recover the deliberation that was
-delegated, anchored to real evidence in the code.
+You are the cuaderno — a tutor that helps a developer understand a codebase with
+less cognitive load. It does not matter who wrote the code — the human, an AI, or
+someone else; your job is the same: make any piece of it LEGIBLE by lowering the
+COST OF REACHING its real structure, anchored to real evidence, without ever hiding
+the structure itself.
 
 ## Hard rules
 
@@ -124,6 +124,16 @@ delegated, anchored to real evidence in the code.
 6. Respond in the SAME LANGUAGE as the user's question. If the question is in
    Spanish, answer in Spanish; if in English, answer in English. This applies to
    every block, including kickers and follow-up labels.
+7. EXPLAIN BY ALTITUDE, never by hiding. Lower the COST OF REACHING the code, never
+   the code itself. Lead with ONE plain anchored sentence — a citation read in
+   plain words, every noun true of the cited lines — then DESCEND: structure, then
+   the full cited detail, citations growing DENSER as you go deeper. Every code
+   claim must keep a REACHABLE descent to real lines: no claim is a dead end, and
+   you never dump every citation at once (a wall hides by flooding exactly as a
+   bare summary hides by floating). You make the structure LEGIBLE; you never make
+   it FEEL simple by leaving the real code unreachable. You CANNOT SEE whether the
+   reader's load dropped — so never optimize for that feeling; optimize the path to
+   the code.
 
 ## How to explore (do this efficiently)
 
@@ -135,8 +145,12 @@ delegated, anchored to real evidence in the code.
   gives the module-level topology — all nodes map to real files (citable).
 - `get_call_path` walks the STATIC downstream call slice from a symbol (what it
   calls, transitively, capped) — the honest answer to "walk me through how X works
-  end-to-end". Emit it as an ordered `citation_stack`, ONE citation per hop, in the
-  order returned, each `note` naming what calls what. It is static call STRUCTURE,
+  end-to-end". Lead with ONE plain anchored sentence naming what the entry does
+  (true of its cited lines), THEN emit the slice as an ordered `citation_stack`, one
+  citation per hop in the order returned, each `note` naming what calls what — that
+  stack is the DESCENT, denser than the lead, never the greeting. Do not open with
+  the whole wall of hops at once (that is FLOOD — a wall hides as much as a bare
+  summary). It is static call STRUCTURE,
   never execution order — do NOT redraw it as a `sequence_diagram` (that reads as
   runtime). If `truncated` (node cap) or `depth_capped` (callees below the limit)
   is set, say the slice is partial. To re-walk an AI burst, take an entry symbol
@@ -158,16 +172,16 @@ delegated, anchored to real evidence in the code.
   and reveal the real cited graph beside their guess. It is STATIC topology, never
   runtime — say so. A matching guess matched THESE cited edges, never "you
   understand the impact", and you never score or grade the guess.
-- TEACH-BACK is the same predict-then-reveal move, turned on understanding itself:
-  when the human is re-owning a piece of AI code or asks you to help them truly get
-  it, you MAY pose ONE teach-back prompt as a followup ("before I show you — explain
-  how `X` works in your own words") and STOP, revealing nothing. On the NEXT turn,
-  after they explain, reveal the cited ground truth BESIDE their words — walk the
-  real path with `get_call_path` (or `read_file`), every claim a citation, and let
-  THEM compare. NEVER diff their explanation against the code, NEVER tell them what
-  they missed or got wrong, NEVER score or grade it: judging what their sentence
-  meant is reading a mind the tutor cannot witness. The friction is theirs; your
-  only job is the citation, and you persist nothing about what they said.
+- TEACH-BACK is an OPTIONAL self-test, never the default and never tied to who wrote
+  the code. ONLY if the human asks to test themselves, pose ONE prompt ("before I
+  show you — from its name and signature, what do you think `X` does?") and STOP.
+  Predict from the SITE, not from memory: a reader who never wrote the code has
+  nothing to recall but can still guess from the name. The DEFAULT is always to
+  explain by altitude (Hard rule 7), never to quiz. On the NEXT turn reveal the
+  cited truth BESIDE their guess; NEVER diff it against the code, NEVER tell them
+  what they missed or got wrong, NEVER score or grade it — judging what their guess
+  meant is reading a mind the tutor cannot witness. The friction, when invited, is
+  theirs; you persist nothing about what they said.
 - `get_commit_change_graph` answers "what was in that change / show me the shape of
   commit X / re-walk the AI burst that touched this file". The SUBJECT is the
   COMMIT, never "the plan": say what the commit changed and how those files call
@@ -287,9 +301,9 @@ not part of the format.
 
 ## Tone
 
-Editorial, plain, never hyped. The user knows what a function is — explain
-what they do not remember deciding, not what they already know. One short
-lead. Then paragraphs and citations. Conclude with 2-4 follow-up questions
-that go deeper, expressed as actions ("walk me through X", "show the commit
-that...").
+Editorial, plain, never hyped. The user knows what a function is — spend your words
+on what is hard to follow, not on what they already know. Lead with ONE short
+anchored sentence, then descend: paragraphs and citations, denser as you go.
+Conclude with 2-4 follow-up questions that go deeper, expressed as actions ("walk
+me through X", "show the commit that...").
 """

--- a/tests/test_cuaderno_prompt.py
+++ b/tests/test_cuaderno_prompt.py
@@ -40,12 +40,34 @@ def test_prompt_requires_answering_the_question_asked():
     assert "asked" in low or ("how" in low and "what" in low)
 
 
-def test_prompt_teaches_teachback_generative_friction():
-    # ⑥ teach-back: the generative pose ("explain ... in your own words") must be
-    # taught, and the reveal must land BESIDE the human's words (not as a verdict).
+def test_prompt_teachback_is_optional_predict_from_site():
+    # ⑥ corrected (cognitive-load doctrine): teach-back is an OPTIONAL self-test,
+    # predict-from-SITE not recall (a reader who never wrote the code has nothing
+    # to recall). The DEFAULT is to explain by altitude, never to quiz. The reveal
+    # lands BESIDE their guess.
     low = SYSTEM_PROMPT.lower()
-    assert "in your own words" in low
+    assert "self-test" in low or "optional" in low
+    assert "from its name" in low
     assert "beside" in low
+
+
+def test_prompt_teaches_altitude_and_descent():
+    # The organizing invariant: lower the COST OF REACHING the structure, never the
+    # structure; one anchored lead → descend; every claim has a reachable descent.
+    low = SYSTEM_PROMPT.lower()
+    assert "cost of reaching" in low
+    assert "descend" in low or "descent" in low
+    assert "legible" in low
+    assert "reachable" in low
+
+
+def test_prompt_forbids_optimizing_felt_load():
+    # Load is a state in a skull, not a property of an utterance; the substrate
+    # cannot see it, so the tool must never optimize for that feeling (= W4-3 score
+    # reborn). It optimizes the path to the code, not the felt drop.
+    low = SYSTEM_PROMPT.lower()
+    assert "load" in low
+    assert "cannot see" in low or "never optimize" in low or "feel simple" in low
 
 
 def test_prompt_forbids_grading_the_teachback_explanation():


### PR DESCRIPTION
## What

The owner **reframed the product's organizing principle** (overriding a junta): the cuaderno is a code-**understanding** tool — explain ANY piece of code lowering its complexity and cognitive load, **regardless of who wrote it**. The authorship axis ("did the human write/decide this?") is the wrong axis; "re-own YOUR AI code" is demoted from organizing principle to one use case.

A Voronov-led architectural pass (Voronov, Null Vale, Iris Tane; unanimous, no Axiom-0 needed) locked the invariant and proved the reframe **clarifies** the prior doctrine rather than killing it. Full lock: `docs/superpowers/2026-06-12-cognitive-load-doctrine.md`.

## The invariant

> An explanation may reduce only the **COST OF REACHING** the structure, never the structure that must be reached. Every claim is a doorway with a live, always-present descent to the cited code — never a terminus.

Voronov's test: *legible = lossy compression with a recoverable original; theater = the compression sold AS the original. Check: is the original recoverable on descent?*

## The trap (never cross)

Never measure/optimize "did cognitive load go down." A **lie lowers load better than the truth** (truth carries irreducible structure; the lie carries none), so comprehension-theater is the *global optimum*, and a per-explanation load-delta **is the W4-3 comprehension score reborn**. Two faces — **FLOAT** (fluent summary, nothing beneath) and **FLOOD** (everything dumped at once — the live failure: a 10-citation wall). *Measure the staircase, never the climber.*

## This gate (prompt only, no anchor)

- **new Hard rule 7** — explain by altitude: one anchored lead → descend, citation density rising, a **reachable** descent for every code claim, never optimize felt load.
- **fix the `get_call_path` bullet** — it suppressed the lead and opened with the whole hop-stack (FLOOD).
- **reframe the intro + Tone** off authorship onto cognitive load.
- **demote teach-back** to an OPTIONAL self-test, re-posed **predict-from-SITE** (recall is empty for a reader who never wrote the code — the live finding).
- **correct the false ⑥ kickoff claim** (⑥ shares ④'s reveal, not its honest pose — Serrano).

## Prior doctrine: clarified, not demolished

- **exposición, no autoría** — untouched (loses only "autoría"; it was never an authorship doctrine, it's the fluency-vs-structure membrane).
- **Axiom-0** — untouched, now the *sole shield* against IOED (the substrate can't measure load, so don't fake it).
- **W4-3** — untouched (the load-delta IS the refused score).
- **generative friction (predict/teach-back)** — demoted from "the only teacher" to one optional altitude-mechanism.

## Verification

TDD via prompt-content locks (altitude/descent present; felt-load optimization forbidden; teach-back optional predict-from-site), red→green. **840 passed**, 1 skipped, 3 known local-env artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)