### PR TITLE
feat(cuaderno): Cruces/Junctions v0.1 — executed-arm overlay over the step-through

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,8 @@ frontend/dist/
 frontend/*.tsbuildinfo
 frontend/vite.config.js
 frontend/vite.config.d.ts
+.vite/
 intelligence.db
+
+# local dev smoke scripts (throwaway server launchers)
+.copyclip-verify.py

--- a/docs/superpowers/plans/2026-07-02-cuaderno-cruces-junctions.md
+++ b/docs/superpowers/plans/2026-07-02-cuaderno-cruces-junctions.md
@@ -1,0 +1,703 @@
+# Cruces / Junctions v0.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the cuaderno step-through, mark which `if`/`elif`/`else` arm the run crossed — as a computed structural overlay on the source pane, never narrated.
+
+**Architecture:** A new pure module `compute_junctions` reads the target function's AST plus the executed-line set the tracer already records, and returns a per-arm `taken` tri-state (`true`/`false`/`null`). An additive `junctions` field rides on the existing `StepThroughResponse`; the Stepper dims not-taken arms and draws a gutter chip on the crossed arm. No capture-pipeline change — it reads a completed trace.
+
+**Tech Stack:** Python (`ast`, `dataclasses`) + pytest backend; React/TypeScript + vitest frontend.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-cuaderno-cruces-junctions-design.md`
+
+## Global Constraints
+
+- **v0.1 scope:** `if` / `elif` / `else` only. No loops, `try`/`except`, ternary, `match`, boolean short-circuit.
+- **Tri-state `taken`:** `true` | `false` | `null`. When the trace was `truncated`, an arm with no executed lines is `null` (unknown) — **never** `false`. Claiming "did not run" over a cut-short trace is forbidden (*exposición, no autoría*).
+- **Scope exclusion:** never emit junctions for `if`s inside nested `def`/`async def`/`class` bodies — those have their own code object and are not traced, so we cannot say which arm ran.
+- **Additive & optional:** `junctions` defaults to `[]` on the backend and is `junctions?:` on the frontend; absent/empty → the Stepper behaves exactly as today.
+- **Structural only:** the overlay is dim + a `→ kind` chip. No prose, no narration, no advice.
+- **`compute_junctions` is pure and I/O-free:** it takes source text, never reads the filesystem. The file read lives in the playground caller.
+- **Line alignment:** junction line numbers are absolute (whole-file `ast.parse`), matching `source_lines[].num` and `Step.line`.
+
+---
+
+### Task 1: The pure `compute_junctions` module
+
+**Files:**
+- Create: `src/copyclip/intelligence/cuaderno/junctions.py`
+- Test: `tests/test_junctions.py`
+
+**Interfaces:**
+- Consumes: nothing (pure; stdlib `ast` only).
+- Produces: `compute_junctions(source: str, func_line: int | None, func_name: str, executed_lines: set[int], truncated: bool) -> list[dict]`. Each element is `{"test_line": int, "arms": [{"kind": "if"|"elif"|"else", "lines": [int, int], "taken": bool | None}, ...]}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_junctions.py
+from copyclip.intelligence.cuaderno.junctions import compute_junctions
+
+SRC_IF_ELSE = (
+    "\n"
+    "def f(x):\n"          # line 2
+    "    if x > 0:\n"      # line 3
+    "        a = 1\n"      # line 4
+    "        b = 2\n"      # line 5
+    "    else:\n"          # line 6
+    "        a = -1\n"     # line 7
+    "    return a\n"       # line 8
+)
+
+SRC_LADDER = (
+    "\n"
+    "def g(x):\n"          # 2
+    "    if x == 1:\n"     # 3
+    "        r = 'a'\n"    # 4
+    "    elif x == 2:\n"   # 5
+    "        r = 'b'\n"    # 6
+    "    else:\n"          # 7
+    "        r = 'c'\n"    # 8
+    "    return r\n"       # 9
+)
+
+SRC_BARE_IF = (
+    "\n"
+    "def h(x):\n"          # 2
+    "    y = 0\n"          # 3
+    "    if x:\n"          # 4
+    "        y = 1\n"      # 5
+    "    return y\n"       # 6
+)
+
+SRC_NESTED = (
+    "\n"
+    "def n(x):\n"          # 2
+    "    if x > 0:\n"      # 3
+    "        if x > 10:\n" # 4
+    "            a = 2\n"  # 5
+    "        else:\n"      # 6
+    "            a = 1\n"  # 7
+    "    else:\n"          # 8
+    "        a = 0\n"      # 9
+    "    return a\n"       # 10
+)
+
+SRC_NESTED_DEF = (
+    "\n"
+    "def outer(x):\n"          # 2
+    "    def inner(y):\n"      # 3
+    "        if y:\n"          # 4
+    "            return 1\n"   # 5
+    "        return 0\n"       # 6
+    "    if x:\n"              # 7
+    "        return inner(x)\n"# 8
+    "    return -1\n"          # 9
+)
+
+
+def test_if_else_took_if():
+    j = compute_junctions(SRC_IF_ELSE, 2, "f", {3, 4, 5, 8}, False)
+    assert j == [{"test_line": 3, "arms": [
+        {"kind": "if", "lines": [4, 5], "taken": True},
+        {"kind": "else", "lines": [7, 7], "taken": False},
+    ]}]
+
+
+def test_if_else_took_else():
+    j = compute_junctions(SRC_IF_ELSE, 2, "f", {3, 7, 8}, False)
+    arms = j[0]["arms"]
+    assert arms[0]["taken"] is False
+    assert arms[1]["taken"] is True
+
+
+def test_ladder_took_elif():
+    j = compute_junctions(SRC_LADDER, 2, "g", {3, 5, 6, 9}, False)
+    assert j == [{"test_line": 3, "arms": [
+        {"kind": "if", "lines": [4, 4], "taken": False},
+        {"kind": "elif", "lines": [6, 6], "taken": True},
+        {"kind": "else", "lines": [8, 8], "taken": False},
+    ]}]
+
+
+def test_bare_if_no_else():
+    j = compute_junctions(SRC_BARE_IF, 2, "h", {3, 4, 6}, False)
+    assert j == [{"test_line": 4, "arms": [
+        {"kind": "if", "lines": [5, 5], "taken": False},
+    ]}]
+
+
+def test_truncated_yields_unknown_not_false():
+    # only the test line was reached before the cap
+    j = compute_junctions(SRC_IF_ELSE, 2, "f", {3}, True)
+    arms = j[0]["arms"]
+    assert arms[0]["taken"] is None
+    assert arms[1]["taken"] is None
+
+
+def test_nested_if_inside_taken_arm():
+    # outer took the if-arm; inner took its else-arm
+    j = compute_junctions(SRC_NESTED, 2, "n", {3, 4, 7, 10}, False)
+    outer = next(x for x in j if x["test_line"] == 3)
+    inner = next(x for x in j if x["test_line"] == 4)
+    assert outer["arms"][0]["taken"] is True     # if-arm (lines 4..7)
+    assert outer["arms"][1]["taken"] is False    # else-arm (line 9)
+    assert inner["arms"][0]["taken"] is False    # inner if (line 5)
+    assert inner["arms"][1]["taken"] is True     # inner else (line 7)
+
+
+def test_if_in_nested_def_excluded():
+    # inner()'s `if y:` must NOT appear — nested defs are not traced
+    j = compute_junctions(SRC_NESTED_DEF, 2, "outer", {7, 8}, False)
+    assert all(x["test_line"] != 4 for x in j)
+    assert [x["test_line"] for x in j] == [7]
+
+
+def test_no_if_returns_empty():
+    src = "\ndef p(x):\n    return x + 1\n"
+    assert compute_junctions(src, 2, "p", {3}, False) == []
+
+
+def test_syntax_error_returns_empty():
+    assert compute_junctions("def broken(:\n", 1, "broken", set(), False) == []
+
+
+def test_target_not_found_returns_empty():
+    assert compute_junctions(SRC_IF_ELSE, 999, "missing", {3}, False) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_junctions.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'copyclip.intelligence.cuaderno.junctions'`
+
+- [ ] **Step 3: Write the module**
+
+```python
+# src/copyclip/intelligence/cuaderno/junctions.py
+"""Cruces / Junctions v0.1 — executed-arm overlay over the step-through.
+
+Pure, I/O-free control-flow reading of a completed trace: for each
+if/elif/else in the target function, mark which arm the run crossed (taken),
+which it did not (not-taken), and — when the trace was truncated — which we
+cannot say (unknown). A branch not taken simply produced no trace events.
+
+See docs/superpowers/specs/2026-07-02-cuaderno-cruces-junctions-design.md.
+"""
+from __future__ import annotations
+
+import ast
+
+
+def compute_junctions(
+    source: str,
+    func_line: int | None,
+    func_name: str,
+    executed_lines: set[int],
+    truncated: bool,
+) -> list[dict]:
+    """Return the if/elif/else junctions of the target function, each arm tagged
+    taken=True|False|None. Fails open to [] on any parse/lookup problem so the
+    feature is invisible rather than wrong."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    target = _find_func(tree, func_line, func_name)
+    if target is None:
+        return []
+    out: list[dict] = []
+    _junctions_in_scope(target.body, executed_lines, truncated, out)
+    return out
+
+
+def _find_func(tree: ast.AST, func_line: int | None, func_name: str):
+    funcs = [
+        n for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    if func_line is not None:
+        for n in funcs:
+            if n.lineno == func_line:
+                return n
+    named = [n for n in funcs if n.name == func_name]
+    return named[0] if len(named) == 1 else None
+
+
+def _arm(kind: str, body: list, executed: set[int], truncated: bool) -> dict:
+    lo = body[0].lineno
+    hi = body[-1].end_lineno
+    hit = any(lo <= line <= hi for line in executed)
+    if hit:
+        taken: bool | None = True
+    elif truncated:
+        taken = None      # unknown — the trace stopped early; do not claim "did not run"
+    else:
+        taken = False
+    return {"kind": kind, "lines": [lo, hi], "taken": taken}
+
+
+def _build_ladder(node: ast.If, executed: set[int], truncated: bool) -> dict:
+    arms = [_arm("if", node.body, executed, truncated)]
+    orelse = node.orelse
+    while len(orelse) == 1 and isinstance(orelse[0], ast.If):
+        elif_node = orelse[0]
+        arms.append(_arm("elif", elif_node.body, executed, truncated))
+        orelse = elif_node.orelse
+    if orelse:
+        arms.append(_arm("else", orelse, executed, truncated))
+    return {"test_line": node.lineno, "arms": arms}
+
+
+def _ladder_bodies(node: ast.If) -> list[list]:
+    """The arm bodies of the ladder, for recursing into nested ifs WITHOUT
+    re-treating the elif If-nodes as their own top-level junctions."""
+    bodies = [node.body]
+    orelse = node.orelse
+    while len(orelse) == 1 and isinstance(orelse[0], ast.If):
+        elif_node = orelse[0]
+        bodies.append(elif_node.body)
+        orelse = elif_node.orelse
+    if orelse:
+        bodies.append(orelse)
+    return bodies
+
+
+def _generic_child_bodies(node: ast.AST) -> list[list]:
+    """Statement-list bodies to descend for nested ifs in the SAME scope
+    (For/While/With/Try). Non-If compound statements only — If is handled by
+    _build_ladder + _ladder_bodies."""
+    out: list[list] = []
+    for field in ("body", "orelse", "finalbody"):
+        val = getattr(node, field, None)
+        if isinstance(val, list) and val and isinstance(val[0], ast.stmt):
+            out.append(val)
+    for handler in getattr(node, "handlers", []) or []:
+        if handler.body:
+            out.append(handler.body)
+    return out
+
+
+def _junctions_in_scope(stmts: list, executed: set[int], truncated: bool, out: list[dict]) -> None:
+    for node in stmts:
+        # Nested defs/classes have their OWN code object and are not traced
+        # (frame-scoping, _capture_driver.py) — we cannot say which of their
+        # branches ran, so we never emit junctions for them.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if isinstance(node, ast.If):
+            out.append(_build_ladder(node, executed, truncated))
+            for body in _ladder_bodies(node):
+                _junctions_in_scope(body, executed, truncated, out)
+        else:
+            for body in _generic_child_bodies(node):
+                _junctions_in_scope(body, executed, truncated, out)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_junctions.py -v`
+Expected: PASS (10 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/copyclip/intelligence/cuaderno/junctions.py tests/test_junctions.py
+git commit -m "feat(cuaderno): compute_junctions — if/elif/else executed-arm reading (Cruces v0.1)"
+```
+
+---
+
+### Task 2: Wire `junctions` onto the step-through response
+
+**Files:**
+- Modify: `src/copyclip/intelligence/capture.py` (imports; `StepThroughResponse` at :233; `to_dict` at :245)
+- Modify: `src/copyclip/intelligence/playground.py` (add helper; thread into the `StepThroughResponse(...)` return at :625)
+- Test: `tests/test_junctions_wiring.py`
+
+**Interfaces:**
+- Consumes: `compute_junctions(...)` from Task 1; `StepThroughResponse`, `Step`, `ResolvedFunction` (existing).
+- Produces: `StepThroughResponse.junctions: list[dict]` (default `[]`), serialized as `"junctions"` in `to_dict()`. Helper `_junctions_for(resolved, project_root, executed_lines, truncated) -> list[dict]` in `playground.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_junctions_wiring.py
+import os
+import textwrap
+
+from copyclip.intelligence.capture import StepThroughResponse, Step
+from copyclip.intelligence import playground as pg
+from copyclip.intelligence.playground import ResolvedFunction
+
+
+def test_to_dict_includes_junctions():
+    resp = StepThroughResponse(
+        trace=[Step(line=3, event="line", changed=[], scope=[])],
+        source_lines=[{"num": 3, "text": "if x:"}],
+        func_name="f", file_line="a.py:2", truncated=False, truncated_reason=None,
+        junctions=[{"test_line": 3, "arms": [{"kind": "if", "lines": [4, 4], "taken": True}]}],
+    )
+    d = resp.to_dict()
+    assert d["junctions"] == [{"test_line": 3, "arms": [{"kind": "if", "lines": [4, 4], "taken": True}]}]
+
+
+def test_to_dict_junctions_defaults_empty():
+    resp = StepThroughResponse(
+        trace=[], source_lines=[], func_name="f", file_line="a.py:1",
+        truncated=False, truncated_reason=None,
+    )
+    assert resp.to_dict()["junctions"] == []
+
+
+def test_junctions_for_reads_file_and_computes(tmp_path):
+    src = textwrap.dedent(
+        """\
+        def f(x):
+            if x > 0:
+                a = 1
+            else:
+                a = -1
+            return a
+        """
+    )
+    (tmp_path / "m.py").write_text(src, encoding="utf-8")
+    resolved = ResolvedFunction(
+        file="m.py", name="f", qualname="f", kind="function",
+        module="m", line_start=1, parent_class=None,
+    )
+    j = pg._junctions_for(resolved, str(tmp_path), {2, 3, 6}, False)
+    assert j == [{"test_line": 2, "arms": [
+        {"kind": "if", "lines": [3, 3], "taken": True},
+        {"kind": "else", "lines": [5, 5], "taken": False},
+    ]}]
+
+
+def test_junctions_for_missing_file_returns_empty():
+    resolved = ResolvedFunction(
+        file="nope.py", name="f", qualname="f", kind="function",
+        module="m", line_start=1, parent_class=None,
+    )
+    assert pg._junctions_for(resolved, os.getcwd(), {1}, False) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_junctions_wiring.py -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'junctions'` and `AttributeError: module ... has no attribute '_junctions_for'`
+
+- [ ] **Step 3a: Add the field + serialization in `capture.py`**
+
+At the top of `capture.py`, ensure `field` is imported (the dataclasses import currently reads `from dataclasses import dataclass`):
+
+```python
+from dataclasses import dataclass, field
+```
+
+Replace the `StepThroughResponse` dataclass (capture.py:232-254) with:
+
+```python
+@dataclass(frozen=True)
+class StepThroughResponse:
+    trace: list[Step]
+    source_lines: list[dict[str, Any]]
+    func_name: str
+    file_line: str
+    truncated: bool
+    # PR #177 fix 5: split the bare `truncated` bool into a REASON so the frontend
+    # shows the right message — 'steps' (MAX_STEPS overflow) vs 'time' (wall-clock
+    # overrun) — and never conflates truncation with a terminal raise. None when
+    # the trace completed cleanly.
+    truncated_reason: str | None = None
+    # Cruces v0.1: if/elif/else arms with taken=True|False|None, computed from
+    # the target AST + the executed-line set. Additive; [] means no junctions.
+    junctions: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "trace",
+            "trace": [s.to_dict() for s in self.trace],
+            "source_lines": self.source_lines,
+            "func_name": self.func_name,
+            "file_line": self.file_line,
+            "truncated": self.truncated,
+            "truncated_reason": self.truncated_reason,
+            "junctions": list(self.junctions),
+        }
+```
+
+- [ ] **Step 3b: Add the helper + thread it in `playground.py`**
+
+Add this helper near the other module-level helpers in `playground.py` (e.g. after `_module_from_file`):
+
+```python
+def _junctions_for(
+    resolved: ResolvedFunction,
+    project_root: str,
+    executed_lines: set[int],
+    truncated: bool,
+) -> list[dict]:
+    """Read the target's source and compute its if/elif/else junctions. Pure
+    logic lives in cuaderno.junctions; this only supplies the source text and
+    fails open to [] so a read/parse problem never breaks the step-through."""
+    from .cuaderno.junctions import compute_junctions
+    try:
+        with open(os.path.join(project_root, resolved.file), encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError:
+        return []
+    return compute_junctions(
+        source, resolved.line_start, resolved.name, executed_lines, truncated
+    )
+```
+
+Replace the `StepThroughResponse(...)` return (playground.py:625-627) with:
+
+```python
+        executed_lines = {s.line for s in steps if s.line}
+        junctions = _junctions_for(resolved, project_root, executed_lines, truncated)
+        return StepThroughResponse(
+            trace=steps, source_lines=source_lines, func_name=func_name,
+            file_line=file_line, truncated=truncated, truncated_reason=truncated_reason,
+            junctions=junctions)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_junctions_wiring.py tests/test_cuaderno_playground_floor.py -v`
+Expected: PASS (new wiring tests pass; existing floor tests still green — `junctions` is additive)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/copyclip/intelligence/capture.py src/copyclip/intelligence/playground.py tests/test_junctions_wiring.py
+git commit -m "feat(cuaderno): thread junctions onto StepThroughResponse from the trace"
+```
+
+---
+
+### Task 3: Frontend type — `Junction` on `StepThroughResponse`
+
+**Files:**
+- Modify: `frontend/src/types/api.ts` (`StepThroughResponse` at :678-686)
+
+**Interfaces:**
+- Produces: TS `Junction` type and optional `junctions?: Junction[]` on `StepThroughResponse`. Consumed by Task 4.
+
+- [ ] **Step 1: Add the type**
+
+Immediately above the `export type StepThroughResponse = {` block (api.ts:678), add:
+
+```ts
+export type Junction = {
+  test_line: number
+  arms: { kind: 'if' | 'elif' | 'else'; lines: [number, number]; taken: boolean | null }[]
+}
+```
+
+Then add one line inside the `StepThroughResponse` object type, after `truncated_reason?: 'steps' | 'time' | null` (api.ts:685):
+
+```ts
+  junctions?: Junction[]
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: PASS (no type errors; the field is optional so no call site breaks)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/types/api.ts
+git commit -m "feat(cuaderno): Junction type on StepThroughResponse (frontend contract)"
+```
+
+---
+
+### Task 4: Stepper overlay — dim not-taken arms + the crossed-arm chip
+
+**Files:**
+- Modify: `frontend/src/components/cuaderno/stepper/trace.ts` (add `junctionOverlay`)
+- Modify: `frontend/src/components/cuaderno/stepper/Stepper.tsx` (apply the overlay in the source-line map, :144-159)
+- Test: `frontend/src/components/cuaderno/stepper/trace.test.ts`
+
+**Interfaces:**
+- Consumes: `Junction` (Task 3).
+- Produces: `junctionOverlay(junctions?: Junction[]): { role: Record<number, 'not-taken' | 'unknown'>; chips: Record<number, string> }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/components/cuaderno/stepper/trace.test.ts
+import { describe, it, expect } from 'vitest'
+import { junctionOverlay } from './trace'
+import type { Junction } from '../../../types/api'
+
+describe('junctionOverlay', () => {
+  it('dims not-taken arm bodies and chips the crossed arm', () => {
+    const j: Junction[] = [{
+      test_line: 3,
+      arms: [
+        { kind: 'if', lines: [4, 5], taken: true },
+        { kind: 'else', lines: [7, 7], taken: false },
+      ],
+    }]
+    const { role, chips } = junctionOverlay(j)
+    expect(role[4]).toBeUndefined()   // taken arm: normal
+    expect(role[5]).toBeUndefined()
+    expect(role[7]).toBe('not-taken') // else body dimmed
+    expect(chips[3]).toBe('→ if')
+  })
+
+  it('marks unknown arms distinctly under truncation', () => {
+    const j: Junction[] = [{
+      test_line: 3,
+      arms: [
+        { kind: 'if', lines: [4, 4], taken: null },
+        { kind: 'else', lines: [6, 6], taken: null },
+      ],
+    }]
+    const { role, chips } = junctionOverlay(j)
+    expect(role[4]).toBe('unknown')
+    expect(role[6]).toBe('unknown')
+    expect(chips[3]).toBeUndefined()  // nothing crossed → no chip
+  })
+
+  it('suppresses the chip for a junction inside a dimmed (dead) range', () => {
+    // outer took the else-arm (lines 8..9); the inner if at line 8 is dead code
+    const j: Junction[] = [
+      { test_line: 3, arms: [
+        { kind: 'if', lines: [4, 5], taken: false },
+        { kind: 'else', lines: [8, 9], taken: true },
+      ] },
+      { test_line: 4, arms: [   // nested inside the not-taken if-arm (4..5)
+        { kind: 'if', lines: [5, 5], taken: false },
+      ] },
+    ]
+    const { chips } = junctionOverlay(j)
+    expect(chips[4]).toBeUndefined() // line 4 is inside the dimmed 4..5 range
+  })
+
+  it('returns empty maps for undefined junctions', () => {
+    expect(junctionOverlay(undefined)).toEqual({ role: {}, chips: {} })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/cuaderno/stepper/trace.test.ts`
+Expected: FAIL — `junctionOverlay is not a function`
+
+- [ ] **Step 3: Implement `junctionOverlay` in `trace.ts`**
+
+Add to the top imports of `trace.ts` (it already imports `Step`):
+
+```ts
+import type { Step, Junction } from '../../../types/api'
+```
+
+(If `trace.ts` currently imports only `Step`, extend that import to include `Junction`; otherwise add the line above.)
+
+Append to `trace.ts`:
+
+```ts
+export type LineRole = 'not-taken' | 'unknown'
+export type JunctionOverlay = { role: Record<number, LineRole>; chips: Record<number, string> }
+
+// Static per-run overlay: dim the body lines of arms the run did not take
+// (or could not observe, under truncation), and chip the crossed arm on its
+// junction's test line. A junction whose test line is itself inside a dimmed
+// range is dead code for this run, so it gets no chip.
+export function junctionOverlay(junctions?: Junction[]): JunctionOverlay {
+  const role: Record<number, LineRole> = {}
+  const chips: Record<number, string> = {}
+  if (!junctions) return { role, chips }
+  for (const j of junctions) {
+    for (const arm of j.arms) {
+      if (arm.taken === true) continue
+      const r: LineRole = arm.taken === null ? 'unknown' : 'not-taken'
+      for (let n = arm.lines[0]; n <= arm.lines[1]; n++) {
+        if (!(n in role)) role[n] = r   // outer (processed first) wins over nested
+      }
+    }
+  }
+  for (const j of junctions) {
+    if (j.test_line in role) continue   // junction sits inside dead code this run
+    const taken = j.arms.find((a) => a.taken === true)
+    if (taken) chips[j.test_line] = `→ ${taken.kind}`
+  }
+  return { role, chips }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/cuaderno/stepper/trace.test.ts`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Apply the overlay in `Stepper.tsx`**
+
+Add `junctionOverlay` to the existing `./trace` import (Stepper.tsx:4-6) and `useMemo` (already imported at :1). After `const markers = markerLefts(trace)` (:62), add:
+
+```tsx
+  // Cruces v0.1: static per-run branch overlay. Suppressed when the source
+  // anchor is stale (same guard the current-step highlight uses).
+  const overlay = useMemo(
+    () => (staleAnchor ? { role: {}, chips: {} } : junctionOverlay(response.junctions)),
+    [response.junctions, staleAnchor],
+  )
+```
+
+Replace the source-line map (Stepper.tsx:152-157) with:
+
+```tsx
+              {lines.map((ln) => {
+                const dim = overlay.role[ln.num]
+                const chip = overlay.chips[ln.num]
+                return (
+                  <div key={ln.num} style={s('display:flex;height:26px;position:relative;')}>
+                    <span style={s(ln.numStyle)}>{ln.num}</span>
+                    <span style={{ ...s(ln.codeStyle), ...(dim ? { opacity: dim === 'unknown' ? 0.5 : 0.34 } : {}) }}>{ln.code}</span>
+                    {chip && (
+                      <span style={s('position:absolute;right:6px;top:0;font-family:var(--font-ui);font-size:10px;letter-spacing:.04em;color:var(--accent-ink);opacity:.85;')}>{chip}</span>
+                    )}
+                  </div>
+                )
+              })}
+```
+
+- [ ] **Step 6: Typecheck + run the full stepper suite**
+
+Run: `cd frontend && npx tsc --noEmit && npx vitest run src/components/cuaderno/stepper/`
+Expected: PASS (typecheck clean; trace tests pass; existing stepper tests unaffected)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/cuaderno/stepper/trace.ts frontend/src/components/cuaderno/stepper/trace.test.ts frontend/src/components/cuaderno/stepper/Stepper.tsx
+git commit -m "feat(cuaderno): Stepper renders the Cruces overlay — dim not-taken arms + crossed-arm chip"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §2 scope (if/elif/else, tri-state, static overlay) → Task 1 (logic) + Task 4 (render). ✓
+- §4 contract (`{test_line, arms:[{kind, lines, taken}]}`, optional frontend field) → Task 1 shape + Task 2 serialization + Task 3 type. ✓
+- §5 AST extraction (whole-file parse, absolute lines, elif chain, find by line_start) → Task 1 `_find_func` / `_build_ladder`; file read in Task 2 `_junctions_for`. ✓
+- §6 taken/not-taken/unknown + `line==0` exclusion → Task 1 `_arm`; Task 2 `{s.line for s in steps if s.line}`. ✓
+- §7 nesting + scope exclusion → Task 1 `_junctions_in_scope` (skip nested defs) + Task 1 `test_if_in_nested_def_excluded`; chip suppression in Task 4. ✓
+- §8 render (dim + chip, staleAnchor suppression, absent→today) → Task 4. ✓
+- §9 files touched → matches Tasks 1-4. ✓
+- §10 testing (pure core cases + frontend overlay + no existing-test change) → Task 1 suite, Task 4 vitest, Task 2 re-runs floor tests. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows complete code; test bodies are concrete. ✓
+
+**3. Type consistency:** `compute_junctions` signature identical in Task 1 (def), Task 2 (call in `_junctions_for`), and the spec. `junctions` field name identical across capture.py, playground.py, api.ts. `junctionOverlay` return shape identical between Task 4 def, its test, and the Stepper `useMemo`. `taken` is `bool | None` (Py) / `boolean | null` (TS) consistently. ✓
+
+## Execution Handoff
+
+Two execution options — chosen after you review the plan.

--- a/docs/superpowers/specs/2026-07-02-cuaderno-cruces-junctions-design.md
+++ b/docs/superpowers/specs/2026-07-02-cuaderno-cruces-junctions-design.md
@@ -1,0 +1,241 @@
+# Cruces / Junctions v0.1 — executed-arm overlay over the step-through
+
+- **Date:** 2026-07-02
+- **Status:** Design approved (brainstorming), pending implementation plan.
+- **Roadmap:** Forward #1 — Cruces / Junctions ([#146]). "In the playground,
+  show *which branch executed the input you just edited*, as a computed value,
+  never narrated."
+- **Arc:** the natural continuation of the playground arc
+  (run-a-symbol → step-through → call synthesis). The expensive substrate — the
+  bounded tracer, the Stepper, the capture pipeline — is already shipped and
+  paid for. This is a pure function plus one additive field plus per-line
+  decoration.
+
+[#146]: https://github.com/sssamuelll/copyclip/issues/146
+
+## 1. Goal
+
+When a step-through runs a real call, the trace already records every line the
+target function actually executed. Cruces surfaces the **control-flow** reading
+of that fact: for each `if`/`elif`/`else` in the function, mark which arm the
+run crossed and which it did not — as a **computed structural overlay on the
+source pane, with zero prose**. A branch not taken simply has no events; the
+overlay reads that off the existing trace.
+
+This honors the product's founding discipline (*exposición, no autoría*): the
+overlay states what the run did, never narrates or advises, and — critically —
+never claims a branch "did not run" when the evidence is incomplete (§6).
+
+## 2. Scope
+
+**In (v0.1):**
+- `if` / `elif` / `else` statements in the target function body, at any nesting
+  depth (nesting handled by the natural rule in §7, no special-casing).
+- A tri-state `taken` per arm: `true` | `false` | `null` (unknown).
+- A static per-run overlay in the Stepper: not-taken arms dimmed, a gutter chip
+  on each junction's test line naming the crossed arm.
+
+**Out (deferred to a later "Junctions v0.2 / control-flow C" iteration):**
+- Loops (`for` / `while`): ran-vs-skipped, iteration counts.
+- `try` / `except` / `finally`: which handler caught.
+- Ternary expressions, boolean short-circuit, `match` / `case`, comprehension
+  filters.
+
+These are deferred deliberately, to be added from real cases rather than
+speculated (ponytail: build the catch for a miss you have counted). v0.1 ships
+the most common junction — the `if` ladder — end to end.
+
+## 3. Architecture & data flow
+
+The step-through payload flows today (unchanged by this feature):
+
+```
+launch_playground (playground.py:508)
+  → run_capture / run_free_text_capture (capture.py:651 / :661)
+  → StepThroughResponse{trace, source_lines, func_name, file_line,
+                        truncated, truncated_reason}   (capture.py:233)
+  → .to_dict() → {kind:'trace', ...}  → SSE frame → <Stepper> (Stepper.tsx:19)
+```
+
+Cruces inserts **without touching the capture pipeline**:
+
+1. A new pure module `cuaderno/junctions.py` exposes
+   `compute_junctions(source: str, target: TargetIdent, executed_lines: set[int],
+   truncated: bool) -> list[dict]`.
+2. `launch_playground`, on the cuaderno step-through path, computes `junctions`
+   right after a successful capture (both the model and the free-text branches
+   converge at the `StepThroughResponse(...)` return, playground.py:625) and
+   passes it into the response.
+3. `StepThroughResponse` gains a `junctions` field, serialized additively in
+   `.to_dict()`.
+4. The Stepper decorates its existing source pane from `junctions`.
+
+The overlay is **static per run** — it describes the whole execution, not the
+current step — so it is computed once and does not change as the user scrubs.
+
+## 4. The `junctions` contract (backend ↔ frontend)
+
+Backend — new field on `StepThroughResponse.to_dict()` (capture.py:245):
+
+```python
+"junctions": [
+  {
+    "test_line": 42,                          # line of the `if` / `elif` keyword
+    "arms": [
+      {"kind": "if",   "lines": [42, 45], "taken": True},
+      {"kind": "elif", "lines": [46, 48], "taken": False},
+      {"kind": "else", "lines": [49, 51], "taken": False}
+    ]
+  }
+]
+```
+
+- `kind`: `"if"` | `"elif"` | `"else"`.
+- `lines`: `[first, last]` absolute line numbers of the arm's **body**
+  (inclusive), aligned with `source_lines[].num` and `Step.line`.
+- `taken`: `true` | `false` | `null` (unknown, §6).
+- An `else`-less ladder simply has no `"else"` arm.
+
+Frontend — extend `StepThroughResponse` (types/api.ts:678). `source_lines`
+stays `{ num, text }[]`; `truncated_reason` stays at :685.
+
+```ts
+export type Junction = {
+  test_line: number
+  arms: { kind: 'if' | 'elif' | 'else'; lines: [number, number]; taken: boolean | null }[]
+}
+// StepThroughResponse gains:
+  junctions?: Junction[]   // optional: absent on older payloads → overlay off
+```
+
+`junctions` is optional so an older backend (or the empty-trace / fallback
+paths, which never build a Stepper) degrades to today's behavior.
+
+## 5. AST branch extraction
+
+`compute_junctions` is pure and I/O-free; `launch_playground` supplies the
+source text and the executed-line set.
+
+- Parse the **whole file** with `ast` (from `os.path.join(project_root,
+  resolved.file)`). Parsing the whole module gives absolute `lineno`/`end_lineno`
+  for free, so junction lines align with `source_lines[].num` and `Step.line`
+  without any offset arithmetic. (Parsing only the function slice would fail on
+  the indented body of a method and force fragile dedent+offset math.)
+- Locate the target `FunctionDef` / `AsyncFunctionDef` by matching
+  `node.lineno == resolved.line_start`. If `line_start` is absent or no node
+  matches, fall back to a unique name match; if still ambiguous, return `[]`.
+- Walk `ast.If` nodes within the target function body:
+  - `test_line = node.lineno` (the `if`/`elif` keyword line).
+  - then-arm `lines = (node.body[0].lineno, node.body[-1].end_lineno)`.
+  - **`elif` chain:** an `orelse` that is exactly `[ast.If(...)]` is a chained
+    `elif` — recurse and emit its arm as `kind:"elif"`, rather than an
+    `else { if }`. A non-If `orelse` is a real `else` arm spanning
+    `(orelse[0].lineno, orelse[-1].end_lineno)`.
+- Only descend into the target function's own body (its nested defs /
+  comprehensions have their own code objects and were never traced line-by-line
+  — spec parity with the tracer's frame-scoping, `_capture_driver.py:256`).
+
+Degradation: a `SyntaxError`, a missing file, or any unexpected shape returns
+`[]` — the feature is invisible rather than wrong. This mirrors how the whole
+playground fails open to an honest note rather than a broken widget.
+
+## 6. taken / not-taken / unknown — the honesty rule
+
+```
+executed = { s.line for s in trace if s.line }   # raise sentinel line==0 excluded
+for each arm with body span (lo, hi):
+    hit = any(lo <= L <= hi for L in executed)
+    if hit:            taken = True
+    elif truncated:    taken = None     # unknown — the trace was cut short
+    else:              taken = False
+```
+
+`truncated` is the existing `StepThroughResponse.truncated` (steps-cap or
+wall-clock overrun, `_capture_driver.py:258-265`). **When the trace was
+truncated, an arm with no executed lines is `unknown`, never `not-taken`.**
+Claiming "this branch did not run" over a trace that stopped early would be
+exactly the overclaim the product forbids. The tri-state is the whole point of
+the feature being on-brand, not a nicety.
+
+The `line == 0` raise sentinel (a raise before the body ran,
+`_capture_driver.py:294`/`:389`) is excluded from `executed` so it can never
+falsely mark an arm taken.
+
+## 7. Nesting policy (no special-casing)
+
+Nesting falls out of §6 for free. If an inner `if` sits inside an arm that was
+not taken (or unknown), its own body lines were never executed either, so its
+arms compute to `false` / `unknown` correctly. In the render (§8), a junction
+whose `test_line` lands inside a dimmed (not-taken/unknown) range does **not**
+draw a chip — it is inside dead code for this run. No depth limit, no
+special-case branch: one classification rule handles the whole tree.
+
+## 8. Render in the Stepper
+
+A **static** overlay on the source pane the Stepper already renders
+(`Stepper.tsx:152-157` via `lineModels`, `trace.ts:30`). Each source line gets a
+junction role derived once from `junctions`:
+
+- **Taken arm:** normal styling. The current-step highlight slab
+  (`Stepper.tsx:146`) still rides on top independently — no conflict.
+- **Not-taken arm (`taken:false`):** dimmed (e.g. reduced opacity / `--ink-4`)
+  — dead code *for this run*.
+- **Unknown arm (`taken:null`):** dimmed with a distinct tint, so "we can't say"
+  never looks like "it didn't run".
+- **Chip on `test_line`:** a small gutter marker naming the crossed arm
+  (`→ if`, `→ else`). Computed value, no prose. Suppressed when the test line
+  is itself inside a dimmed range (§7).
+
+Implementation seam: extend `lineModels` (or add a sibling that consumes
+`junctions`) to tag each `LineModel` with `role: 'taken' | 'dim-not-taken' |
+'dim-unknown' | undefined`; the render maps role → style. The exact colors and
+chip glyph are an implementation-time polish detail, not a contract decision.
+
+Degradation in the UI:
+- `junctions` absent or `[]` → Stepper identical to today (feature invisible).
+- `staleAnchor` (source moved, line not found, `Stepper.tsx:57`) → suppress the
+  overlay entirely, same principle the current highlight already uses.
+
+## 9. Files touched
+
+Backend:
+- `src/copyclip/intelligence/cuaderno/junctions.py` — **new**, pure
+  `compute_junctions` + AST walk + tri-state classification.
+- `src/copyclip/intelligence/capture.py` — add `junctions` to
+  `StepThroughResponse` and its `.to_dict()` (:233, :245).
+- `src/copyclip/intelligence/playground.py` — call `compute_junctions` on the
+  cuaderno step-through path and thread it into the response (:602/:625). Read
+  the target source for the AST parse.
+
+Frontend:
+- `frontend/src/types/api.ts` — add `Junction` type and optional `junctions` on
+  `StepThroughResponse` (:678).
+- `frontend/src/components/cuaderno/stepper/trace.ts` — junction-role tagging in
+  / alongside `lineModels` (:30).
+- `frontend/src/components/cuaderno/stepper/Stepper.tsx` — apply the role styling
+  and render the test-line chip (:144-159).
+
+## 10. Testing strategy
+
+- **Core (pure, no LLM, no subprocess) — the risky, deterministic logic:**
+  `compute_junctions` over hand-built sources:
+  - simple `if` (taken then; else absent);
+  - `if` / `else` (each arm taken in separate cases);
+  - `if` / `elif` / `else` chain (elif emitted as `kind:"elif"`, not nested else);
+  - nested `if` inside a not-taken arm → inner arms `false`, chip suppressed;
+  - `truncated=True` with an unexecuted arm → `taken:null` (the honesty rule);
+  - function with no `if` → `[]`;
+  - unresolvable target / `SyntaxError` → `[]`.
+- **Frontend:** one overlay test over a `StepThroughResponse` fixture — taken
+  normal, not-taken dimmed, unknown tinted, chip on `test_line`, and overlay
+  suppressed under `staleAnchor`.
+- **No change** to existing step-through / capture tests: `junctions` is additive
+  and optional.
+
+## 11. Non-goals
+
+- No new capture mechanism, subprocess, or tracer change — reads the existing
+  trace only.
+- No prose, no narration, no advice — a structural overlay only (roadmap #146).
+- No loops / try-except / ternary / match in v0.1 (§2, deferred to real cases).
+- No cross-file or whole-program branch analysis — the target function only.

--- a/frontend/src/components/cuaderno/stepper/Stepper.tsx
+++ b/frontend/src/components/cuaderno/stepper/Stepper.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useMemo } from 'react'
 import type { StepThroughResponse } from '../../../types/api'
 import { t } from '../strings'
 import {
-  ROW_H, clampStep, nextChange, trackFraction, lineModels, buildRows, markerLefts, sourceTranslateY,
+  ROW_H, clampStep, nextChange, trackFraction, lineModels, buildRows, markerLefts, sourceTranslateY, junctionOverlay,
 } from './trace'
 import { StateRow, s } from './StateRow'
 
@@ -60,6 +60,13 @@ export function Stepper({ response, onClose, onEdit, lang }: Props) {
   const hlTop = curIdx * ROW_H     // only used when !staleAnchor
   const handleLeft = total > 1 ? `${((cur - 1) / (total - 1)) * 100}%` : '0%'
   const markers = markerLefts(trace)
+
+  // Cruces v0.1: static per-run branch overlay. Suppressed when the source
+  // anchor is stale (same guard the current-step highlight uses).
+  const overlay = useMemo(
+    () => (staleAnchor ? { role: {}, chips: {} } : junctionOverlay(response.junctions)),
+    [response.junctions, staleAnchor],
+  )
 
   // raised: only treated as terminal if it's also the last step (cur === total)
   const raised = (tr.event === 'raise' || !!tr.raised) && cur === total
@@ -149,12 +156,19 @@ export function Stepper({ response, onClose, onEdit, lang }: Props) {
               data-testid="source-lines"
               style={{ ...s('position:relative;'), transform: `translateY(${srcTranslateY}px)`, transition: 'transform .22s cubic-bezier(.4,0,.2,1)' }}
             >
-              {lines.map((ln) => (
-                <div key={ln.num} style={s('display:flex;height:26px;')}>
-                  <span style={s(ln.numStyle)}>{ln.num}</span>
-                  <span style={s(ln.codeStyle)}>{ln.code}</span>
-                </div>
-              ))}
+              {lines.map((ln) => {
+                const dim = overlay.role[ln.num]
+                const chip = overlay.chips[ln.num]
+                return (
+                  <div key={ln.num} style={s('display:flex;height:26px;position:relative;')}>
+                    <span style={s(ln.numStyle)}>{ln.num}</span>
+                    <span style={{ ...s(ln.codeStyle), ...(dim ? { opacity: dim === 'unknown' ? 0.5 : 0.34 } : {}) }}>{ln.code}</span>
+                    {chip && (
+                      <span style={s('position:absolute;right:6px;top:0;font-family:var(--font-ui);font-size:10px;letter-spacing:.04em;color:var(--accent-ink);opacity:.85;')}>{chip}</span>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           </div>
           {/* divider */}

--- a/frontend/src/components/cuaderno/stepper/trace.test.ts
+++ b/frontend/src/components/cuaderno/stepper/trace.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import type { Step, Var } from '../../../types/api'
-import { clampStep, nextChange, trackFraction, lineModels, buildRows, markerLefts, sourceTranslateY, ROW_H } from './trace'
+import type { Step, Var, Junction } from '../../../types/api'
+import { clampStep, nextChange, trackFraction, lineModels, buildRows, markerLefts, sourceTranslateY, ROW_H, junctionOverlay } from './trace'
 
 const v = (name: string, kind: Var['kind'], extra: Partial<Var> = {}): Var => ({ name, kind, ...extra })
 
@@ -153,5 +153,55 @@ describe('markerLefts (hero geometry)', () => {
     expect(lefts).toHaveLength(1)
     expect(lefts[0]).toBe(50)
     expect(Number.isNaN(lefts[0])).toBe(false)
+  })
+})
+
+describe('junctionOverlay', () => {
+  it('dims not-taken arm bodies and chips the crossed arm', () => {
+    const j: Junction[] = [{
+      test_line: 3,
+      arms: [
+        { kind: 'if', lines: [4, 5], taken: true },
+        { kind: 'else', lines: [7, 7], taken: false },
+      ],
+    }]
+    const { role, chips } = junctionOverlay(j)
+    expect(role[4]).toBeUndefined()   // taken arm: normal
+    expect(role[5]).toBeUndefined()
+    expect(role[7]).toBe('not-taken') // else body dimmed
+    expect(chips[3]).toBe('→ if')
+  })
+
+  it('marks unknown arms distinctly under truncation', () => {
+    const j: Junction[] = [{
+      test_line: 3,
+      arms: [
+        { kind: 'if', lines: [4, 4], taken: null },
+        { kind: 'else', lines: [6, 6], taken: null },
+      ],
+    }]
+    const { role, chips } = junctionOverlay(j)
+    expect(role[4]).toBe('unknown')
+    expect(role[6]).toBe('unknown')
+    expect(chips[3]).toBeUndefined()  // nothing crossed → no chip
+  })
+
+  it('suppresses the chip for a junction inside a dimmed (dead) range', () => {
+    // outer took the else-arm (lines 8..9); the inner if at line 8 is dead code
+    const j: Junction[] = [
+      { test_line: 3, arms: [
+        { kind: 'if', lines: [4, 5], taken: false },
+        { kind: 'else', lines: [8, 9], taken: true },
+      ] },
+      { test_line: 4, arms: [   // nested inside the not-taken if-arm (4..5)
+        { kind: 'if', lines: [5, 5], taken: false },
+      ] },
+    ]
+    const { chips } = junctionOverlay(j)
+    expect(chips[4]).toBeUndefined() // line 4 is inside the dimmed 4..5 range
+  })
+
+  it('returns empty maps for undefined junctions', () => {
+    expect(junctionOverlay(undefined)).toEqual({ role: {}, chips: {} })
   })
 })

--- a/frontend/src/components/cuaderno/stepper/trace.ts
+++ b/frontend/src/components/cuaderno/stepper/trace.ts
@@ -1,4 +1,4 @@
-import type { Step, Var } from '../../../types/api'
+import type { Step, Var, Junction } from '../../../types/api'
 
 export const ROW_H = 26 // px — load-bearing: slab top = curIdx*ROW_H, line-height
 
@@ -125,4 +125,32 @@ export function markerLefts(trace: Step[]): number[] {
     .map((t, i) => ({ on: t.changed.length > 0, left: denom === 0 ? 50 : (i / denom) * 100 }))
     .filter((m) => m.on)
     .map((m) => m.left)
+}
+
+export type LineRole = 'not-taken' | 'unknown'
+export type JunctionOverlay = { role: Record<number, LineRole>; chips: Record<number, string> }
+
+// Static per-run overlay: dim the body lines of arms the run did not take
+// (or could not observe, under truncation), and chip the crossed arm on its
+// junction's test line. A junction whose test line is itself inside a dimmed
+// range is dead code for this run, so it gets no chip.
+export function junctionOverlay(junctions?: Junction[]): JunctionOverlay {
+  const role: Record<number, LineRole> = {}
+  const chips: Record<number, string> = {}
+  if (!junctions) return { role, chips }
+  for (const j of junctions) {
+    for (const arm of j.arms) {
+      if (arm.taken === true) continue
+      const r: LineRole = arm.taken === null ? 'unknown' : 'not-taken'
+      for (let n = arm.lines[0]; n <= arm.lines[1]; n++) {
+        if (!(n in role)) role[n] = r   // outer (processed first) wins over nested
+      }
+    }
+  }
+  for (const j of junctions) {
+    if (j.test_line in role) continue   // junction sits inside dead code this run
+    const taken = j.arms.find((a) => a.taken === true)
+    if (taken) chips[j.test_line] = `→ ${taken.kind}`
+  }
+  return { role, chips }
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -675,6 +675,11 @@ export type Step = {
   raised?: { type: string; message: string }  // only on the final step if it threw
 }
 
+export type Junction = {
+  test_line: number
+  arms: { kind: 'if' | 'elif' | 'else'; lines: [number, number]; taken: boolean | null }[]
+}
+
 export type StepThroughResponse = {
   kind: 'trace'
   trace: Step[]
@@ -683,6 +688,7 @@ export type StepThroughResponse = {
   file_line: string                   // e.g. "intelligence/symbols.py:255"
   truncated: boolean
   truncated_reason?: 'steps' | 'time' | null
+  junctions?: Junction[]
 }
 
 export type FallbackResponse = {

--- a/src/copyclip/intelligence/capture.py
+++ b/src/copyclip/intelligence/capture.py
@@ -241,6 +241,9 @@ class StepThroughResponse:
     # overrun) — and never conflates truncation with a terminal raise. None when
     # the trace completed cleanly.
     truncated_reason: str | None = None
+    # Cruces v0.1: if/elif/else arms with taken=True|False|None, computed from
+    # the target AST + the executed-line set. Additive; [] means no junctions.
+    junctions: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -251,6 +254,7 @@ class StepThroughResponse:
             "file_line": self.file_line,
             "truncated": self.truncated,
             "truncated_reason": self.truncated_reason,
+            "junctions": list(self.junctions),
         }
 
 

--- a/src/copyclip/intelligence/cuaderno/junctions.py
+++ b/src/copyclip/intelligence/cuaderno/junctions.py
@@ -1,0 +1,117 @@
+"""Cruces / Junctions v0.1 — executed-arm overlay over the step-through.
+
+Pure, I/O-free control-flow reading of a completed trace: for each
+if/elif/else in the target function, mark which arm the run crossed (taken),
+which it did not (not-taken), and — when the trace was truncated — which we
+cannot say (unknown). A branch not taken simply produced no trace events.
+
+See docs/superpowers/specs/2026-07-02-cuaderno-cruces-junctions-design.md.
+"""
+from __future__ import annotations
+
+import ast
+
+
+def compute_junctions(
+    source: str,
+    func_line: int | None,
+    func_name: str,
+    executed_lines: set[int],
+    truncated: bool,
+) -> list[dict]:
+    """Return the if/elif/else junctions of the target function, each arm tagged
+    taken=True|False|None. Fails open to [] on any parse/lookup problem so the
+    feature is invisible rather than wrong."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    target = _find_func(tree, func_line, func_name)
+    if target is None:
+        return []
+    out: list[dict] = []
+    _junctions_in_scope(target.body, executed_lines, truncated, out)
+    return out
+
+
+def _find_func(tree: ast.AST, func_line: int | None, func_name: str):
+    funcs = [
+        n for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    if func_line is not None:
+        for n in funcs:
+            if n.lineno == func_line:
+                return n
+    named = [n for n in funcs if n.name == func_name]
+    return named[0] if len(named) == 1 else None
+
+
+def _arm(kind: str, body: list, executed: set[int], truncated: bool) -> dict:
+    lo = body[0].lineno
+    hi = body[-1].end_lineno
+    hit = any(lo <= line <= hi for line in executed)
+    if hit:
+        taken: bool | None = True
+    elif truncated:
+        taken = None      # unknown — the trace stopped early; do not claim "did not run"
+    else:
+        taken = False
+    return {"kind": kind, "lines": [lo, hi], "taken": taken}
+
+
+def _build_ladder(node: ast.If, executed: set[int], truncated: bool) -> dict:
+    arms = [_arm("if", node.body, executed, truncated)]
+    orelse = node.orelse
+    while len(orelse) == 1 and isinstance(orelse[0], ast.If):
+        elif_node = orelse[0]
+        arms.append(_arm("elif", elif_node.body, executed, truncated))
+        orelse = elif_node.orelse
+    if orelse:
+        arms.append(_arm("else", orelse, executed, truncated))
+    return {"test_line": node.lineno, "arms": arms}
+
+
+def _ladder_bodies(node: ast.If) -> list[list]:
+    """The arm bodies of the ladder, for recursing into nested ifs WITHOUT
+    re-treating the elif If-nodes as their own top-level junctions."""
+    bodies = [node.body]
+    orelse = node.orelse
+    while len(orelse) == 1 and isinstance(orelse[0], ast.If):
+        elif_node = orelse[0]
+        bodies.append(elif_node.body)
+        orelse = elif_node.orelse
+    if orelse:
+        bodies.append(orelse)
+    return bodies
+
+
+def _generic_child_bodies(node: ast.AST) -> list[list]:
+    """Statement-list bodies to descend for nested ifs in the SAME scope
+    (For/While/With/Try). Non-If compound statements only — If is handled by
+    _build_ladder + _ladder_bodies."""
+    out: list[list] = []
+    for field in ("body", "orelse", "finalbody"):
+        val = getattr(node, field, None)
+        if isinstance(val, list) and val and isinstance(val[0], ast.stmt):
+            out.append(val)
+    for handler in getattr(node, "handlers", []) or []:
+        if handler.body:
+            out.append(handler.body)
+    return out
+
+
+def _junctions_in_scope(stmts: list, executed: set[int], truncated: bool, out: list[dict]) -> None:
+    for node in stmts:
+        # Nested defs/classes have their OWN code object and are not traced
+        # (frame-scoping, _capture_driver.py) — we cannot say which of their
+        # branches ran, so we never emit junctions for them.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if isinstance(node, ast.If):
+            out.append(_build_ladder(node, executed, truncated))
+            for body in _ladder_bodies(node):
+                _junctions_in_scope(body, executed, truncated, out)
+        else:
+            for body in _generic_child_bodies(node):
+                _junctions_in_scope(body, executed, truncated, out)

--- a/src/copyclip/intelligence/cuaderno/junctions.py
+++ b/src/copyclip/intelligence/cuaderno/junctions.py
@@ -24,7 +24,7 @@ def compute_junctions(
     feature is invisible rather than wrong."""
     try:
         tree = ast.parse(source)
-    except SyntaxError:
+    except (SyntaxError, ValueError):
         return []
     target = _find_func(tree, func_line, func_name)
     if target is None:
@@ -47,28 +47,45 @@ def _find_func(tree: ast.AST, func_line: int | None, func_name: str):
     return named[0] if len(named) == 1 else None
 
 
-def _arm(kind: str, body: list, executed: set[int], truncated: bool) -> dict:
+def _classify(kind: str, keyword_line: int, body: list, executed: set[int]):
+    """Raw per-arm evidence: (lo, hi, hit, ambiguous).
+
+    An if/elif whose body starts ON its condition line (inline ``if x: a = 1``)
+    cannot be confirmed from a line trace: the condition line is recorded on every
+    evaluation, regardless of which arm runs. So evidence for such an arm starts
+    STRICTLY PAST the condition line — and an inline single-line body has no such
+    line, making it 'ambiguous' (indeterminable from line events alone)."""
     lo = body[0].lineno
     hi = body[-1].end_lineno
-    hit = any(lo <= line <= hi for line in executed)
-    if hit:
-        taken: bool | None = True
-    elif truncated:
-        taken = None      # unknown — the trace stopped early; do not claim "did not run"
-    else:
-        taken = False
-    return {"kind": kind, "lines": [lo, hi], "taken": taken}
+    ev_lo = lo + 1 if (kind in ("if", "elif") and lo == keyword_line) else lo
+    hit = any(ev_lo <= line <= hi for line in executed)
+    ambiguous = ev_lo > hi   # inline arm: no line distinctly proves it ran
+    return lo, hi, hit, ambiguous
 
 
 def _build_ladder(node: ast.If, executed: set[int], truncated: bool) -> dict:
-    arms = [_arm("if", node.body, executed, truncated)]
+    # (kind, keyword_line, body) for each arm of the if/elif/else ladder.
+    spans = [("if", node.lineno, node.body)]
     orelse = node.orelse
     while len(orelse) == 1 and isinstance(orelse[0], ast.If):
         elif_node = orelse[0]
-        arms.append(_arm("elif", elif_node.body, executed, truncated))
+        spans.append(("elif", elif_node.lineno, elif_node.body))
         orelse = elif_node.orelse
     if orelse:
-        arms.append(_arm("else", orelse, executed, truncated))
+        spans.append(("else", orelse[0].lineno, orelse))
+    classified = [(kind, *_classify(kind, kw, body, executed)) for (kind, kw, body) in spans]
+    any_hit = any(c[3] for c in classified)   # c = (kind, lo, hi, hit, ambiguous)
+    arms = []
+    for kind, lo, hi, hit, ambiguous in classified:
+        if hit:
+            taken: bool | None = True
+        elif ambiguous:
+            # inline arm with no distinguishable body line: a distinguishable
+            # sibling running proves this one did not; otherwise we cannot say.
+            taken = False if any_hit else None
+        else:
+            taken = None if truncated else False
+        arms.append({"kind": kind, "lines": [lo, hi], "taken": taken})
     return {"test_line": node.lineno, "arms": arms}
 
 
@@ -98,6 +115,11 @@ def _generic_child_bodies(node: ast.AST) -> list[list]:
     for handler in getattr(node, "handlers", []) or []:
         if handler.body:
             out.append(handler.body)
+    # match/case bodies live in the SAME frame (match creates no code object);
+    # its arms hang off cases[].body, which the field-loop above does not reach.
+    for case in getattr(node, "cases", []) or []:
+        if case.body:
+            out.append(case.body)
     return out
 
 

--- a/src/copyclip/intelligence/playground.py
+++ b/src/copyclip/intelligence/playground.py
@@ -622,9 +622,12 @@ def launch_playground(
         # Low display #6: for a method, use qualname (e.g. "MyClass.process") so
         # the stepper header shows class context; fall back to name otherwise.
         func_name = (resolved.qualname if resolved.parent_class else resolved.name)
+        executed_lines = {s.line for s in steps if s.line}
+        junctions = _junctions_for(resolved, project_root, executed_lines, truncated)
         return StepThroughResponse(
             trace=steps, source_lines=source_lines, func_name=func_name,
-            file_line=file_line, truncated=truncated, truncated_reason=truncated_reason)
+            file_line=file_line, truncated=truncated, truncated_reason=truncated_reason,
+            junctions=junctions)
 
     # Non-cuaderno sources: the Marimo iframe path is UNCHANGED.
     return _launch_marimo(req, project_root, resolved, runner, trace)
@@ -746,6 +749,26 @@ def _looks_absolute(path: str) -> bool:
     if len(path) >= 2 and path[1] == ":":
         return True
     return False
+
+
+def _junctions_for(
+    resolved: ResolvedFunction,
+    project_root: str,
+    executed_lines: set[int],
+    truncated: bool,
+) -> list[dict]:
+    """Read the target's source and compute its if/elif/else junctions. Pure
+    logic lives in cuaderno.junctions; this only supplies the source text and
+    fails open to [] so a read/parse problem never breaks the step-through."""
+    from .cuaderno.junctions import compute_junctions
+    try:
+        with open(os.path.join(project_root, resolved.file), encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError:
+        return []
+    return compute_junctions(
+        source, resolved.line_start, resolved.name, executed_lines, truncated
+    )
 
 
 def _module_from_file(file_path: str) -> str:

--- a/src/copyclip/intelligence/playground.py
+++ b/src/copyclip/intelligence/playground.py
@@ -764,11 +764,14 @@ def _junctions_for(
     try:
         with open(os.path.join(project_root, resolved.file), encoding="utf-8") as fh:
             source = fh.read()
-    except OSError:
+        return compute_junctions(
+            source, resolved.line_start, resolved.name, executed_lines, truncated
+        )
+    except (OSError, ValueError):
+        # OSError (missing/unreadable) or ValueError (a non-utf-8 source raises
+        # UnicodeDecodeError, a ValueError subclass) — fail open so this optional
+        # overlay never breaks a step-through the capture already produced.
         return []
-    return compute_junctions(
-        source, resolved.line_start, resolved.name, executed_lines, truncated
-    )
 
 
 def _module_from_file(file_path: str) -> str:

--- a/tests/test_junctions.py
+++ b/tests/test_junctions.py
@@ -126,3 +126,64 @@ def test_syntax_error_returns_empty():
 
 def test_target_not_found_returns_empty():
     assert compute_junctions(SRC_IF_ELSE, 999, "missing", {3}, False) == []
+
+
+# ---- adversarial-review fixes: inline bodies, match nesting, null-byte source ----
+
+SRC_INLINE = (
+    "\n"
+    "def f(x):\n"          # 2
+    "    if x: a = 1\n"    # 3  (test AND if-body share line 3)
+    "    else: a = 2\n"    # 4
+    "    return a\n"       # 5
+)
+
+SRC_INLINE_BARE = (
+    "\n"
+    "def h(x):\n"          # 2
+    "    if x: a = 1\n"    # 3
+    "    return a\n"       # 4
+)
+
+SRC_MATCH = (
+    "\n"
+    "def m(x):\n"              # 2
+    "    match x:\n"           # 3
+    "        case 1:\n"        # 4
+    "            if x > 0:\n"  # 5
+    "                a = 1\n"  # 6
+    "            else:\n"      # 7
+    "                a = 2\n"  # 8
+    "        case _:\n"        # 9
+    "            a = 3\n"      # 10
+    "    return a\n"           # 11
+)
+
+
+def test_inline_if_else_took_else_no_overclaim():
+    # f(0): the else runs. The if-body shares its line with the always-recorded
+    # test line, so it must NOT be claimed taken — the else must get the chip.
+    j = compute_junctions(SRC_INLINE, 2, "f", {3, 4, 5}, False)
+    assert j == [{"test_line": 3, "arms": [
+        {"kind": "if", "lines": [3, 3], "taken": False},
+        {"kind": "else", "lines": [4, 4], "taken": True},
+    ]}]
+
+
+def test_inline_bare_if_is_unknown_not_overclaimed():
+    # `if x: a = 1` with no else: a line trace cannot tell whether the body ran
+    # (its only line is the ever-recorded test line) -> honest None, never True/False.
+    j = compute_junctions(SRC_INLINE_BARE, 2, "h", {3, 4}, False)
+    assert j == [{"test_line": 3, "arms": [{"kind": "if", "lines": [3, 3], "taken": None}]}]
+
+
+def test_if_inside_match_case_is_emitted():
+    # an if inside a match/case body is in the target's own frame -> must appear.
+    j = compute_junctions(SRC_MATCH, 2, "m", {3, 4, 5, 6, 11}, False)
+    inner = next(x for x in j if x["test_line"] == 5)
+    assert inner["arms"][0]["taken"] is True    # if body (line 6) executed
+    assert inner["arms"][1]["taken"] is False   # else body (line 8) not executed
+
+
+def test_null_byte_source_returns_empty():
+    assert compute_junctions("def f():\n\x00", 1, "f", set(), False) == []

--- a/tests/test_junctions.py
+++ b/tests/test_junctions.py
@@ -1,0 +1,128 @@
+from copyclip.intelligence.cuaderno.junctions import compute_junctions
+
+SRC_IF_ELSE = (
+    "\n"
+    "def f(x):\n"          # line 2
+    "    if x > 0:\n"      # line 3
+    "        a = 1\n"      # line 4
+    "        b = 2\n"      # line 5
+    "    else:\n"          # line 6
+    "        a = -1\n"     # line 7
+    "    return a\n"       # line 8
+)
+
+SRC_LADDER = (
+    "\n"
+    "def g(x):\n"          # 2
+    "    if x == 1:\n"     # 3
+    "        r = 'a'\n"    # 4
+    "    elif x == 2:\n"   # 5
+    "        r = 'b'\n"    # 6
+    "    else:\n"          # 7
+    "        r = 'c'\n"    # 8
+    "    return r\n"       # 9
+)
+
+SRC_BARE_IF = (
+    "\n"
+    "def h(x):\n"          # 2
+    "    y = 0\n"          # 3
+    "    if x:\n"          # 4
+    "        y = 1\n"      # 5
+    "    return y\n"       # 6
+)
+
+SRC_NESTED = (
+    "\n"
+    "def n(x):\n"          # 2
+    "    if x > 0:\n"      # 3
+    "        if x > 10:\n" # 4
+    "            a = 2\n"  # 5
+    "        else:\n"      # 6
+    "            a = 1\n"  # 7
+    "    else:\n"          # 8
+    "        a = 0\n"      # 9
+    "    return a\n"       # 10
+)
+
+SRC_NESTED_DEF = (
+    "\n"
+    "def outer(x):\n"          # 2
+    "    def inner(y):\n"      # 3
+    "        if y:\n"          # 4
+    "            return 1\n"   # 5
+    "        return 0\n"       # 6
+    "    if x:\n"              # 7
+    "        return inner(x)\n"# 8
+    "    return -1\n"          # 9
+)
+
+
+def test_if_else_took_if():
+    j = compute_junctions(SRC_IF_ELSE, 2, "f", {3, 4, 5, 8}, False)
+    assert j == [{"test_line": 3, "arms": [
+        {"kind": "if", "lines": [4, 5], "taken": True},
+        {"kind": "else", "lines": [7, 7], "taken": False},
+    ]}]
+
+
+def test_if_else_took_else():
+    j = compute_junctions(SRC_IF_ELSE, 2, "f", {3, 7, 8}, False)
+    arms = j[0]["arms"]
+    assert arms[0]["taken"] is False
+    assert arms[1]["taken"] is True
+
+
+def test_ladder_took_elif():
+    j = compute_junctions(SRC_LADDER, 2, "g", {3, 5, 6, 9}, False)
+    assert j == [{"test_line": 3, "arms": [
+        {"kind": "if", "lines": [4, 4], "taken": False},
+        {"kind": "elif", "lines": [6, 6], "taken": True},
+        {"kind": "else", "lines": [8, 8], "taken": False},
+    ]}]
+
+
+def test_bare_if_no_else():
+    j = compute_junctions(SRC_BARE_IF, 2, "h", {3, 4, 6}, False)
+    assert j == [{"test_line": 4, "arms": [
+        {"kind": "if", "lines": [5, 5], "taken": False},
+    ]}]
+
+
+def test_truncated_yields_unknown_not_false():
+    # only the test line was reached before the cap
+    j = compute_junctions(SRC_IF_ELSE, 2, "f", {3}, True)
+    arms = j[0]["arms"]
+    assert arms[0]["taken"] is None
+    assert arms[1]["taken"] is None
+
+
+def test_nested_if_inside_taken_arm():
+    # outer took the if-arm; inner took its else-arm
+    j = compute_junctions(SRC_NESTED, 2, "n", {3, 4, 7, 10}, False)
+    outer = next(x for x in j if x["test_line"] == 3)
+    inner = next(x for x in j if x["test_line"] == 4)
+    assert outer["arms"][0]["taken"] is True     # if-arm (lines 4..7)
+    assert outer["arms"][1]["taken"] is False    # else-arm (line 9)
+    assert inner["arms"][0]["taken"] is False    # inner if (line 5)
+    assert inner["arms"][1]["taken"] is True     # inner else (line 7)
+
+
+def test_if_in_nested_def_excluded():
+    # inner()'s `if y:` must NOT appear — nested defs are not traced
+    j = compute_junctions(SRC_NESTED_DEF, 2, "outer", {7, 8}, False)
+    assert all(x["test_line"] != 4 for x in j)
+    assert [x["test_line"] for x in j] == [7]
+
+
+def test_no_if_returns_empty():
+    src = "\ndef p(x):\n    return x + 1\n"
+    assert compute_junctions(src, 2, "p", {3}, False) == []
+
+
+def test_syntax_error_returns_empty():
+    assert compute_junctions("def broken(:\n", 1, "broken", set(), False) == []
+
+
+def test_target_not_found_returns_empty():
+    assert compute_junctions(SRC_IF_ELSE, 999, "missing", {3}, False) == []

--- a/tests/test_junctions_wiring.py
+++ b/tests/test_junctions_wiring.py
@@ -1,0 +1,56 @@
+import os
+import textwrap
+
+from copyclip.intelligence.capture import StepThroughResponse, Step
+from copyclip.intelligence import playground as pg
+from copyclip.intelligence.playground import ResolvedFunction
+
+
+def test_to_dict_includes_junctions():
+    resp = StepThroughResponse(
+        trace=[Step(line=3, event="line", changed=[], scope=[])],
+        source_lines=[{"num": 3, "text": "if x:"}],
+        func_name="f", file_line="a.py:2", truncated=False, truncated_reason=None,
+        junctions=[{"test_line": 3, "arms": [{"kind": "if", "lines": [4, 4], "taken": True}]}],
+    )
+    d = resp.to_dict()
+    assert d["junctions"] == [{"test_line": 3, "arms": [{"kind": "if", "lines": [4, 4], "taken": True}]}]
+
+
+def test_to_dict_junctions_defaults_empty():
+    resp = StepThroughResponse(
+        trace=[], source_lines=[], func_name="f", file_line="a.py:1",
+        truncated=False, truncated_reason=None,
+    )
+    assert resp.to_dict()["junctions"] == []
+
+
+def test_junctions_for_reads_file_and_computes(tmp_path):
+    src = textwrap.dedent(
+        """\
+        def f(x):
+            if x > 0:
+                a = 1
+            else:
+                a = -1
+            return a
+        """
+    )
+    (tmp_path / "m.py").write_text(src, encoding="utf-8")
+    resolved = ResolvedFunction(
+        file="m.py", name="f", qualname="f", kind="function",
+        module="m", line_start=1, parent_class=None,
+    )
+    j = pg._junctions_for(resolved, str(tmp_path), {2, 3, 6}, False)
+    assert j == [{"test_line": 2, "arms": [
+        {"kind": "if", "lines": [3, 3], "taken": True},
+        {"kind": "else", "lines": [5, 5], "taken": False},
+    ]}]
+
+
+def test_junctions_for_missing_file_returns_empty():
+    resolved = ResolvedFunction(
+        file="nope.py", name="f", qualname="f", kind="function",
+        module="m", line_start=1, parent_class=None,
+    )
+    assert pg._junctions_for(resolved, os.getcwd(), {1}, False) == []

--- a/tests/test_junctions_wiring.py
+++ b/tests/test_junctions_wiring.py
@@ -54,3 +54,23 @@ def test_junctions_for_missing_file_returns_empty():
         module="m", line_start=1, parent_class=None,
     )
     assert pg._junctions_for(resolved, os.getcwd(), {1}, False) == []
+
+
+def test_junctions_for_non_utf8_source_fails_open(tmp_path):
+    # A PEP-263-declared latin-1 file: the capture driver decodes it fine (honors
+    # the cookie), but _junctions_for's strict utf-8 read hits the 0xE9 byte and
+    # raises UnicodeDecodeError (a ValueError, NOT an OSError). It must fail open
+    # to [] — never propagate and 500 the already-successful step-through.
+    (tmp_path / "legacy.py").write_bytes(
+        b"# -*- coding: latin-1 -*-\n"
+        b"def f(x):\n"
+        b"    y = '\xe9'\n"
+        b"    if x:\n"
+        b"        return y\n"
+        b"    return None\n"
+    )
+    resolved = ResolvedFunction(
+        file="legacy.py", name="f", qualname="f", kind="function",
+        module="legacy", line_start=2, parent_class=None,
+    )
+    assert pg._junctions_for(resolved, str(tmp_path), {2, 4, 5}, False) == []


### PR DESCRIPTION
## What

In the cuaderno step-through, mark **which `if`/`elif`/`else` arm the run crossed** — as a computed structural overlay on the source pane, never narrated. Not-taken arms dim; a gutter chip (`→ if`, `→ else`) names the crossed arm on its test line. A branch not taken simply produced no trace events; the overlay reads that off the existing trace.

Honors the founding discipline (*exposición, no autoría*): the overlay states what the run did, and — critically — a tri-state `taken` (`true`/`false`/`null`) never claims a branch "did not run" when the evidence is incomplete (truncated trace → `null`, unknown).

Roadmap Forward #1 — Cruces/Junctions ([#146]). Continuation of the playground arc (run-a-symbol → step-through → call synthesis). Reuses the already-shipped tracer/Stepper/capture substrate: a pure function + one additive field + per-line decoration. **No capture-pipeline change** — reads a completed trace.

- Design: `docs/superpowers/specs/2026-07-02-cuaderno-cruces-junctions-design.md`
- Plan: `docs/superpowers/plans/2026-07-02-cuaderno-cruces-junctions.md`

[#146]: https://github.com/sssamuelll/copyclip/issues/146

## How (4 TDD tasks)

1. **`compute_junctions`** — pure, I/O-free module (`cuaderno/junctions.py`): whole-file `ast.parse`, walk the target function's own body for `if`/`elif`/`else` at any depth, classify each arm's `taken` from the executed-line set. Fails open to `[]` on any parse/lookup problem.
2. **Wiring** — additive `junctions` field on `StepThroughResponse` (default `[]`, serialized in `to_dict`); `playground.py` computes it from the trace at the step-through return. Reads the target source; fails open.
3. **Frontend contract** — optional `junctions?: Junction[]` + `Junction` type on `StepThroughResponse`.
4. **Overlay** — `junctionOverlay` in `trace.ts` (role + chips maps); the Stepper dims not-taken/unknown arm bodies and draws the crossed-arm chip, suppressed under `staleAnchor`.

## Adversarial verification

An 11-agent workflow (4 independent lenses — honesty rule, AST extraction, frontend overlay, integration seam — each finding refuted by a separate skeptic). 7 findings raised, **4 confirmed (3 root causes), 0 blockers**; 3 false positives refuted (loop-both-arms chip, `else{if}`→`elif` flattening, post-raise not-taken). All 3 confirmed root causes fixed with regression tests (commit `5aa54d3`):

- **HIGH (honesty):** an inline single-line body (`if x: a = 1`) shares its line with the always-recorded condition line, so the arm was marked `taken=True` even when the other arm ran — a confidently-wrong chip. Fixed: evidence for an `if`/`elif` arm now starts strictly past its condition line; an inline arm with no distinct body line is `false` when a distinguishable sibling ran, else `null` (honest unknown).
- **MEDIUM (fail-open):** `_junctions_for` caught only `OSError`; a non-UTF-8 source raises `UnicodeDecodeError` (a `ValueError`) and would 500 an already-successful step-through. Now catches `(OSError, ValueError)`; `compute_junctions` broadened to `(SyntaxError, ValueError)`.
- **MEDIUM (coverage):** an `if` inside a `match`/`case` (same frame) was dropped — `_generic_child_bodies` now descends `cases[].body`.

## Tests

- Backend: **1040 passed, 3 skipped** (full suite). `compute_junctions` + wiring: 19/19, including inline-body honesty, match nesting, non-UTF-8 fail-open, truncation → unknown.
- Frontend: **219 passed**, `tsc --noEmit` clean, `npm run build` OK. `junctionOverlay`: 4/4.
- Additive & optional throughout — absent/empty `junctions` → Stepper behaves exactly as before; zero existing tests changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added junction-aware step-through rendering that highlights control-flow branches in the source view.
  * Step-through responses now include branch metadata, enabling the UI to show which paths were taken, not taken, or unknown.
  * Improved handling for stale source anchors by hiding the branch overlay when it can’t be safely matched.

* **Bug Fixes**
  * Better preserves branch display accuracy for nested and truncated traces.
  * Added safeguards so missing or unreadable source data falls back gracefully without breaking playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->