### PR TITLE
docs(roadmap): reconcile Forward with main — Cruces + Pulso shipped, fix Pulso mechanism

### DIFF
--- a/src/copyclip/roadmap.md
+++ b/src/copyclip/roadmap.md
@@ -1,7 +1,9 @@
 # 🚀 CopyClip — Capability Roadmap
 
 > Runtime/package version is currently `v0.4.0`. This describes product capability
-> direction, not a strict semver changelog.
+> direction, not a strict semver changelog. Last reconciled **2026-07-07** against
+> `main` @ `eb92344` — the previous list carried Cruces and Pulso as "Forward"
+> after both had already shipped; corrected here.
 
 ## The surface: the cuaderno
 
@@ -17,21 +19,58 @@ cited tutor tool or widget; three auxiliary views survive — **codebase map**,
 **safe handoff**, **settings** — reached from the cuaderno's ⊞ menu. MCP exposes
 the same bounded, audited views to external agents.
 
-## ✅ Shipped baseline
-- [x] **Cuaderno:** evidence-first tutor; answers stream as cited blocks + widgets; the human ratifies decision status (the one write).
+## ✅ Shipped
+
+**Baseline**
+- [x] **Cuaderno:** evidence-first tutor; answers stream (SSE) as cited blocks + widgets; the human ratifies decision status (the one write).
 - [x] **MCP server:** bounded, audited project views for external agents (intent manifesto, context bundle, audit, heat, handoff).
-- [x] **Codebase map:** interactive graph of the codebase (a survivor side surface).
-- [x] **Safe handoff:** bounded delegation packets with pre-delegation review.
-- [x] **Heat:** maintenance/attention pressure per file, from the live composite engine.
-- [x] **In-situ setup + background analysis:** LLM config and re-index from settings; analysis follows the rhythm of bursts.
+- [x] **Codebase map**, **safe handoff**, **in-situ setup + background analysis** — the surviving side surfaces and the re-index rhythm.
+
+**Answer honesty (engine/quality)**
+- [x] **Multi-provider** LLM (DeepSeek default, OpenAI-compat adapter) with SSE streaming.
+- [x] **Answer quality:** a deterministic evidence gate plus a semantic judge, with two-world abstention — an answer it cannot stand behind abstains rather than asserts.
+
+**The comprehension ladder** — six tutor moves, each a deterministic anchor over real substrate, each withholding the interpretive act; subordinated under the cognitive-load / explain-by-altitude doctrine:
+- [x] ① Walk the path · ② Accepted, not decided · ③ Hasn't been back · ④ Blast radius · ⑤ Commit change graph · ⑥ Teach-back.
+
+**The playground arc** — one paid-for capture, read ever more cheaply, never a control surface, never a fabrication:
+- [x] **Run a symbol** with a real example (the boundary).
+- [x] **Guided step-through** — record-then-replay of the real run, line by line (#177).
+- [x] **Call synthesis** — auto-fill a runnable call lifted from real usage (#178).
+- [x] **Cruces / Junctions v0.1** — which `if`/`elif`/`else` arm the run crossed, computed, tri-state honest (`null` when the trace was truncated, never overclaimed) (#179).
+
+**Pulso** — clocks that follow the rhythm of bursts, not the wall clock:
+- [x] **Last contact** (burst-recency from the `Co-Authored-By` AI-burst signal) and **Last visit** (decision ratification as a second clock) (#162–166). Heat v2 dropped the dead `agent_authored_ratio` factor.
 
 ## 🎯 Forward (≤3)
-1. **Cruces / Junctions v0.1** ([#146]) — in the playground, show *which branch executed the input you just edited*, as a computed value, never narrated. High-level debugging anchored to a real run.
-2. **Pulso** ([#152]) — continuous, incremental, background analysis that follows the rhythm of development bursts (filesystem watch or commit trigger, non-intrusive notices). The connective tissue that lets CopyClip survive the gap between bursts.
-3. **Intent Drift Surface** — a passive layer that flags code regions drifted from registered architectural decisions and surfaces the drift to the author for inspection. Never proposes refactors or triggers agentic action — *exposición, no autoría*.
+
+*(reconciled 2026-07-07; the prior #1 Cruces and #2 Pulso both shipped)*
+
+1. **Cruces / Junctions v0.2 — control-flow C** ([#146]) — extend the executed-arm
+   overlay beyond the `if` ladder: loops (`for`/`while` ran-vs-skipped + iteration
+   counts), `try`/`except`/`finally`, ternaries, `match`/`case`. Loop
+   iteration-identity is a joint fix — it also unlocks the step-through's deferred
+   loop-folding. Built from real captured cases, never speculation.
+2. **Intent Drift Surface** — a passive layer that flags code regions drifted from
+   registered architectural decisions, for the author to inspect. Never proposes
+   refactors or triggers agentic action — *exposición, no autoría*. **Honest
+   precursor:** the decision ledger is nearly empty, so *populating decisions*
+   likely has to precede the feature — drift needs something to drift *from*.
+3. **Aprendizaje / active-recall** — the family that would consume the write-only
+   `got_it` and the ④/⑥ prediction events. **Gated on one deliberate decision:
+   the witness-event ledger** — the substrate that unblocks it sits one refactor
+   from becoming the per-file comprehension score the doctrine forbids. Decide it
+   consciously, do not drift into it; its current *absence* is what protects the
+   doctrine.
+
+**Held / gated (deliberately not in the ≤3):** Pulso's continuous background infra
+(commit-trigger + WAL; filesystem-watch was rejected in the kickoff) and its
+burst→gap→reconnection ledger; polyglot playground *execution* (static analysis is
+already polyglot via tree-sitter, execution is Python-only — gate on real demand);
+the eval-harness (Phase B noise-floor is the gate before trusting any regression
+delta).
 
 [#146]: https://github.com/sssamuelll/copyclip/issues/146
-[#152]: https://github.com/sssamuelll/copyclip/issues/152
 
 # 🎯 Vision
 A personal cognitive sentinel for the author — the tool that lets him stay


### PR DESCRIPTION
## Why

For a tool whose doctrine is *"the map must never lie about what is real,"* its own
roadmap was lying. `Forward (≤3)` still listed **Cruces (#146)** and **Pulso (#152)**
as pending after both had merged to `main`, and the Pulso line still named a
**filesystem-watch** mechanism the kickoff (#161) explicitly rejected in favour of a
commit-trigger. Reconciled against `main` @ `eb92344`.

## What changed

**Retired from Forward → moved to Shipped (both are on `main`):**
- Cruces / Junctions v0.1 (#179).
- Pulso v0.1 "Last contact" + v0.2.1 "Last visit" (#162–166); heat v2 dropped the dead `agent_authored_ratio` factor (#165).

**Represented what was under-listed** (Shipped was missing most of what shipped):
- the comprehension ladder ①–⑥ (#167–174),
- the full playground arc — run → step-through (#177) → call synthesis (#178) → Cruces (#179),
- engine honesty — deterministic gate + semantic judge + two-world abstention,
- Pulso's contact/visit clocks.

**New Forward (≤3)** — reconciled, and honest about what gates each:
1. **Cruces / Junctions v0.2 — control-flow C** (loops / try / ternary / match; loop iteration-identity also unlocks the deferred step-through loop-folding).
2. **Intent Drift Surface** — with the honest precursor named: the decision ledger is nearly empty, so *populating decisions* likely precedes the feature.
3. **Aprendizaje / active-recall** — gated on the **witness-event ledger** decision, to be made consciously (it sits one refactor from the per-file comprehension score the doctrine forbids; its absence is what protects the doctrine).

Plus a **Held / gated** section for what exists but is deliberately not in the top-3: Pulso's continuous background infra (commit-trigger + WAL), polyglot playground *execution* (static analysis is already polyglot; execution is Python-only — gate on real demand), and the eval-harness (Phase B noise-floor gate).

Docs-only. No code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the roadmap note so the runtime/package version is presented as descriptive rather than a semantic version.
  * Updated the reconciliation status and refreshed the shipped and upcoming capability lists for better accuracy.
  * Expanded the roadmap with more detailed descriptions of shipped features and near-term priorities, including updated product milestones and gated items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->