### PR TITLE
feat(cuaderno): the open-order nudge — Level 2 of the cognitive-load doctrine

### DIFF
--- a/docs/superpowers/2026-06-12-cognitive-load-doctrine.md
+++ b/docs/superpowers/2026-06-12-cognitive-load-doctrine.md
@@ -52,10 +52,25 @@ Progressive disclosure where **citation density RISES as abstraction falls**:
 - the descent path is **ALWAYS-PRESENT-THOUGH-COLLAPSED**, never optional/skippable
   — if the real lines are skippable, altitude becomes a lid, not a staircase.
 
-**Enforcement (the honest-by-construction path):** the descent edge should be
-structurally REQUIRED, not prompt-hope — the way `quality.py` seals grounding and
-the ② gate seals the stamp. Without an enforced descent, load-reduction is
-unfalsifiable and ships theater.
+**Enforcement — what is structurally sealable (Level-2 design council, 2026-06-12):**
+legibility itself is NOT structurally sealable. By the doctrine's own logic ("never
+measure the climber" + "never INFER"), only two things can be enforced: (a) that a
+real step EXISTS beneath a claim — grounding, already sealed by `quality.assess`;
+and (b) that the answer does not OPEN with the wall — the open-order nudge. FLOAT (a
+fluent summary with nothing reachable beneath) is byte-indistinguishable from a
+legible answer except by meaning, so it is NOT catchable structurally; FLOOD's
+*greeting* is. Everything past that is the climber's judgment and stays prompt-guided
+— not a failure, the doctrine being consistent with itself.
+
+The shipped enforcement is `quality.altitude_violation` (+ a one-shot
+`altitude_retry`, behind a passing grounding verdict): a code-question answer whose
+FIRST block is a `citation_stack` of >=3 items is rejected and re-emitted lead-first.
+Block-KIND + item-count only — never reads text, never judges "plain". It is a
+NUDGE, not an invariant: it bans the one witnessed FLOOD-greeting (the 10-hop-wall
+reveal) and nothing more; a re-flood at block 2 is not caught, and the retry fires
+once. `check 2` (reachable descent) and `check 3` (density monotonicity) from the
+proposal were CUT — check 2 is grounding (assess owns it) and as written
+false-positives the grep/git tolerance assess deliberately protects; check 3 is INFER.
 
 ## Fate of the prior doctrine (clarified, not demolished)
 
@@ -76,6 +91,7 @@ unfalsifiable and ships theater.
 2. Rebuild the reveal/explanation around altitude: plain anchored lead → structure
    → full cited detail on descent. Neither FLOAT nor FLOOD.
 3. Demote teach-back/predict-first to an optional self-test mode, never the spine.
-4. Eventually: a structural descent-edge requirement (honest-by-construction), so
-   "every claim is a doorway" is enforced, not hoped.
+4. The structural floor is grounding (`assess`) + the open-order nudge
+   (`altitude_violation`); "every claim is a doorway" past that is prompt-guided,
+   because enforcing it would require INFER, which the doctrine forbids.
 5. Forbidden forever: any metric/score of "load reduced for this human."

--- a/src/copyclip/intelligence/cuaderno/compositor.py
+++ b/src/copyclip/intelligence/cuaderno/compositor.py
@@ -11,10 +11,11 @@ from .prompts import (
     SYSTEM_PROMPT, GROUNDING_RETRY_DIRECTIVE, LANGUAGE_RETRY_DIRECTIVE,
     RESPONSIVENESS_RETRY_FALLBACK, INVALID_BLOCK_RECOVERY, WIDGET_RECOVERY_DIRECTIVE,
     WIDGET_RECOVERY_DIRECTIVE_VISUAL, WIDGET_RECOVERY_DIRECTIVE_RUN,
+    ALTITUDE_RETRY_DIRECTIVE,
 )
 from .read_ledger import ReadLedger, is_content_bearing_read
 from .trace import NULL_TRACE
-from .quality import assess, cheap_verdict_dict, artifacts_cited
+from .quality import assess, cheap_verdict_dict, artifacts_cited, altitude_violation
 from .judge import judge_verdict_dict
 from .language import detect_language
 from .i18n import tr
@@ -411,6 +412,7 @@ def iter_compose_events(
     trace = trace if trace is not None else NULL_TRACE
     grounding_retry_used = False
     responsiveness_retry_used = False
+    altitude_retry_used = False
     evidence = GraphEvidence()  # graph-tool results seen this TURN — accumulates across rounds
     # Files get_rationale ruled accepted_not_decided this TURN — accumulates across
     # rounds, same as `evidence`. A callout citing one must carry the verbatim stamp.
@@ -534,6 +536,26 @@ def iter_compose_events(
                            "frame": _seal(question, emitted, verdict.status,
                                           cheap_verdict_dict(verdict))}
                     return
+                # Grounding passed. Open-order nudge (Level 2, council-corrected):
+                # a code answer must not OPEN with the wall — a dense citation_stack
+                # as the first block, no plain lead. A NUDGE, not an invariant
+                # (legibility is not structurally sealable); block-kind only, never
+                # reads text. It sits BEHIND grounding (which already `continue`d if
+                # it fired), so the two never contest the one shared retry.
+                altitude = altitude_violation(emitted, question)
+                if altitude and not altitude_retry_used and can_retry:
+                    altitude_retry_used = True
+                    discarded = len(emitted)
+                    emitted.clear()
+                    acks = _ack_terminal_tools(turn_content, emit_status)
+                    if acks:
+                        messages.append({"role": "user", "content": acks})
+                    _inject_directive(messages, ALTITUDE_RETRY_DIRECTIVE)
+                    trace.event("retry", kind="altitude", reason=altitude,
+                                directive=ALTITUDE_RETRY_DIRECTIVE,
+                                discarded_blocks=discarded, sse=True)
+                    yield {"type": "reset"}
+                    continue
                 if judge is not None:
                     jv = judge(question, emitted, ledger)
                     _trace_judge(trace, jv)

--- a/src/copyclip/intelligence/cuaderno/prompts.py
+++ b/src/copyclip/intelligence/cuaderno/prompts.py
@@ -45,6 +45,13 @@ JSON shape (retry_directive only for "retry"; world REQUIRED for "insufficient")
  "retry_directive":"...","reason":"one short sentence"}
 """
 
+ALTITUDE_RETRY_DIRECTIVE = (
+    "Your answer OPENED with a wall of citations. Lead with ONE plain sentence that "
+    "names what this is — true of the cited lines — THEN descend into the citation "
+    "stack. Re-emit every block in order: the plain lead first, the stack after. Do "
+    "not open with the stack; the stack is the descent, not the greeting."
+)
+
 GROUNDING_RETRY_DIRECTIVE = (
     "Your answer is not yet anchored to the code: you have not read evidence "
     "that supports it. Do NOT finish yet. Use the read tools now to ground the "

--- a/src/copyclip/intelligence/cuaderno/quality.py
+++ b/src/copyclip/intelligence/cuaderno/quality.py
@@ -226,6 +226,37 @@ def assess(*, question: str, blocks: list[Block], ledger: ReadLedger) -> Quality
     )
 
 
+# A citation_stack of this many items, emitted as the FIRST block, is the wall.
+ALTITUDE_DENSE_STACK_MIN = 3
+
+
+def altitude_violation(blocks: list[Block], question: str) -> Optional[str]:
+    """The open-order nudge — the honest residue of the descent gate (cognitive-load
+    doctrine, council-corrected 2026-06-12). A code-question answer must not OPEN
+    with the wall: a `citation_stack` of >=3 items as the FIRST block, with no plain
+    lead before it.
+
+    Block-KIND + item-count ONLY. It never reads a block's text and never judges
+    whether a lead is "plain" — that would be INFER, which the doctrine forbids
+    (legibility lives on the far side of the INFER wall). It is a NUDGE, not an
+    invariant: the council proved legibility is not structurally sealable ("never
+    measure the climber"), so this bans exactly the ONE witnessed FLOOD-greeting
+    (the 10-hop-wall reveal) and leaves the rest of altitude to the prompt. FLOAT is
+    not catchable here. Carve-outs are automatic: a lead / paragraph / code_block /
+    callout / widget opener, or a short (<3-item) stack, all pass."""
+    if not blocks or not looks_like_code_question(question):
+        return None
+    first = blocks[0]
+    if first.kind == "citation_stack":
+        n = len(first.data.get("items") or [])
+        if n >= ALTITUDE_DENSE_STACK_MIN:
+            return (
+                f"answer OPENS with a {n}-item citation_stack (a wall) — lead with "
+                "one plain sentence first, then descend into the stack"
+            )
+    return None
+
+
 def cheap_verdict_dict(v: QualityVerdict) -> dict[str, Any]:
     """The cheap layer's partial verdict as the persisted pre-image. The cheap
     layer cannot judge responsiveness, so `responsive` is None (unknown)."""

--- a/tests/test_compositor_altitude_gate.py
+++ b/tests/test_compositor_altitude_gate.py
@@ -1,0 +1,111 @@
+"""The open-order nudge — the honest residue of the descent gate (Level 2 of the
+cognitive-load doctrine, council-corrected 2026-06-12).
+
+The design council found legibility is NOT structurally sealable: "never measure the
+climber" + "never INFER" leave only grounding (already sealed by assess) and ONE
+INFER-free move — do not OPEN with the wall. So `altitude_violation` rejects exactly
+the one witnessed failure: a code-question answer whose FIRST block is a dense
+`citation_stack` (>=3 items), with no plain lead before it. Block-KIND + item-count
+only; it never reads a block's text and never judges whether a lead is "plain". It is
+a NUDGE, not an invariant — it bans the FLOOD-greeting and nothing more; FLOAT and
+the rest of legibility stay prompt-guided.
+"""
+from copyclip.intelligence.cuaderno.quality import altitude_violation
+from copyclip.intelligence.cuaderno.schema import Block
+
+CODE_Q = "how does assess work end to end?"
+
+
+def _stack(n):
+    return Block(kind="citation_stack", data={"items": [
+        {"citation": {"kind": "path", "path": "a.py", "line_start": i}, "note": "x"}
+        for i in range(1, n + 1)
+    ]})
+
+
+def test_opening_with_a_dense_stack_is_a_violation():
+    reason = altitude_violation([_stack(3), Block.lead("ok")], CODE_Q)
+    assert reason is not None and "wall" in reason
+
+
+def test_short_opening_stack_passes():
+    # 1-2 items is a terse reveal, not a wall.
+    assert altitude_violation([_stack(2)], CODE_Q) is None
+
+
+def test_lead_before_the_wall_passes():
+    assert altitude_violation([Block.lead("assess seals grounding"), _stack(10)], CODE_Q) is None
+
+
+def test_code_block_opener_passes():
+    # The terse "here is the function" reveal — nothing hidden, descent reachable.
+    blocks = [Block(kind="code_block", data={"code": "def f(): ...", "language": "python"})]
+    assert altitude_violation(blocks, CODE_Q) is None
+
+
+def test_callout_opener_passes():
+    # A Risk/decision answer legitimately leads with a callout (the claim block).
+    blocks = [Block.callout("risk", "high churn", [{"kind": "path", "path": "a.py"}])]
+    assert altitude_violation(blocks, CODE_Q) is None
+
+
+def test_non_code_question_passes():
+    # Meta questions never require a descent shape.
+    assert altitude_violation([_stack(5)], "what can i ask you?") is None
+
+
+def test_empty_blocks_pass():
+    assert altitude_violation([], CODE_Q) is None
+
+
+# --- wired through the real compose loop ---
+
+class _Stub:
+    def __init__(self, turns):
+        self._turns = list(turns)
+
+    def messages_stream(self, **kwargs):
+        for ev in self._turns.pop(0):
+            yield ev
+
+
+def _stop(bid, name, inp):
+    return {"type": "block_stop",
+            "block": {"type": "tool_use", "id": bid, "name": name, "input": inp}}
+
+
+def _content(bid, name, inp):
+    return {"type": "tool_use", "id": bid, "name": name, "input": inp}
+
+
+def _msg(content):
+    return {"type": "message_stop", "stop_reason": "tool_use", "content": content}
+
+
+def test_compose_retries_when_a_code_answer_opens_with_the_wall(tmp_path):
+    (tmp_path / "a.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    stack = {"kind": "citation_stack", "items": [
+        {"citation": {"kind": "path", "path": "a.py", "line_start": 1}, "note": "x"},
+        {"citation": {"kind": "path", "path": "a.py", "line_start": 2}, "note": "y"},
+        {"citation": {"kind": "path", "path": "a.py", "line_start": 1}, "note": "z"},
+    ]}
+    lead = {"kind": "lead", "text": "f returns 1"}
+    from copyclip.intelligence.cuaderno.compositor import iter_compose_events
+    turns = [
+        # round 0: open the file so grounding can pass
+        [_stop("r", "read_file", {"path": "a.py"}),
+         _msg([_content("r", "read_file", {"path": "a.py"})])],
+        # round 1: OPEN WITH THE WALL (3-item stack) + finish -> grounding passes,
+        # altitude fires
+        [_stop("b", "emit_block", stack), _stop("f", "finish", {}),
+         _msg([_content("b", "emit_block", stack), _content("f", "finish", {})])],
+        # round 2 (the altitude retry round): lead first -> seal
+        [_stop("b2", "emit_block", lead), _stop("f2", "finish", {}),
+         _msg([_content("b2", "emit_block", lead), _content("f2", "finish", {})])],
+    ]
+    events = list(iter_compose_events(
+        client=_Stub(turns), question="how does f work end to end?",
+        project_root=str(tmp_path), project_id=1, conn=None, max_tool_rounds=5))
+    assert any(e["type"] == "reset" for e in events)  # the altitude retry fired
+    frame = next(e["frame"] for e in events if e["type"] == "frame")
+    assert frame["blocks"][0]["kind"] == "lead"  # re-emitted lead-first


### PR DESCRIPTION
## What

The honest residue of the "descent gate" (Level 2). A 6-lens design council (Voronov, Iris, Halberg, Null Vale, Serrano, Cassian) found that **legibility is NOT structurally sealable** — and it's the doctrine's *own* logic that forbids it.

## The finding

By **"never measure the climber" + "never INFER"**, only two things can be enforced:
- that a real **step exists** beneath a claim — grounding, already sealed by `quality.assess`;
- that the answer does not **OPEN with the wall** — the open-order nudge.

**FLOAT** (a fluent summary with nothing reachable beneath) is byte-indistinguishable from a legible answer except by *meaning*, so it is **not catchable structurally**. **FLOOD's greeting** is. Everything past that is the climber's judgment and stays **prompt-guided** — not a failure, the doctrine being consistent with itself.

So Level 2 shrank from "structural teeth for the whole altitude invariant" to **one INFER-free nudge for the single witnessed failure**.

## Shipped

`quality.altitude_violation(blocks, question)` + a one-shot `altitude_retry`, **behind a passing grounding verdict** (so the two never contest the one shared retry): a code-question answer whose **FIRST block is a `citation_stack` of ≥3 items** is rejected and re-emitted lead-first.

- **Block-KIND + item-count ONLY** — never reads a block's text, never judges whether a lead is "plain" (that would be INFER).
- **A NUDGE, not an invariant** — it bans the one witnessed FLOOD-greeting (the live 10-hop-wall reveal) and nothing more (a re-flood at block 2 is uncaught; the retry fires once).
- Carve-outs are automatic: a lead / paragraph / code_block / callout / widget opener, or a short (<3-item) stack, all pass.

## Cut by the council

- **check 2 (reachable descent)** — it is *grounding*, `assess` owns it, and as written it false-positives the grep/git-only tolerance `assess` deliberately protects (`quality.py:204-211`). Voronov mislabeled it as FLOAT-catching; the substrate settled it 5-1.
- **check 3 (density monotonicity)** — INFER.
- No Axiom-0: the Voronov-vs-rest split was settled by **code evidence**, not a deadlock.

## Verification

TDD: **7 unit tests** (the wall rejected; short stack / lead / code_block / callout openers and non-code questions pass) + **1 wiring test** (the retry fires through `iter_compose_events` and re-emits lead-first). **848 passed**, 1 skipped, 3 known local-env artifacts. Doctrine doc updated with the "legibility is not sealable" result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic quality check preventing code answers from opening with citation stacks; answers failing this check automatically retry with improved structure.

* **Tests**
  * Added comprehensive test suite validating answer structure enforcement and automatic retry behavior.

* **Documentation**
  * Updated quality enforcement doctrine with concrete structural rules and enforcement mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->