### PR TITLE
feat(cuaderno): wire the entry cue to session-open — the first honest push

### DIFF
--- a/frontend/src/api/cuaderno.ts
+++ b/frontend/src/api/cuaderno.ts
@@ -1,4 +1,4 @@
-import type { CuadernoSession, CuadernoStreamEvent, CuadernoProvidersResponse } from '../types/api'
+import type { CuadernoSession, CuadernoStreamEvent, CuadernoProvidersResponse, EntryCueResponse } from '../types/api'
 
 async function patchJson<T>(url: string, body: unknown): Promise<T> {
   const r = await fetch(url, {
@@ -53,6 +53,9 @@ export const cuadernoApi = {
   },
   providers() {
     return getJson<CuadernoProvidersResponse>('/api/cuaderno/providers')
+  },
+  entryCue() {
+    return getJson<EntryCueResponse>('/api/cuaderno/entry-cue')
   },
   setProvider(provider: string, model: string) {
     return postJson<{ status: string }>('/api/config', {

--- a/frontend/src/components/cuaderno/Cuaderno.tsx
+++ b/frontend/src/components/cuaderno/Cuaderno.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { Block, Citation, CuadernoQuestion, ToolRow, CuadernoProvidersResponse } from '../../types/api'
+import type { Block, Citation, CuadernoQuestion, ToolRow, CuadernoProvidersResponse, EntryCue } from '../../types/api'
 import { SURVIVOR_NAV, type SurvivorPage } from '../../nav'
 import { Composer } from './Composer'
 import { AnswerCheck } from './AnswerCheck'
@@ -26,6 +26,7 @@ type Props = {
   onSelectFromHistory: (position: number) => void
   onSetAnswerCheck: (position: number, value: 'answers' | 'not_yet') => void
   questionLanguage?: string | null
+  entryCue?: EntryCue | null
 }
 
 export function Cuaderno({
@@ -44,6 +45,7 @@ export function Cuaderno({
   onSelectFromHistory,
   onSetAnswerCheck,
   questionLanguage,
+  entryCue = null,
 }: Props) {
   const [sidePanelFor, setSidePanelFor] = useState<Citation | null>(null)
   const [historyOpen, setHistoryOpen] = useState(false)
@@ -140,7 +142,7 @@ export function Cuaderno({
       <div className="cua-stage swap-fade">
         <div className="cua-frame-wrap">
           <div className="cua-frame" key={activeQuestion?.position ?? scene}>
-            {scene === 'empty' && <FrameEmpty onAsk={onAsk} />}
+            {scene === 'empty' && <FrameEmpty onAsk={onAsk} entryCue={entryCue} />}
             {scene === 'midstream' && (
               <FrameMidStream
                 question={streamingQuestion || questions[questions.length - 1]?.question || '…'}

--- a/frontend/src/components/cuaderno/frames/FrameEmpty.test.tsx
+++ b/frontend/src/components/cuaderno/frames/FrameEmpty.test.tsx
@@ -14,21 +14,26 @@ const CUE: EntryCue = {
   stale: false,
 }
 
+const h1Text = (container: HTMLElement) =>
+  container.querySelector('h1')?.textContent ?? ''
+
 describe('FrameEmpty — entry cue', () => {
-  it('without a cue, keeps the default first-time copy (silent, nothing invented)', () => {
-    render(<FrameEmpty onAsk={() => {}} />)
-    expect(screen.getByText(/First time in this project/)).toBeInTheDocument()
-    expect(screen.queryByText(/AI burst/)).toBeNull()
+  it('without a cue, renders neutral copy with NO unwitnessed claims (no "first time", no burst)', () => {
+    const { container } = render(<FrameEmpty onAsk={() => {}} />)
+    expect(screen.getByText(/What interests you\?/)).toBeInTheDocument()
+    // "First time in this project" was a claim the system cannot witness — gone.
+    expect(container.textContent).not.toMatch(/first time/i)
+    expect(container.textContent).not.toMatch(/AI burst/)
   })
 
-  it('with a cue, surfaces the computed gap instead of the first-time copy', () => {
+  it('with a fresh cue, surfaces the computed gap in witnessed present tense', () => {
     const { container } = render(<FrameEmpty onAsk={() => {}} entryCue={CUE} />)
-    expect(screen.queryByText(/First time in this project/)).toBeNull()
     const text = container.textContent ?? ''
     expect(text).toContain('src/copyclip/intelligence/capture.py')
     expect(text).toMatch(/AI burst shaped/)
     expect(text).toMatch(/~19 days ago/)
     expect(text).toMatch(/haven't been back in 41 days/)
+    expect(text).not.toMatch(/first time/i)
   })
 
   it('cue starter launches an ask about that file', async () => {
@@ -41,11 +46,17 @@ describe('FrameEmpty — entry cue', () => {
     expect(onAsk.mock.calls[0][0]).toContain('src/copyclip/intelligence/capture.py')
   })
 
-  it('a stale cue hedges the claim to the age of the last analysis', () => {
+  it('a stale cue rescopes the GAP CLAIM ITSELF in the headline — never a present-tense gap', () => {
     const { container } = render(
       <FrameEmpty onAsk={() => {}} entryCue={{ ...CUE, stale: true, analyzed_age_days: 20 }} />,
     )
-    expect(container.textContent).toMatch(/as of the last analysis ~20 days ago/i)
+    const h1 = h1Text(container)
+    // the claim carries its own scope, in past tense, inside the h1
+    expect(h1).toMatch(/As of the last analysis ~20 days ago, you hadn't been back in 41 days\./)
+    // the unhedged present-tense form must NOT appear anywhere
+    expect(container.textContent).not.toMatch(/You haven't been back/)
+    // the burst fact itself stays unhedged — it is a witnessed commit
+    expect(h1).toMatch(/AI burst shaped/)
   })
 
   it('a fresh cue does not hedge', () => {
@@ -53,12 +64,47 @@ describe('FrameEmpty — entry cue', () => {
     expect(container.textContent).not.toMatch(/as of the last analysis/i)
   })
 
-  it('never_human_touched says so instead of claiming a return gap', () => {
-    const { container } = render(
+  it('never_human_touched: present claim when fresh, past + scoped when stale', () => {
+    const fresh = render(
       <FrameEmpty onAsk={() => {}} entryCue={{ ...CUE, never_human_touched: true }} />,
     )
-    expect(container.textContent).toMatch(/no human commit has ever touched it/i)
-    expect(container.textContent).not.toMatch(/haven't been back in/)
+    expect(fresh.container.textContent).toMatch(/No human commit has ever touched it\./)
+    expect(fresh.container.textContent).not.toMatch(/been back/)
+    fresh.unmount()
+
+    const stale = render(
+      <FrameEmpty
+        onAsk={() => {}}
+        entryCue={{ ...CUE, never_human_touched: true, stale: true, analyzed_age_days: 20 }}
+      />,
+    )
+    const h1 = h1Text(stale.container)
+    expect(h1).toMatch(/As of the last analysis ~20 days ago, no human commit had touched it\./)
+    expect(stale.container.textContent).not.toMatch(/has ever touched/)
+  })
+
+  it('last_contact_days=0 never renders "0 days" — the same-day touch is phrased honestly', () => {
+    const { container } = render(
+      <FrameEmpty onAsk={() => {}} entryCue={{ ...CUE, last_contact_days: 0 }} />,
+    )
+    expect(container.textContent).toMatch(/You touched it earlier today — the burst came after\./)
+    expect(container.textContent).not.toMatch(/0 days/)
+  })
+
+  it('singular day counts render "1 day", never "1 days"', () => {
+    const { container } = render(
+      <FrameEmpty onAsk={() => {}} entryCue={{ ...CUE, last_contact_days: 1, ai_burst_days: 1 }} />,
+    )
+    expect(container.textContent).toMatch(/~1 day ago/)
+    expect(container.textContent).toMatch(/back in 1 day\./)
+    expect(container.textContent).not.toMatch(/1 days/)
+  })
+
+  it('ai_burst_days=0 renders "today"', () => {
+    const { container } = render(
+      <FrameEmpty onAsk={() => {}} entryCue={{ ...CUE, ai_burst_days: 0 }} />,
+    )
+    expect(h1Text(container)).toMatch(/shaped .* today\./)
   })
 
   it('the three generic starters survive in both states', () => {

--- a/frontend/src/components/cuaderno/frames/FrameEmpty.test.tsx
+++ b/frontend/src/components/cuaderno/frames/FrameEmpty.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FrameEmpty } from './FrameEmpty'
+import type { EntryCue } from '../../../types/api'
+
+const CUE: EntryCue = {
+  file_path: 'src/copyclip/intelligence/capture.py',
+  last_contact_days: 41,
+  ai_burst_days: 19,
+  last_contact_source: 'git',
+  never_human_touched: false,
+  analyzed_age_days: 3,
+  stale: false,
+}
+
+describe('FrameEmpty — entry cue', () => {
+  it('without a cue, keeps the default first-time copy (silent, nothing invented)', () => {
+    render(<FrameEmpty onAsk={() => {}} />)
+    expect(screen.getByText(/First time in this project/)).toBeInTheDocument()
+    expect(screen.queryByText(/AI burst/)).toBeNull()
+  })
+
+  it('with a cue, surfaces the computed gap instead of the first-time copy', () => {
+    const { container } = render(<FrameEmpty onAsk={() => {}} entryCue={CUE} />)
+    expect(screen.queryByText(/First time in this project/)).toBeNull()
+    const text = container.textContent ?? ''
+    expect(text).toContain('src/copyclip/intelligence/capture.py')
+    expect(text).toMatch(/AI burst shaped/)
+    expect(text).toMatch(/~19 days ago/)
+    expect(text).toMatch(/haven't been back in 41 days/)
+  })
+
+  it('cue starter launches an ask about that file', async () => {
+    const onAsk = vi.fn()
+    render(<FrameEmpty onAsk={onAsk} entryCue={CUE} />)
+    await userEvent.click(
+      screen.getByRole('button', { name: /why does .*capture\.py exist/i }),
+    )
+    expect(onAsk).toHaveBeenCalledTimes(1)
+    expect(onAsk.mock.calls[0][0]).toContain('src/copyclip/intelligence/capture.py')
+  })
+
+  it('a stale cue hedges the claim to the age of the last analysis', () => {
+    const { container } = render(
+      <FrameEmpty onAsk={() => {}} entryCue={{ ...CUE, stale: true, analyzed_age_days: 20 }} />,
+    )
+    expect(container.textContent).toMatch(/as of the last analysis ~20 days ago/i)
+  })
+
+  it('a fresh cue does not hedge', () => {
+    const { container } = render(<FrameEmpty onAsk={() => {}} entryCue={CUE} />)
+    expect(container.textContent).not.toMatch(/as of the last analysis/i)
+  })
+
+  it('never_human_touched says so instead of claiming a return gap', () => {
+    const { container } = render(
+      <FrameEmpty onAsk={() => {}} entryCue={{ ...CUE, never_human_touched: true }} />,
+    )
+    expect(container.textContent).toMatch(/no human commit has ever touched it/i)
+    expect(container.textContent).not.toMatch(/haven't been back in/)
+  })
+
+  it('the three generic starters survive in both states', () => {
+    const { rerender } = render(<FrameEmpty onAsk={() => {}} />)
+    expect(screen.getByRole('button', { name: /what does this project do/i })).toBeInTheDocument()
+    rerender(<FrameEmpty onAsk={() => {}} entryCue={CUE} />)
+    expect(screen.getByRole('button', { name: /what does this project do/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/cuaderno/frames/FrameEmpty.tsx
+++ b/frontend/src/components/cuaderno/frames/FrameEmpty.tsx
@@ -1,19 +1,75 @@
-type Props = { onAsk: (q: string) => void }
+import type { EntryCue } from '../../../types/api'
 
-export function FrameEmpty({ onAsk }: Props) {
+type Props = { onAsk: (q: string) => void; entryCue?: EntryCue | null }
+
+const mono = {
+  fontFamily: 'var(--font-mono)',
+  fontStyle: 'normal',
+  fontSize: '0.85em',
+} as const
+
+// Rendering doctrine (prompts.py, get_entry_cue): "an AI burst shaped `X`
+// ~N days ago; you haven't been back". If stale, scope the claim to "as of the
+// last analysis ~N days ago" — never a present-tense gap past what analysis
+// witnessed. A null cue means nothing to surface: the default copy, no invention.
+export function FrameEmpty({ onAsk, entryCue }: Props) {
+  const cue = entryCue ?? null
   return (
     <div className="empty">
-      <h1 className="hi">
-        First time in this project. <em>What interests you?</em>
-      </h1>
-      <p className="sub">
-        Ask anything in your own words — broad ("what does this project do?"),
-        relational ("how do X and Y connect?"), or atomic ("why is line 152
-        written this way?"). Every answer is anchored to real code; nothing
-        invented.
-      </p>
+      {cue ? (
+        <>
+          <h1 className="hi">
+            An AI burst shaped{' '}
+            <code style={mono}>{cue.file_path}</code>{' '}
+            {cue.ai_burst_days === 0 ? 'today' : `~${cue.ai_burst_days} days ago`}.{' '}
+            <em>
+              {cue.never_human_touched
+                ? 'No human commit has ever touched it.'
+                : `You haven't been back in ${cue.last_contact_days} days.`}
+            </em>
+          </h1>
+          <p className="sub">
+            {cue.stale
+              ? `As of the last analysis${
+                  cue.analyzed_age_days != null ? ` ~${cue.analyzed_age_days} days ago` : ''
+                } — the gap may have closed since. `
+              : ''}
+            Ask anything in your own words — every answer is anchored to real
+            code; nothing invented.
+          </p>
+        </>
+      ) : (
+        <>
+          <h1 className="hi">
+            First time in this project. <em>What interests you?</em>
+          </h1>
+          <p className="sub">
+            Ask anything in your own words — broad ("what does this project do?"),
+            relational ("how do X and Y connect?"), or atomic ("why is line 152
+            written this way?"). Every answer is anchored to real code; nothing
+            invented.
+          </p>
+        </>
+      )}
       <div className="starters">
-        <div className="cap">or start from here</div>
+        <div className="cap">{cue ? 'start from the gap' : 'or start from here'}</div>
+        {cue && (
+          <button
+            className="starter"
+            onClick={() =>
+              onAsk(
+                `why does ${cue.file_path} exist, and what shaped it in the last AI burst?`,
+              )
+            }
+          >
+            <span className="glyph">◆</span>
+            <span>
+              why does <code style={mono}>{cue.file_path}</code> exist, and what
+              shaped it in the last AI burst?
+            </span>
+            <span className="arr">→</span>
+          </button>
+        )}
         <button
           className="starter"
           onClick={() => onAsk('what does this project do?')}
@@ -43,7 +99,7 @@ export function FrameEmpty({ onAsk }: Props) {
           <span className="glyph">C</span>
           <span>
             why does{' '}
-            <code style={{ fontFamily: 'var(--font-mono)', fontStyle: 'normal', fontSize: '0.85em' }}>
+            <code style={mono}>
               _module_from_relpath
             </code>{' '}
             use slash instead of dot?

--- a/frontend/src/components/cuaderno/frames/FrameEmpty.tsx
+++ b/frontend/src/components/cuaderno/frames/FrameEmpty.tsx
@@ -8,10 +8,34 @@ const mono = {
   fontSize: '0.85em',
 } as const
 
-// Rendering doctrine (prompts.py, get_entry_cue): "an AI burst shaped `X`
-// ~N days ago; you haven't been back". If stale, scope the claim to "as of the
-// last analysis ~N days ago" — never a present-tense gap past what analysis
-// witnessed. A null cue means nothing to surface: the default copy, no invention.
+const nDays = (n: number) => (n === 1 ? '1 day' : `${n} days`)
+
+// The gap claim, rescoped per the doctrine (prompts.py, get_entry_cue): the
+// burst itself is a witnessed commit — its age is exact even over a stale
+// table — but the ABSENCE of a return is only witnessed up to the last
+// analysis. So when stale=true the gap claim itself carries the scope and
+// drops to past tense; it is never asserted as a present-tense fact.
+function gapClaim(cue: EntryCue): string {
+  const scope = cue.stale
+    ? `As of the last analysis ~${nDays(cue.analyzed_age_days ?? 0)} ago, `
+    : ''
+  if (cue.never_human_touched) {
+    return cue.stale
+      ? `${scope}no human commit had touched it.`
+      : 'No human commit has ever touched it.'
+  }
+  if (cue.last_contact_days === 0) {
+    return cue.stale
+      ? `${scope}you hadn't been back after your same-day touch.`
+      : 'You touched it earlier today — the burst came after.'
+  }
+  return cue.stale
+    ? `${scope}you hadn't been back in ${nDays(cue.last_contact_days)}.`
+    : `You haven't been back in ${nDays(cue.last_contact_days)}.`
+}
+
+// A null cue means nothing honest to surface: neutral copy, no invention —
+// including no "first time" claim the system cannot witness either.
 export function FrameEmpty({ onAsk, entryCue }: Props) {
   const cue = entryCue ?? null
   return (
@@ -21,19 +45,11 @@ export function FrameEmpty({ onAsk, entryCue }: Props) {
           <h1 className="hi">
             An AI burst shaped{' '}
             <code style={mono}>{cue.file_path}</code>{' '}
-            {cue.ai_burst_days === 0 ? 'today' : `~${cue.ai_burst_days} days ago`}.{' '}
-            <em>
-              {cue.never_human_touched
-                ? 'No human commit has ever touched it.'
-                : `You haven't been back in ${cue.last_contact_days} days.`}
-            </em>
+            {cue.ai_burst_days === 0 ? 'today' : `~${nDays(cue.ai_burst_days)} ago`}.{' '}
+            <em>{gapClaim(cue)}</em>
           </h1>
           <p className="sub">
-            {cue.stale
-              ? `As of the last analysis${
-                  cue.analyzed_age_days != null ? ` ~${cue.analyzed_age_days} days ago` : ''
-                } — the gap may have closed since. `
-              : ''}
+            {cue.stale ? 'That may have changed since. ' : ''}
             Ask anything in your own words — every answer is anchored to real
             code; nothing invented.
           </p>
@@ -41,7 +57,7 @@ export function FrameEmpty({ onAsk, entryCue }: Props) {
       ) : (
         <>
           <h1 className="hi">
-            First time in this project. <em>What interests you?</em>
+            <em>What interests you?</em>
           </h1>
           <p className="sub">
             Ask anything in your own words — broad ("what does this project do?"),

--- a/frontend/src/pages/CuadernoPage.tsx
+++ b/frontend/src/pages/CuadernoPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { Block, CuadernoQuestion, ToolRow, CuadernoProvidersResponse } from '../types/api'
+import type { Block, CuadernoQuestion, ToolRow, CuadernoProvidersResponse, EntryCue } from '../types/api'
 import { Cuaderno } from '../components/cuaderno/Cuaderno'
 import { askStream, cuadernoApi } from '../api/cuaderno'
 import { reconcileOnMount, onActiveFrameChange } from '../components/cuaderno/playgroundSlot'
@@ -54,6 +54,13 @@ export function CuadernoPage({ onNavigate }: { onNavigate?: (target: SurvivorPag
   // Load the provider list / current selection once on mount.
   useEffect(() => {
     cuadernoApi.providers().then(setProviders).catch(() => {})
+  }, [])
+
+  // The entry cue: the one computed thing that greets the author unprompted.
+  // Silent on failure — an absent cue renders the default copy, never an error.
+  const [entryCue, setEntryCue] = useState<EntryCue | null>(null)
+  useEffect(() => {
+    cuadernoApi.entryCue().then((r) => setEntryCue(r.entry_cue)).catch(() => {})
   }, [])
 
   const onSetProvider = (provider: string, model: string) => {
@@ -210,6 +217,7 @@ export function CuadernoPage({ onNavigate }: { onNavigate?: (target: SurvivorPag
         onSelectFromHistory={onSelectFromHistory}
         onSetAnswerCheck={onSetAnswerCheck}
         questionLanguage={currentQuestionLanguage}
+        entryCue={entryCue}
       />
     </>
   )

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -823,6 +823,20 @@ export type CuadernoSession = {
   questions: CuadernoQuestion[]
 }
 
+// The entry cue (pulso.build_entry_cue): the single most-overdue AI burst the
+// human has NOT returned to. null = nothing honest to surface (stay silent).
+export type EntryCue = {
+  file_path: string
+  last_contact_days: number
+  ai_burst_days: number
+  last_contact_source: 'git' | 'decision' | null
+  never_human_touched: boolean
+  analyzed_age_days: number | null
+  stale: boolean
+}
+
+export type EntryCueResponse = { entry_cue: EntryCue | null }
+
 export type ToolRow = {
   state: 'queued' | 'running' | 'done' | 'error'
   name: string

--- a/src/copyclip/intelligence/server.py
+++ b/src/copyclip/intelligence/server.py
@@ -1363,6 +1363,19 @@ def run_server(
                     handle_settings_get(self, ctx, conn)
                     return
 
+                if parsed.path == "/api/cuaderno/entry-cue":
+                    # The entry cue wired to session-open: pure exposición — it
+                    # reads, it never records. Reading the cue is NOT returning
+                    # to the file (unlike /api/reacquaintance, which records a
+                    # visit), so no project_visits write here. An unindexed
+                    # project has nothing honest to surface -> silent null.
+                    if not pid:
+                        self._json({"entry_cue": None})
+                        return
+                    from .cuaderno.anchor import get_entry_cue
+                    self._json(get_entry_cue(conn, pid))
+                    return
+
                 if parsed.path == "/api/cuaderno/providers":
                     from .cuaderno.provider import (
                         provider_key_status, DEFAULT_MODELS, TOOL_INCAPABLE_MODELS,

--- a/tests/test_entry_cue_endpoint.py
+++ b/tests/test_entry_cue_endpoint.py
@@ -1,0 +1,123 @@
+"""GET /api/cuaderno/entry-cue — the entry cue wired to session-open.
+
+The cue is the proactive launching point (pulso.build_entry_cue): the single
+most-overdue AI burst the human has NOT returned to. The route must be pure
+exposición — it reads, it never records. Reading the cue is not returning to
+the file, so unlike /api/reacquaintance it must NOT write a project visit.
+"""
+import json
+import socket
+import tempfile
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib import request
+
+from copyclip.intelligence.db import connect, init_schema, init_cuaderno_schema
+from copyclip.intelligence.server import run_server
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _wait_port(port, timeout_s=3.0):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError(f"server did not start on {port}")
+
+
+def _get_json(url, timeout=10):
+    with request.urlopen(url, timeout=timeout) as r:
+        return r.status, json.loads(r.read().decode("utf-8"))
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%d %H:%M:%S +0000")
+
+
+def _setup_server(*, with_cue_data: bool):
+    td = tempfile.mkdtemp(prefix="entry-cue-test-")
+    root = str(Path(td).absolute())
+    conn = connect(root)
+    init_schema(conn)
+    init_cuaderno_schema(conn)
+    conn.execute("INSERT INTO projects(root_path,name) VALUES(?,?)", (root, "test"))
+    pid = conn.execute("SELECT id FROM projects WHERE root_path=?", (root,)).fetchone()[0]
+
+    if with_cue_data:
+        now = datetime.now(timezone.utc)
+        # Snapshot row selects the candidate; updated_at 20d old -> stale=True.
+        conn.execute(
+            "INSERT INTO analysis_file_insights"
+            "(project_id, path, module, pulso_last_contact_days, updated_at) "
+            "VALUES(?,?,?,?,?)",
+            (pid, "src/cold.py", "m", 100,
+             (now - timedelta(days=20)).strftime("%Y-%m-%d %H:%M:%S")),
+        )
+        # Live verification: human commit, then an AI burst after -> hasn't been back.
+        conn.execute(
+            "INSERT INTO commits(project_id, sha, author, date, message, ai_attributed) "
+            "VALUES(?,?,?,?,?,?)",
+            (pid, "h-cold", "S", _iso(now - timedelta(days=120)), "m", 0))
+        conn.execute(
+            "INSERT INTO commits(project_id, sha, author, date, message, ai_attributed) "
+            "VALUES(?,?,?,?,?,?)",
+            (pid, "ai-cold", "S", _iso(now - timedelta(days=60)), "m", 1))
+        for sha in ("h-cold", "ai-cold"):
+            conn.execute(
+                "INSERT INTO file_changes(project_id, commit_sha, file_path, additions, deletions) "
+                "VALUES(?,?,?,0,0)", (pid, sha, "src/cold.py"))
+
+    conn.commit()
+    conn.close()
+    port = _free_port()
+    th = threading.Thread(target=run_server, args=(root, port), daemon=True)
+    th.start()
+    _wait_port(port)
+    return root, port
+
+
+def test_entry_cue_route_returns_the_live_cue():
+    root, port = _setup_server(with_cue_data=True)
+    status, payload = _get_json(f"http://127.0.0.1:{port}/api/cuaderno/entry-cue")
+    assert status == 200
+    cue = payload["entry_cue"]
+    assert cue is not None
+    assert cue["file_path"] == "src/cold.py"
+    assert cue["ai_burst_days"] >= 59
+    assert cue["last_contact_source"] == "git"
+    assert cue["never_human_touched"] is False
+    # snapshot is 20d old (> stale_after_days=14) -> the claim must be hedged
+    assert cue["stale"] is True
+    assert cue["analyzed_age_days"] >= 19
+
+
+def test_entry_cue_route_is_silent_when_nothing_to_surface():
+    root, port = _setup_server(with_cue_data=False)
+    status, payload = _get_json(f"http://127.0.0.1:{port}/api/cuaderno/entry-cue")
+    assert status == 200
+    assert payload == {"entry_cue": None}
+
+
+def test_entry_cue_route_never_records_a_visit():
+    # Reading the cue is not returning to the file: unlike /api/reacquaintance
+    # (server.py records a reacquaintance_api visit), this GET must write nothing.
+    root, port = _setup_server(with_cue_data=True)
+    _get_json(f"http://127.0.0.1:{port}/api/cuaderno/entry-cue")
+    conn = connect(root)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM project_visits").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 0


### PR DESCRIPTION
## Why

copyclip was 100% pull: the cuaderno opened with a hardcoded "First time in this
project" (even on the author's 200th session), while Pulso's entry cue —
`build_entry_cue`, self-described *"the proactive launching point"*, built, tested,
honest by construction — sat stranded behind a tutor tool that can only run after
the author has already typed a question. The rendering doctrine for the cue was
already written (`prompts.py`, `get_entry_cue`: *"when the human opens the
cuaderno … call it"*) but the tutor only executes inside `POST /api/cuaderno/ask`,
so that clause was dead code: an instruction with no channel to obey it.

The mission is the gap between AI bursts — and the moment of return is exactly the
one the product could not serve unprompted. This PR wires the existing cue to
session-open: the first computed thing that ever greets the author.

## What

**Backend — `GET /api/cuaderno/entry-cue`** (server.py): wraps the existing
`anchor.get_entry_cue` (live-verified, staleness-scoped, silent-on-None).
Pure exposición: unlike `/api/reacquaintance`, it records **no** `project_visits`
row — reading the cue is not returning to the file. Unindexed project → silent
`{"entry_cue": null}`.

**Frontend** — `EntryCue` type + `cuadernoApi.entryCue()`; `CuadernoPage` fetches
once on mount (silent on failure); `FrameEmpty` renders the cue when present,
following the written rendering doctrine verbatim:

- *"An AI burst shaped `X` ~N days ago. You haven't been back in M days."* (or
  *"No human commit has ever touched it."*)
- `stale: true` → **the gap claim itself is rescoped, in past tense**: *"As of
  the last analysis ~N days ago, you hadn't been back in M days."* Never a
  present-tense gap past what analysis witnessed. The burst sentence stays
  unhedged — it is a witnessed commit whose age is exact even over a stale table;
  the unwitnessed thing is only the *absence* of a return.
- One starter that launches the existing ask on that file (rationale/burst-shaped,
  never the playground).
- Null cue → neutral copy. This PR also drops the old hardcoded **"First time in
  this project"** greeting — a claim the system cannot witness (false on every
  returning session, and it flashed during the cue fetch). *"What interests you?"*
  in all unwitnessed worlds; the cue upgrades it when one arrives.

## Adversarial verification

Two independent skeptics (seam + doctrine) attacked the diff; both converged on
the same real breach — the stale hedge lived in the `.sub` paragraph while the H1
kept the unhedged present-tense claim, exactly the construction the doctrine
forbids. Fixed (second commit), plus: `last_contact_days=0` no longer renders
*"back in 0 days"* (same-day touch phrased honestly), singular counts render
*"1 day"*, and the false "First time" greeting was removed as above. One finding
deferred as its own issue: `src/copyclip/intelligence/ui/index.html` (the
packaged UI the server serves) has not been refreshed since #172 — stepthrough,
call-synthesis, Cruces, and this PR are all absent from it. Separate follow-up;
out of scope here.

## Doctrine

No tension. A gated, hedged, computed fact — silent when there is nothing honest
to surface. The FILE is stale, never the mind. Maps onto #152's direction (the
next PR — open-time staleness check + incremental commit ingest — is what lights
the Pulso clocks on live data).

## Tests

- Backend: 3 new endpoint tests (`tests/test_entry_cue_endpoint.py`) — live cue
  over real commit fixtures, silence when nothing to surface, and **no
  `project_visits` write** (the /api/reacquaintance trap, asserted against).
- Frontend: 7 new `FrameEmpty` tests — cue vs default copy, stale hedge present /
  absent, never-touched wording, starter launches the ask with the file path,
  generic starters survive both states.
- Full suites green: backend pytest, frontend vitest 226, `tsc --noEmit`,
  `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual entry cues to Cuaderno’s empty state, highlighting relevant files, activity gaps, and suggested questions.
  * Added a cue-specific starter action to help users begin exploring surfaced context.
  * Added an endpoint to retrieve entry cues without recording a visit.
  * Preserved a neutral empty state when no cue is available.

* **Bug Fixes**
  * Improved wording for same-day activity, singular day counts, stale cues, and previously untouched items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->