### PR TITLE
feat(cli): --split-lines — chunked clipboard export (paste, Enter, repeat)

### DIFF
--- a/src/copyclip/__main__.py
+++ b/src/copyclip/__main__.py
@@ -32,6 +32,53 @@ EXPORT_ONLY_FLAGS = frozenset({
 })
 
 
+def pack_chunks(parts: list, max_lines: int) -> list:
+    """Greedy file-boundary packing of export blocks into <=max_lines chunks.
+
+    A block never splits across chunks if it fits whole in one; only a block
+    that ALONE exceeds the budget is hard-split, each later slice carrying an
+    honest '(continued)' header (derived from the block's 'path:' first line
+    when it has one). The '\\n\\n' joiner between blocks counts as one line."""
+    chunks: list = []
+    cur: list = []
+    cur_lines = 0
+
+    def flush():
+        nonlocal cur, cur_lines
+        if cur:
+            chunks.append("\n\n".join(cur))
+            cur, cur_lines = [], 0
+
+    for part in parts:
+        n = part.count("\n") + 1
+        if n > max_lines:
+            flush()
+            lines = part.split("\n")
+            first = lines[0]
+            has_header = first.endswith(":")
+            i = 0
+            first_slice = True
+            while i < len(lines):
+                if first_slice:
+                    take = lines[i:i + max_lines]
+                    chunks.append("\n".join(take))
+                    first_slice = False
+                else:
+                    header = (first[:-1] + " (continued):") if has_header else "(continued)"
+                    take = lines[i:i + max_lines - 1]
+                    chunks.append(header + "\n" + "\n".join(take))
+                i += len(take)
+            continue
+        joiner = 1 if cur else 0
+        if cur_lines + joiner + n > max_lines:
+            flush()
+            joiner = 0
+        cur.append(part)
+        cur_lines += joiner + n
+    flush()
+    return chunks
+
+
 def classify_bare_invocation(argv: list) -> tuple:
     """Route a non-subcommand invocation. Returns ('start', folder) or
     ('error', offending_flag). The front door opens the shell; export flags
@@ -146,8 +193,13 @@ def run_export(argv_tail: list) -> None:
     parser.add_argument("--with-dependencies", action="store_true", help="Prepend Mermaid dependency graph (with --minimize contextual)")
     parser.add_argument("--no-decisions", action="store_true", help="Exclude architectural decisions from context")
     parser.add_argument("--prompt", help="Select files relevant to this task/intent via LLM")
+    parser.add_argument("--split-lines", type=int, default=None, metavar="N",
+                        help="Split output into chunks of <=N lines and copy them one at a time "
+                             "(paste, press Enter, repeat) — for paste-limited surfaces like chat UIs")
 
     args = parser.parse_args(argv_tail)
+    if args.split_lines is not None and args.split_lines < 2:
+        parser.error("--split-lines must be at least 2")
 
     # An LLM is only needed when --prompt asks the model to select files. A plain
     # clipboard export must never block on provider config or launch onboarding —
@@ -379,6 +431,33 @@ def run_export(argv_tail: list) -> None:
         final_output = "\n\n".join(output_parts)
 
         clipboard = ClipboardManager()
+
+        if args.split_lines is not None:
+            chunks = pack_chunks(output_parts, args.split_lines)
+            total = len(chunks)
+            if total > 1:
+                if not sys.stdin.isatty():
+                    print("[ERROR] --split-lines is an interactive flow (paste, Enter, repeat) — run it in a terminal.", file=sys.stderr)
+                    sys.exit(2)
+                for i, chunk in enumerate(chunks, 1):
+                    payload = f"--- copyclip part {i}/{total} ---\n{chunk}"
+                    if not clipboard.copy(payload):
+                        print("[ERROR] Failed to copy content to clipboard.", file=sys.stderr)
+                        sys.exit(1)
+                    n_lines = payload.count("\n") + 1
+                    if i < total:
+                        print(f"[INFO] part {i}/{total} copied ({n_lines} lines). Paste it, then press Enter for the next (Ctrl+C to stop)...", file=sys.stderr)
+                        try:
+                            input()
+                        except EOFError:
+                            print("[WARN] stdin closed — stopping after part "
+                                  f"{i}/{total}.", file=sys.stderr)
+                            sys.exit(1)
+                    else:
+                        print(f"[INFO] part {i}/{total} copied (final) — all {total} parts delivered.", file=sys.stderr)
+                return
+            # 0 or 1 chunks: fall through to the normal single copy below.
+
         if clipboard.copy(final_output):
             print("[INFO] Content has been copied to the clipboard.", file=sys.stderr)
             tokenizer_pref = os.environ.get("COPYCLIP_TOKENIZER")

--- a/tests/test_export_split.py
+++ b/tests/test_export_split.py
@@ -1,0 +1,102 @@
+"""--split-lines: chunked clipboard export for paste-limited surfaces.
+
+pack_chunks is the pure core: greedy file-boundary packing (a file block never
+splits across chunks if it fits whole in one), hard-splitting only blocks that
+alone exceed the budget — with an honest '(continued):' header on each slice.
+"""
+import subprocess
+import sys
+
+from copyclip.__main__ import pack_chunks
+
+
+FILE_A = "a.py:\nline1\nline2\nline3"          # 4 lines
+FILE_B = "b.py:\nuno\ndos"                     # 3 lines
+FILE_C = "c.md:\nx"                            # 2 lines
+
+
+def test_everything_fits_in_one_chunk():
+    chunks = pack_chunks([FILE_A, FILE_B], max_lines=100)
+    assert chunks == [FILE_A + "\n\n" + FILE_B]
+
+
+def test_packs_at_file_boundaries_never_mid_file():
+    # budget of 8: A(4) + joiner(1) + B(3) = 8 fits; C starts chunk 2
+    chunks = pack_chunks([FILE_A, FILE_B, FILE_C], max_lines=8)
+    assert chunks == [FILE_A + "\n\n" + FILE_B, FILE_C]
+
+
+def test_file_that_would_overflow_moves_whole_to_next_chunk():
+    # budget of 6: A(4) fits; B would need 4+1+3=8 -> B moves whole
+    chunks = pack_chunks([FILE_A, FILE_B], max_lines=6)
+    assert chunks == [FILE_A, FILE_B]
+
+
+def test_oversize_single_block_hard_splits_with_continued_header():
+    big = "big.py:\n" + "\n".join(f"l{i}" for i in range(1, 10))  # 10 lines
+    chunks = pack_chunks([big], max_lines=6)
+    # slice 1: header + l1..l5 (6 lines); slice 2: continued header + l6..l9
+    assert chunks[0] == "big.py:\nl1\nl2\nl3\nl4\nl5"
+    assert chunks[1] == "big.py (continued):\nl6\nl7\nl8\nl9"
+    assert all(c.count("\n") + 1 <= 6 for c in chunks)
+
+
+def test_oversize_block_without_header_colon_gets_generic_continuation():
+    blob = "\n".join(f"x{i}" for i in range(1, 8))  # 7 lines, no 'path:' first line
+    chunks = pack_chunks([blob], max_lines=4)
+    assert chunks[0] == "x1\nx2\nx3\nx4"
+    assert chunks[1].startswith("(continued)\n")
+    assert all(c.count("\n") + 1 <= 4 for c in chunks)
+
+
+def test_oversize_block_neighbors_still_pack_around_it():
+    big = "big.py:\n" + "\n".join(f"l{i}" for i in range(1, 8))  # 8 lines
+    chunks = pack_chunks([FILE_C, big, FILE_B], max_lines=5)
+    # C alone (big won't fit after it), big split into 2, B packs after? No —
+    # slices of big fill their own chunks; B starts fresh.
+    assert chunks[0] == FILE_C
+    assert chunks[1] == "big.py:\nl1\nl2\nl3\nl4"
+    assert chunks[2] == "big.py (continued):\nl5\nl6\nl7"
+    assert chunks[3] == FILE_B
+
+
+def test_empty_parts_yield_no_chunks():
+    assert pack_chunks([], max_lines=10) == []
+
+
+def test_interactive_loop_copies_each_part_with_markers(tmp_path, monkeypatch):
+    # Wiring test: run_export with --split-lines delivers every chunk to the
+    # clipboard in order, each with its part marker, waiting for Enter between.
+    from copyclip import __main__ as m
+
+    (tmp_path / "one.md").write_text("\n".join(f"a{i}" for i in range(1, 21)), encoding="utf-8")
+    (tmp_path / "two.md").write_text("\n".join(f"b{i}" for i in range(1, 21)), encoding="utf-8")
+
+    copied = []
+
+    class FakeClipboard:
+        def copy(self, text):
+            copied.append(text)
+            return True
+
+    enters = iter(["", "", "", ""])
+    monkeypatch.setattr(m, "ClipboardManager", FakeClipboard)
+    monkeypatch.setattr("builtins.input", lambda *a: next(enters))
+    monkeypatch.setattr("sys.stdin", type("S", (), {"isatty": staticmethod(lambda: True)})())
+
+    m.run_export([str(tmp_path), "--split-lines", "25", "--view", "text", "--no-progress"])
+
+    assert len(copied) >= 2
+    for i, payload in enumerate(copied, 1):
+        assert payload.startswith(f"--- copyclip part {i}/{len(copied)} ---\n")
+    # every content line of both files made it across, in order
+    joined = "\n".join(copied)
+    for token in ["a1", "a20", "b1", "b20"]:
+        assert token in joined
+
+
+def test_split_lines_flag_in_help():
+    out = subprocess.run([sys.executable, "-m", "copyclip", "copy", "--help"],
+                         capture_output=True, text=True, timeout=60)
+    assert out.returncode == 0
+    assert "--split-lines" in out.stdout


### PR DESCRIPTION
## Why

Pasting a `copyclip copy` export into chat UIs (claude.ai) truncates around
~130 KB / ~1400 lines. Samuel's design-bundle paste got cut. The export needs a
way to deliver itself in clipboard-sized installments.

## What

`--split-lines N` on `copyclip copy` / `copyclip export`: split the assembled
output into chunks of ≤N lines and copy them **one at a time** — paste, press
Enter, next part is on the clipboard, until done.

```
copyclip copy . --split-lines 1400
[INFO] part 1/4 copied (1400 lines). Paste it, then press Enter for the next (Ctrl+C to stop)...
```

**Packing is file-boundary-aware** (`pack_chunks`, pure): a file block never
splits across chunks if it fits whole in one; only a block that ALONE exceeds
the budget is hard-split, and each later slice carries an honest
`path (continued):` header so the receiving side never sees decapitated
content. Each part is prefixed `--- copyclip part i/N ---` so the receiver can
track installments. If everything fits in one chunk, behavior is identical to
today (no markers).

Guards: non-TTY invocation errors out (it is an interactive flow) — and because
Windows' NUL device fools `isatty`, an `EOFError` on the Enter-wait also stops
cleanly with a warning (live-verified: that net caught exactly this case).

## Tests

9 new in `tests/test_export_split.py`: pack semantics pinned exactly
(single-chunk, boundary packing, whole-block overflow moves, oversize
hard-split with continued headers, headerless blob, neighbors around an
oversize block, empty input), a wiring test driving `run_export` end-to-end
with mocked clipboard/stdin (every part marker in order, all content lines
delivered), and a `--help` smoke. Full backend suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--split-lines` option to divide large exports into clipboard-friendly parts.
  * Preserves file boundaries where possible and labels continued sections clearly.
  * Prompts for confirmation between clipboard copies during interactive exports.
  * Added validation and error handling for invalid limits, non-interactive use, and copy failures.

* **Tests**
  * Added coverage for chunking behavior, oversized files, ordering, clipboard delivery, and CLI help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->